### PR TITLE
Flex fields allows API to expand related data on demand

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -33,6 +33,7 @@ from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     PressPassRegisterView,
     PressPassUserMembershipViewSet,
+    PressPassUserInvitationViewSet,
     PressPassUserViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,
@@ -75,7 +76,7 @@ user_router = routers.NestedDefaultRouter(
     presspass_router, "users", lookup="user"
 )
 user_router.register("memberships", PressPassUserMembershipViewSet)
-# user_router.register("invitations", PressPassNestedInvitationViewSet)
+user_router.register("invitations", PressPassUserInvitationViewSet)
 
 urlpatterns = [
     path("", HomeView.as_view(), name="home"),

--- a/config/urls.py
+++ b/config/urls.py
@@ -71,9 +71,7 @@ organization_router.register("memberships", PressPassMembershipViewSet)
 organization_router.register("invitations", PressPassNestedInvitationViewSet)
 organization_router.register("subscriptions", PressPassSubscriptionViewSet)
 
-user_router = routers.NestedDefaultRouter(
-    presspass_router, "users", lookup="user"
-)
+user_router = routers.NestedDefaultRouter(presspass_router, "users", lookup="user")
 user_router.register("memberships", PressPassUserMembershipViewSet)
 
 urlpatterns = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -32,6 +32,7 @@ from squarelet.organizations.viewsets import (
 from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     PressPassRegisterView,
+    PressPassUserMembershipViewSet,
     PressPassUserViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,
@@ -70,6 +71,12 @@ organization_router.register("memberships", PressPassMembershipViewSet)
 organization_router.register("invitations", PressPassNestedInvitationViewSet)
 organization_router.register("subscriptions", PressPassSubscriptionViewSet)
 
+user_router = routers.NestedDefaultRouter(
+    presspass_router, "users", lookup="user"
+)
+user_router.register("memberships", PressPassUserMembershipViewSet)
+# user_router.register("invitations", PressPassNestedInvitationViewSet)
+
 urlpatterns = [
     path("", HomeView.as_view(), name="home"),
     path(
@@ -94,6 +101,7 @@ urlpatterns = [
     path("pp-api/auth/", include("squarelet.auth_helpers.urls")),
     path("pp-api/", include(presspass_router.urls)),
     path("pp-api/", include(organization_router.urls)),
+    path("pp-api/", include(user_router.urls)),
     # Swagger
     path("swagger<format>", SchemaView.without_ui(cache_timeout=0), name="schema-json"),
     path(

--- a/config/urls.py
+++ b/config/urls.py
@@ -33,7 +33,6 @@ from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     PressPassRegisterView,
     PressPassUserMembershipViewSet,
-    PressPassUserInvitationViewSet,
     PressPassUserViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,
@@ -76,7 +75,6 @@ user_router = routers.NestedDefaultRouter(
     presspass_router, "users", lookup="user"
 )
 user_router.register("memberships", PressPassUserMembershipViewSet)
-user_router.register("invitations", PressPassUserInvitationViewSet)
 
 urlpatterns = [
     path("", HomeView.as_view(), name="home"),

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -30,6 +30,7 @@ django<2.2
 djangorestframework
 djangorestframework_simplejwt
 dogslow
+drf-flex-fields
 drf-nested-routers
 drf-yasg
 furl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,62 +7,64 @@
 --no-binary psycopg2
 
 amqp==2.3.2               # via kombu
-argon2-cffi==18.1.0
+appnope==0.1.0            # via ipython
+argon2-cffi==18.1.0       # via -r requirements/base.in
 backcall==0.1.0           # via ipython
-bcrypt==3.1.4
+bcrypt==3.1.4             # via -r requirements/base.in
 billiard==3.5.0.4         # via celery
 boto3==1.9.32             # via django-storages, smart-open
 boto==2.49.0              # via smart-open
 botocore==1.12.32         # via boto3, s3transfer
 bz2file==0.98             # via smart-open
-celery==4.2.0
+celery==4.2.0             # via -r requirements/base.in
 certifi==2018.4.16        # via requests
 cffi==1.11.5              # via argon2-cffi, bcrypt, cryptography
 chardet==3.0.4            # via requests
-coreapi==2.3.3
+coreapi==2.3.3            # via -r requirements/base.in, drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-cryptography==2.8
+cryptography==2.8         # via -r requirements/base.in
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.3.2          # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid
-django-allauth==0.38.0
+django-allauth==0.38.0    # via -r requirements/base.in
 django-appconf==1.0.2     # via django-compressor
-django-autocomplete-light==3.3.2
-django-autoslug-iplweb==1.9.4
-django-choices==1.6.1
+django-autocomplete-light==3.3.2  # via -r requirements/base.in
+django-autoslug-iplweb==1.9.4  # via -r requirements/base.in
+django-choices==1.6.1     # via -r requirements/base.in
 django-compat==1.0.15     # via django-hijack
-django-compressor==2.2
-django-cors-headers==3.1.1
-django-crispy-forms==1.7.2
-django-debug-toolbar==1.11
-django-email-bandit==1.5
-django-environ==0.4.4
-django-extensions==2.1.5
-django-filter==2.2.0
-django-hijack==2.1.10
-django-model-utils==3.1.2
-django-oidc-provider==0.7.0
-django-premailer==0.2.0
-django-redis==4.9.0
-django-request-token==0.9.2
-django-rest-auth==0.9.5
-django-reversion==3.0.3
-django-sesame==1.5
-django-storages[boto3]==1.7.1
-django==2.1.7
-djangorestframework-simplejwt==4.3.0
-djangorestframework==3.9.2
+django-compressor==2.2    # via -r requirements/base.in
+django-cors-headers==3.1.1  # via -r requirements/base.in
+django-crispy-forms==1.7.2  # via -r requirements/base.in
+django-debug-toolbar==1.11  # via -r requirements/base.in
+django-email-bandit==1.5  # via -r requirements/base.in
+django-environ==0.4.4     # via -r requirements/base.in
+django-extensions==2.1.5  # via -r requirements/base.in
+django-filter==2.2.0      # via -r requirements/base.in
+django-hijack==2.1.10     # via -r requirements/base.in
+django-model-utils==3.1.2  # via -r requirements/base.in
+django-oidc-provider==0.7.0  # via -r requirements/base.in
+django-premailer==0.2.0   # via -r requirements/base.in
+django-redis==4.9.0       # via -r requirements/base.in
+django-request-token==0.9.2  # via -r requirements/base.in
+django-rest-auth==0.9.5   # via -r requirements/base.in
+django-reversion==3.0.3   # via -r requirements/base.in
+django-sesame==1.5        # via -r requirements/base.in
+django-storages[boto3]==1.7.1  # via -r requirements/base.in
+django==2.1.7             # via -r requirements/base.in, django-allauth, django-choices, django-cors-headers, django-debug-toolbar, django-environ, django-filter, django-model-utils, django-redis, django-request-token, django-rest-auth, django-reversion, django-storages, djangorestframework-simplejwt, dogslow, drf-nested-routers, drf-yasg
+djangorestframework-simplejwt==4.3.0  # via -r requirements/base.in
+djangorestframework==3.9.2  # via -r requirements/base.in, django-rest-auth, djangorestframework-simplejwt, drf-nested-routers, drf-yasg
 docutils==0.14            # via botocore
-dogslow==1.2
-drf-nested-routers==0.91
-drf-yasg==1.17.0
-furl==2.0.0
+dogslow==1.2              # via -r requirements/base.in
+drf-flex-fields==0.7.5    # via -r requirements/base.in
+drf-nested-routers==0.91  # via -r requirements/base.in
+drf-yasg==1.17.0          # via -r requirements/base.in
+furl==2.0.0               # via -r requirements/base.in
 future==0.16.0            # via pyjwkest
-html2text==2018.1.9
+html2text==2018.1.9       # via -r requirements/base.in
 idna==2.7                 # via requests
 inflection==0.3.1         # via drf-yasg
-ipdb==0.11
+ipdb==0.11                # via -r requirements/base.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.2.0            # via ipdb
 itypes==1.1.0             # via coreapi
@@ -72,18 +74,18 @@ jmespath==0.9.3           # via boto3, botocore
 kombu==4.2.1              # via celery
 lxml==4.3.0               # via premailer
 markupsafe==1.0           # via jinja2
-memoize==1.0.0
+memoize==1.0.0            # via -r requirements/base.in
 oauthlib==2.1.0           # via requests-oauthlib
 orderedmultidict==1.0     # via furl
 packaging==19.2           # via drf-yasg
 parso==0.3.3              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pillow==5.1.0
+pillow==5.1.0             # via -r requirements/base.in
 premailer==3.0.0          # via django-premailer
 prompt-toolkit==2.0.8     # via ipython
 psycopg2-binary==2.7.7    # via django-request-token
-psycopg2==2.7.5
+psycopg2==2.7.5           # via -r requirements/base.in
 ptyprocess==0.6.0         # via pexpect
 pycparser==2.18           # via cffi
 pycryptodomex==3.6.4      # via pyjwkest
@@ -92,27 +94,30 @@ pyjwkest==1.4.0           # via django-oidc-provider
 pyjwt==1.7.1              # via django-request-token, djangorestframework-simplejwt
 pyparsing==2.4.5          # via packaging
 python-dateutil==2.7.4    # via botocore
-python-slugify==1.2.5
+python-slugify==1.2.5     # via -r requirements/base.in
 python3-openid==3.1.0     # via django-allauth
-pytz==2018.4
-raven==6.9.0
-rcssmin==1.0.6
-redis==2.10.6
+pytz==2018.4              # via -r requirements/base.in, celery, django
+raven==6.9.0              # via -r requirements/base.in
+rcssmin==1.0.6            # via -r requirements/base.in, django-compressor
+redis==2.10.6             # via -r requirements/base.in, django-redis
 requests-oauthlib==1.0.0  # via django-allauth
 requests==2.21.0          # via coreapi, django-allauth, premailer, pyjwkest, requests-oauthlib, smart-open, stripe
 rjsmin==1.0.12            # via django-compressor
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
-rules==2.1
+rules==2.1                # via -r requirements/base.in
 s3transfer==0.1.13        # via boto3
 six==1.11.0               # via argon2-cffi, bcrypt, cryptography, django-compat, django-environ, django-extensions, django-rest-auth, drf-yasg, furl, orderedmultidict, packaging, prompt-toolkit, pyjwkest, python-dateutil, traitlets
-smart-open==1.7.1
-sorl-thumbnail==12.5.0
+smart-open==1.7.1         # via -r requirements/base.in
+sorl-thumbnail==12.5.0    # via -r requirements/base.in
 sqlparse==0.2.4           # via django-debug-toolbar, django-request-token
-stripe==2.10.1
+stripe==2.10.1            # via -r requirements/base.in
 traitlets==4.3.2          # via ipython
 unidecode==1.0.22         # via python-slugify
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via botocore, requests
 vine==1.1.4               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -5,6 +5,7 @@ black
 coverage
 django-coverage-plugin
 django-test-plus
+drf-flex-fields
 factory-boy
 flake8
 pip-tools

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -5,7 +5,6 @@ black
 coverage
 django-coverage-plugin
 django-test-plus
-drf-flex-fields
 factory-boy
 flake8
 pip-tools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,159 +7,164 @@
 --no-binary psycopg2
 
 alabaster==0.7.11         # via sphinx
-amqp==2.3.2
+amqp==2.3.2               # via -r requirements/base.txt, kombu
 appdirs==1.4.3            # via black
-argon2-cffi==18.1.0
+appnope==0.1.0            # via ipython
+argon2-cffi==18.1.0       # via -r requirements/base.txt
 astroid==1.6.5            # via pylint, pylint-celery
 atomicwrites==1.1.5       # via pytest
 attrs==18.1.0             # via black, pytest
 babel==2.6.0              # via sphinx
-backcall==0.1.0
-bcrypt==3.1.4
-billiard==3.5.0.4
-black==19.10b0
-boto3==1.9.32
-boto==2.49.0
-botocore==1.12.32
-bz2file==0.98
-celery==4.2.0
-certifi==2018.4.16
-cffi==1.11.5
-chardet==3.0.4
+backcall==0.1.0           # via -r requirements/base.txt, ipython
+bcrypt==3.1.4             # via -r requirements/base.txt
+billiard==3.5.0.4         # via -r requirements/base.txt, celery
+black==19.10b0            # via -r requirements/local.in
+boto3==1.9.32             # via -r requirements/base.txt, django-storages, smart-open
+boto==2.49.0              # via -r requirements/base.txt, smart-open
+botocore==1.12.32         # via -r requirements/base.txt, boto3, s3transfer
+bz2file==0.98             # via -r requirements/base.txt, smart-open
+celery==4.2.0             # via -r requirements/base.txt
+certifi==2018.4.16        # via -r requirements/base.txt, requests
+cffi==1.11.5              # via -r requirements/base.txt, argon2-cffi, bcrypt, cryptography
+chardet==3.0.4            # via -r requirements/base.txt, requests
 click==6.7                # via black, pip-tools
-coreapi==2.3.3
-coreschema==0.0.4
-coverage==4.5.1
-cryptography==2.8
-cssselect==1.0.3
-cssutils==1.0.2
-decorator==4.3.2
-defusedxml==0.5.0
-django-allauth==0.38.0
-django-appconf==1.0.2
-django-autocomplete-light==3.3.2
-django-autoslug-iplweb==1.9.4
-django-choices==1.6.1
-django-compat==1.0.15
-django-compressor==2.2
-django-cors-headers==3.1.1
-django-coverage-plugin==1.6.0
-django-crispy-forms==1.7.2
-django-debug-toolbar==1.11
-django-email-bandit==1.5
-django-environ==0.4.4
-django-extensions==2.1.5
-django-filter==2.2.0
-django-hijack==2.1.10
-django-model-utils==3.1.2
-django-oidc-provider==0.7.0
-django-premailer==0.2.0
-django-redis==4.9.0
-django-request-token==0.9.2
-django-rest-auth==0.9.5
-django-reversion==3.0.3
-django-sesame==1.5
-django-storages[boto3]==1.7.1
-django-test-plus==1.1.0
-django==2.1.7
-djangorestframework-simplejwt==4.3.0
-djangorestframework==3.9.2
-docutils==0.14
-dogslow==1.2
-drf-nested-routers==0.91
-drf-yasg==1.17.0
-factory-boy==2.11.1
+coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
+coverage==4.5.1           # via -r requirements/local.in, django-coverage-plugin
+cryptography==2.8         # via -r requirements/base.txt
+cssselect==1.0.3          # via -r requirements/base.txt, premailer
+cssutils==1.0.2           # via -r requirements/base.txt, premailer
+decorator==4.3.2          # via -r requirements/base.txt, ipython, traitlets
+defusedxml==0.5.0         # via -r requirements/base.txt, python3-openid
+django-allauth==0.38.0    # via -r requirements/base.txt
+django-appconf==1.0.2     # via -r requirements/base.txt, django-compressor
+django-autocomplete-light==3.3.2  # via -r requirements/base.txt
+django-autoslug-iplweb==1.9.4  # via -r requirements/base.txt
+django-choices==1.6.1     # via -r requirements/base.txt
+django-compat==1.0.15     # via -r requirements/base.txt, django-hijack
+django-compressor==2.2    # via -r requirements/base.txt
+django-cors-headers==3.1.1  # via -r requirements/base.txt
+django-coverage-plugin==1.6.0  # via -r requirements/local.in
+django-crispy-forms==1.7.2  # via -r requirements/base.txt
+django-debug-toolbar==1.11  # via -r requirements/base.txt
+django-email-bandit==1.5  # via -r requirements/base.txt
+django-environ==0.4.4     # via -r requirements/base.txt
+django-extensions==2.1.5  # via -r requirements/base.txt
+django-filter==2.2.0      # via -r requirements/base.txt
+django-hijack==2.1.10     # via -r requirements/base.txt
+django-model-utils==3.1.2  # via -r requirements/base.txt
+django-oidc-provider==0.7.0  # via -r requirements/base.txt
+django-premailer==0.2.0   # via -r requirements/base.txt
+django-redis==4.9.0       # via -r requirements/base.txt
+django-request-token==0.9.2  # via -r requirements/base.txt
+django-rest-auth==0.9.5   # via -r requirements/base.txt
+django-reversion==3.0.3   # via -r requirements/base.txt
+django-sesame==1.5        # via -r requirements/base.txt
+django-storages[boto3]==1.7.1  # via -r requirements/base.txt
+django-test-plus==1.1.0   # via -r requirements/local.in
+django==2.1.7             # via -r requirements/base.txt, django-allauth, django-choices, django-cors-headers, django-debug-toolbar, django-environ, django-filter, django-model-utils, django-redis, django-request-token, django-rest-auth, django-reversion, django-storages, djangorestframework-simplejwt, dogslow, drf-nested-routers, drf-yasg
+djangorestframework-simplejwt==4.3.0  # via -r requirements/base.txt
+djangorestframework==3.9.2  # via -r requirements/base.txt, django-rest-auth, djangorestframework-simplejwt, drf-nested-routers, drf-yasg
+docutils==0.14            # via -r requirements/base.txt, botocore, sphinx
+dogslow==1.2              # via -r requirements/base.txt
+drf-flex-fields==0.7.5    # via -r requirements/local.in
+drf-nested-routers==0.91  # via -r requirements/base.txt
+drf-yasg==1.17.0          # via -r requirements/base.txt
+factory-boy==2.11.1       # via -r requirements/local.in, pytest-factoryboy
 faker==0.8.17             # via factory-boy
-flake8==3.5.0
+flake8==3.5.0             # via -r requirements/local.in
 freezegun==0.3.11         # via pytest-freezegun
-furl==2.0.0
-future==0.16.0
-html2text==2018.1.9
-idna==2.7
+furl==2.0.0               # via -r requirements/base.txt
+future==0.16.0            # via -r requirements/base.txt, pyjwkest
+html2text==2018.1.9       # via -r requirements/base.txt
+idna==2.7                 # via -r requirements/base.txt, requests
 imagesize==1.0.0          # via sphinx
-inflection==0.3.1
-ipdb==0.11
-ipython-genutils==0.2.0
-ipython==7.2.0
+inflection==0.3.1         # via -r requirements/base.txt, drf-yasg, pytest-factoryboy
+ipdb==0.11                # via -r requirements/base.txt
+ipython-genutils==0.2.0   # via -r requirements/base.txt, traitlets
+ipython==7.2.0            # via -r requirements/base.txt, ipdb
 isort==4.3.4              # via pylint
-itypes==1.1.0
-jedi==0.13.2
-jinja2==2.10
-jmespath==0.9.3
-kombu==4.2.1
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jedi==0.13.2              # via -r requirements/base.txt, ipython
+jinja2==2.10              # via -r requirements/base.txt, coreschema, sphinx
+jmespath==0.9.3           # via -r requirements/base.txt, boto3, botocore
+kombu==4.2.1              # via -r requirements/base.txt, celery
 lazy-object-proxy==1.3.1  # via astroid
-lxml==4.3.0
-markupsafe==1.0
+lxml==4.3.0               # via -r requirements/base.txt, premailer
+markupsafe==1.0           # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via flake8, pylint
-memoize==1.0.0
+memoize==1.0.0            # via -r requirements/base.txt
 more-itertools==4.2.0     # via pytest
-oauthlib==2.1.0
-orderedmultidict==1.0
-packaging==19.2
-parso==0.3.3
+oauthlib==2.1.0           # via -r requirements/base.txt, requests-oauthlib
+orderedmultidict==1.0     # via -r requirements/base.txt, furl
+packaging==19.2           # via -r requirements/base.txt, drf-yasg, sphinx
+parso==0.3.3              # via -r requirements/base.txt, jedi
 pathspec==0.6.0           # via black
-pexpect==4.6.0
-pickleshare==0.7.5
-pillow==5.1.0
-pip-tools==3.6.1
+pexpect==4.6.0            # via -r requirements/base.txt, ipython
+pickleshare==0.7.5        # via -r requirements/base.txt, ipython
+pillow==5.1.0             # via -r requirements/base.txt
+pip-tools==3.6.1          # via -r requirements/local.in
 pluggy==0.6.0             # via pytest
-premailer==3.0.0
-prompt-toolkit==2.0.8
-psycopg2-binary==2.7.7
-psycopg2==2.7.5
-ptyprocess==0.6.0
+premailer==3.0.0          # via -r requirements/base.txt, django-premailer
+prompt-toolkit==2.0.8     # via -r requirements/base.txt, ipython
+psycopg2-binary==2.7.7    # via -r requirements/base.txt, django-request-token
+psycopg2==2.7.5           # via -r requirements/base.txt
+ptyprocess==0.6.0         # via -r requirements/base.txt, pexpect
 py==1.5.4                 # via pytest
 pycodestyle==2.3.1        # via flake8
-pycparser==2.18
-pycryptodomex==3.6.4
+pycparser==2.18           # via -r requirements/base.txt, cffi
+pycryptodomex==3.6.4      # via -r requirements/base.txt, pyjwkest
 pyflakes==1.6.0           # via flake8
-pygments==2.3.1
-pyjwkest==1.4.0
-pyjwt==1.7.1
-pylint-celery==0.3
-pylint-common==0.2.5
-pylint-django==0.11.1
+pygments==2.3.1           # via -r requirements/base.txt, ipython, sphinx
+pyjwkest==1.4.0           # via -r requirements/base.txt, django-oidc-provider
+pyjwt==1.7.1              # via -r requirements/base.txt, django-request-token, djangorestframework-simplejwt
+pylint-celery==0.3        # via -r requirements/local.in
+pylint-common==0.2.5      # via -r requirements/local.in
+pylint-django==0.11.1     # via -r requirements/local.in
 pylint-plugin-utils==0.4  # via pylint-celery, pylint-common, pylint-django
-pylint==1.9.2
-pyparsing==2.4.5
-pytest-django==3.3.0
-pytest-factoryboy==2.0.2
-pytest-freezegun==0.3.0.post1
-pytest-mock==1.10.1
-pytest-sugar==0.9.1
-pytest==3.6.2
-python-dateutil==2.7.4
-python-slugify==1.2.5
-python3-openid==3.1.0
-pytz==2018.4
-raven==6.9.0
-rcssmin==1.0.6
-redis==2.10.6
+pylint==1.9.2             # via -r requirements/local.in, pylint-celery, pylint-common, pylint-django, pylint-plugin-utils
+pyparsing==2.4.5          # via -r requirements/base.txt, packaging
+pytest-django==3.3.0      # via -r requirements/local.in
+pytest-factoryboy==2.0.2  # via -r requirements/local.in
+pytest-freezegun==0.3.0.post1  # via -r requirements/local.in
+pytest-mock==1.10.1       # via -r requirements/local.in
+pytest-sugar==0.9.1       # via -r requirements/local.in
+pytest==3.6.2             # via -r requirements/local.in, pytest-django, pytest-factoryboy, pytest-freezegun, pytest-mock, pytest-sugar
+python-dateutil==2.7.4    # via -r requirements/base.txt, botocore, faker, freezegun
+python-slugify==1.2.5     # via -r requirements/base.txt
+python3-openid==3.1.0     # via -r requirements/base.txt, django-allauth
+pytz==2018.4              # via -r requirements/base.txt, babel, celery, django
+raven==6.9.0              # via -r requirements/base.txt
+rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
+redis==2.10.6             # via -r requirements/base.txt, django-redis
 regex==2019.11.1          # via black
-requests-oauthlib==1.0.0
-requests==2.21.0
-rjsmin==1.0.12
-ruamel.yaml.clib==0.2.0
-ruamel.yaml==0.16.5
-rules==2.1
-s3transfer==0.1.13
-six==1.11.0
-smart-open==1.7.1
+requests-oauthlib==1.0.0  # via -r requirements/base.txt, django-allauth
+requests==2.21.0          # via -r requirements/base.txt, coreapi, django-allauth, premailer, pyjwkest, requests-oauthlib, smart-open, sphinx, stripe
+rjsmin==1.0.12            # via -r requirements/base.txt, django-compressor
+ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
+ruamel.yaml==0.16.5       # via -r requirements/base.txt, drf-yasg
+rules==2.1                # via -r requirements/base.txt
+s3transfer==0.1.13        # via -r requirements/base.txt, boto3
+six==1.11.0               # via -r requirements/base.txt, argon2-cffi, astroid, bcrypt, cryptography, django-compat, django-coverage-plugin, django-environ, django-extensions, django-rest-auth, drf-yasg, faker, freezegun, furl, more-itertools, orderedmultidict, packaging, pip-tools, prompt-toolkit, pyjwkest, pylint, pytest, python-dateutil, sphinx, traitlets
+smart-open==1.7.1         # via -r requirements/base.txt
 snowballstemmer==1.2.1    # via sphinx
-sorl-thumbnail==12.5.0
-sphinx==1.7.5
+sorl-thumbnail==12.5.0    # via -r requirements/base.txt
+sphinx==1.7.5             # via -r requirements/local.in
 sphinxcontrib-websupport==1.1.0  # via sphinx
-sqlparse==0.2.4
-stripe==2.10.1
+sqlparse==0.2.4           # via -r requirements/base.txt, django-debug-toolbar, django-request-token
+stripe==2.10.1            # via -r requirements/base.txt
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
 toml==0.9.4               # via black
-traitlets==4.3.2
+traitlets==4.3.2          # via -r requirements/base.txt, ipython
 typed-ast==1.4.0          # via black
-unidecode==1.0.22
-uritemplate==3.0.0
-urllib3==1.23
-vine==1.1.4
-wcwidth==0.1.7
-werkzeug==0.14.1
+unidecode==1.0.22         # via -r requirements/base.txt, python-slugify
+uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.23             # via -r requirements/base.txt, botocore, requests
+vine==1.1.4               # via -r requirements/base.txt, amqp
+wcwidth==0.1.7            # via -r requirements/base.txt, prompt-toolkit
+werkzeug==0.14.1          # via -r requirements/local.in
 wrapt==1.10.11            # via astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -9,7 +9,7 @@
 alabaster==0.7.11         # via sphinx
 amqp==2.3.2               # via -r requirements/base.txt, kombu
 appdirs==1.4.3            # via black
-appnope==0.1.0            # via ipython
+appnope==0.1.0            # via -r requirements/base.txt, ipython
 argon2-cffi==18.1.0       # via -r requirements/base.txt
 astroid==1.6.5            # via pylint, pylint-celery
 atomicwrites==1.1.5       # via pytest
@@ -67,7 +67,7 @@ djangorestframework-simplejwt==4.3.0  # via -r requirements/base.txt
 djangorestframework==3.9.2  # via -r requirements/base.txt, django-rest-auth, djangorestframework-simplejwt, drf-nested-routers, drf-yasg
 docutils==0.14            # via -r requirements/base.txt, botocore, sphinx
 dogslow==1.2              # via -r requirements/base.txt
-drf-flex-fields==0.7.5    # via -r requirements/local.in
+drf-flex-fields==0.7.5    # via -r requirements/base.txt
 drf-nested-routers==0.91  # via -r requirements/base.txt
 drf-yasg==1.17.0          # via -r requirements/base.txt
 factory-boy==2.11.1       # via -r requirements/local.in, pytest-factoryboy

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,117 +6,122 @@
 #
 --no-binary psycopg2
 
-amqp==2.3.2
-argon2-cffi==18.1.0
-backcall==0.1.0
-bcrypt==3.1.4
-billiard==3.5.0.4
-boto3==1.9.32
-boto==2.49.0
-botocore==1.12.32
-bz2file==0.98
-celery==4.2.0
-certifi==2018.4.16
-cffi==1.11.5
-chardet==3.0.4
-collectfast==0.6.2
-coreapi==2.3.3
-coreschema==0.0.4
-cryptography==2.8
-cssselect==1.0.3
-cssutils==1.0.2
-decorator==4.3.2
-defusedxml==0.5.0
-django-allauth==0.38.0
-django-anymail[mailgun]==3.0
-django-appconf==1.0.2
-django-autocomplete-light==3.3.2
-django-autoslug-iplweb==1.9.4
-django-celery-email==2.0.1
-django-choices==1.6.1
-django-compat==1.0.15
-django-compressor==2.2
-django-cors-headers==3.1.1
-django-crispy-forms==1.7.2
-django-debug-toolbar==1.11
-django-email-bandit==1.5
-django-environ==0.4.4
-django-extensions==2.1.5
-django-filter==2.2.0
-django-hijack==2.1.10
-django-model-utils==3.1.2
-django-oidc-provider==0.7.0
-django-premailer==0.2.0
-django-redis==4.9.0
-django-request-token==0.9.2
-django-rest-auth==0.9.5
-django-reversion==3.0.3
-django-sesame==1.5
-django-storages[boto3]==1.7.1
-django==2.1.7
-djangorestframework-simplejwt==4.3.0
-djangorestframework==3.9.2
-docutils==0.14
-dogslow==1.2
-drf-nested-routers==0.91
-drf-yasg==1.17.0
-furl==2.0.0
-future==0.16.0
-gunicorn==19.8.1
-html2text==2018.1.9
-idna==2.7
-inflection==0.3.1
-ipdb==0.11
-ipython-genutils==0.2.0
-ipython==7.2.0
-itypes==1.1.0
-jedi==0.13.2
-jinja2==2.10
-jmespath==0.9.3
-kombu==4.2.1
-lxml==4.3.0
-markupsafe==1.0
-memoize==1.0.0
-oauthlib==2.1.0
-orderedmultidict==1.0
-packaging==19.2
-parso==0.3.3
-pexpect==4.6.0
-pickleshare==0.7.5
-pillow==5.1.0
-premailer==3.0.0
-prompt-toolkit==2.0.8
-psycopg2-binary==2.7.7
-psycopg2==2.7.5
-ptyprocess==0.6.0
-pycparser==2.18
-pycryptodomex==3.6.4
-pygments==2.3.1
-pyjwkest==1.4.0
-pyjwt==1.7.1
-pyparsing==2.4.5
-python-dateutil==2.7.4
-python-slugify==1.2.5
-python3-openid==3.1.0
-pytz==2018.4
-raven==6.9.0
-rcssmin==1.0.6
-redis==2.10.6
-requests-oauthlib==1.0.0
-requests==2.21.0
-rjsmin==1.0.12
-ruamel.yaml.clib==0.2.0
-ruamel.yaml==0.16.5
-rules==2.1
-s3transfer==0.1.13
-six==1.11.0
-smart-open==1.7.1
-sorl-thumbnail==12.5.0
-sqlparse==0.2.4
-stripe==2.10.1
-traitlets==4.3.2
-unidecode==1.0.22
-uritemplate==3.0.0
-urllib3==1.23
-vine==1.1.4
-wcwidth==0.1.7
+amqp==2.3.2               # via -r requirements/base.txt, kombu
+appnope==0.1.0            # via -r requirements/base.txt, ipython
+argon2-cffi==18.1.0       # via -r requirements/base.txt
+backcall==0.1.0           # via -r requirements/base.txt, ipython
+bcrypt==3.1.4             # via -r requirements/base.txt
+billiard==3.5.0.4         # via -r requirements/base.txt, celery
+boto3==1.9.32             # via -r requirements/base.txt, django-storages, smart-open
+boto==2.49.0              # via -r requirements/base.txt, smart-open
+botocore==1.12.32         # via -r requirements/base.txt, boto3, s3transfer
+bz2file==0.98             # via -r requirements/base.txt, smart-open
+celery==4.2.0             # via -r requirements/base.txt, django-celery-email
+certifi==2018.4.16        # via -r requirements/base.txt, requests
+cffi==1.11.5              # via -r requirements/base.txt, argon2-cffi, bcrypt, cryptography
+chardet==3.0.4            # via -r requirements/base.txt, requests
+collectfast==0.6.2        # via -r requirements/production.in
+coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
+cryptography==2.8         # via -r requirements/base.txt
+cssselect==1.0.3          # via -r requirements/base.txt, premailer
+cssutils==1.0.2           # via -r requirements/base.txt, premailer
+decorator==4.3.2          # via -r requirements/base.txt, ipython, traitlets
+defusedxml==0.5.0         # via -r requirements/base.txt, python3-openid
+django-allauth==0.38.0    # via -r requirements/base.txt
+django-anymail[mailgun]==3.0  # via -r requirements/production.in
+django-appconf==1.0.2     # via -r requirements/base.txt, django-celery-email, django-compressor
+django-autocomplete-light==3.3.2  # via -r requirements/base.txt
+django-autoslug-iplweb==1.9.4  # via -r requirements/base.txt
+django-celery-email==2.0.1  # via -r requirements/production.in
+django-choices==1.6.1     # via -r requirements/base.txt
+django-compat==1.0.15     # via -r requirements/base.txt, django-hijack
+django-compressor==2.2    # via -r requirements/base.txt
+django-cors-headers==3.1.1  # via -r requirements/base.txt
+django-crispy-forms==1.7.2  # via -r requirements/base.txt
+django-debug-toolbar==1.11  # via -r requirements/base.txt
+django-email-bandit==1.5  # via -r requirements/base.txt
+django-environ==0.4.4     # via -r requirements/base.txt
+django-extensions==2.1.5  # via -r requirements/base.txt
+django-filter==2.2.0      # via -r requirements/base.txt
+django-hijack==2.1.10     # via -r requirements/base.txt
+django-model-utils==3.1.2  # via -r requirements/base.txt
+django-oidc-provider==0.7.0  # via -r requirements/base.txt
+django-premailer==0.2.0   # via -r requirements/base.txt
+django-redis==4.9.0       # via -r requirements/base.txt
+django-request-token==0.9.2  # via -r requirements/base.txt
+django-rest-auth==0.9.5   # via -r requirements/base.txt
+django-reversion==3.0.3   # via -r requirements/base.txt
+django-sesame==1.5        # via -r requirements/base.txt
+django-storages[boto3]==1.7.1  # via -r requirements/base.txt, collectfast
+django==2.1.7             # via -r requirements/base.txt, collectfast, django-allauth, django-anymail, django-celery-email, django-choices, django-cors-headers, django-debug-toolbar, django-environ, django-filter, django-model-utils, django-redis, django-request-token, django-rest-auth, django-reversion, django-storages, djangorestframework-simplejwt, dogslow, drf-nested-routers, drf-yasg
+djangorestframework-simplejwt==4.3.0  # via -r requirements/base.txt
+djangorestframework==3.9.2  # via -r requirements/base.txt, django-rest-auth, djangorestframework-simplejwt, drf-nested-routers, drf-yasg
+docutils==0.14            # via -r requirements/base.txt, botocore
+dogslow==1.2              # via -r requirements/base.txt
+drf-flex-fields==0.7.5    # via -r requirements/base.txt
+drf-nested-routers==0.91  # via -r requirements/base.txt
+drf-yasg==1.17.0          # via -r requirements/base.txt
+furl==2.0.0               # via -r requirements/base.txt
+future==0.16.0            # via -r requirements/base.txt, pyjwkest
+gunicorn==19.8.1          # via -r requirements/production.in
+html2text==2018.1.9       # via -r requirements/base.txt
+idna==2.7                 # via -r requirements/base.txt, requests
+inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
+ipdb==0.11                # via -r requirements/base.txt
+ipython-genutils==0.2.0   # via -r requirements/base.txt, traitlets
+ipython==7.2.0            # via -r requirements/base.txt, ipdb
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jedi==0.13.2              # via -r requirements/base.txt, ipython
+jinja2==2.10              # via -r requirements/base.txt, coreschema
+jmespath==0.9.3           # via -r requirements/base.txt, boto3, botocore
+kombu==4.2.1              # via -r requirements/base.txt, celery
+lxml==4.3.0               # via -r requirements/base.txt, premailer
+markupsafe==1.0           # via -r requirements/base.txt, jinja2
+memoize==1.0.0            # via -r requirements/base.txt
+oauthlib==2.1.0           # via -r requirements/base.txt, requests-oauthlib
+orderedmultidict==1.0     # via -r requirements/base.txt, furl
+packaging==19.2           # via -r requirements/base.txt, drf-yasg
+parso==0.3.3              # via -r requirements/base.txt, jedi
+pexpect==4.6.0            # via -r requirements/base.txt, ipython
+pickleshare==0.7.5        # via -r requirements/base.txt, ipython
+pillow==5.1.0             # via -r requirements/base.txt
+premailer==3.0.0          # via -r requirements/base.txt, django-premailer
+prompt-toolkit==2.0.8     # via -r requirements/base.txt, ipython
+psycopg2-binary==2.7.7    # via -r requirements/base.txt, django-request-token
+psycopg2==2.7.5           # via -r requirements/base.txt
+ptyprocess==0.6.0         # via -r requirements/base.txt, pexpect
+pycparser==2.18           # via -r requirements/base.txt, cffi
+pycryptodomex==3.6.4      # via -r requirements/base.txt, pyjwkest
+pygments==2.3.1           # via -r requirements/base.txt, ipython
+pyjwkest==1.4.0           # via -r requirements/base.txt, django-oidc-provider
+pyjwt==1.7.1              # via -r requirements/base.txt, django-request-token, djangorestframework-simplejwt
+pyparsing==2.4.5          # via -r requirements/base.txt, packaging
+python-dateutil==2.7.4    # via -r requirements/base.txt, botocore
+python-slugify==1.2.5     # via -r requirements/base.txt
+python3-openid==3.1.0     # via -r requirements/base.txt, django-allauth
+pytz==2018.4              # via -r requirements/base.txt, celery, django
+raven==6.9.0              # via -r requirements/base.txt
+rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
+redis==2.10.6             # via -r requirements/base.txt, django-redis
+requests-oauthlib==1.0.0  # via -r requirements/base.txt, django-allauth
+requests==2.21.0          # via -r requirements/base.txt, coreapi, django-allauth, django-anymail, premailer, pyjwkest, requests-oauthlib, smart-open, stripe
+rjsmin==1.0.12            # via -r requirements/base.txt, django-compressor
+ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
+ruamel.yaml==0.16.5       # via -r requirements/base.txt, drf-yasg
+rules==2.1                # via -r requirements/base.txt
+s3transfer==0.1.13        # via -r requirements/base.txt, boto3
+six==1.11.0               # via -r requirements/base.txt, argon2-cffi, bcrypt, cryptography, django-anymail, django-compat, django-environ, django-extensions, django-rest-auth, drf-yasg, furl, orderedmultidict, packaging, prompt-toolkit, pyjwkest, python-dateutil, traitlets
+smart-open==1.7.1         # via -r requirements/base.txt
+sorl-thumbnail==12.5.0    # via -r requirements/base.txt
+sqlparse==0.2.4           # via -r requirements/base.txt, django-debug-toolbar, django-request-token
+stripe==2.10.1            # via -r requirements/base.txt
+traitlets==4.3.2          # via -r requirements/base.txt, ipython
+unidecode==1.0.22         # via -r requirements/base.txt, python-slugify
+uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.23             # via -r requirements/base.txt, botocore, requests
+vine==1.1.4               # via -r requirements/base.txt, amqp
+wcwidth==0.1.7            # via -r requirements/base.txt, prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -47,7 +47,9 @@ class OrganizationQuerySet(models.QuerySet):
 
 class MembershipQuerySet(models.QuerySet):
     def get_viewable(self, user):
-        return user.memberships.filter(Q(private=False) | Q(organization__users=self.request.user))
+        return user.memberships.filter(
+            Q(private=False) | Q(organization__users=self.request.user)
+        )
 
 
 class PlanQuerySet(models.QuerySet):

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -45,6 +45,11 @@ class OrganizationQuerySet(models.QuerySet):
         return user.individual_organization
 
 
+class MembershipQuerySet(models.QuerySet):
+    def get_viewable(self, user):
+        return user.memberships.filter(Q(private=False) | Q(organization__users=self.request.user))
+
+
 class PlanQuerySet(models.QuerySet):
     def get_viewable(self, user):
         if user.is_staff:

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -19,7 +19,7 @@ from squarelet.organizations.models import (
 )
 
 
-class OrganizationSerializer(FlexFieldsModelSerializer):
+class OrganizationSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(required=False)
     # XXX remove plan once muckrock is updated to handle entitlements
     plan = serializers.SerializerMethodField()
@@ -60,7 +60,7 @@ class OrganizationSerializer(FlexFieldsModelSerializer):
         return obj.customer(StripeAccounts.muckrock).card_display
 
 
-class MembershipSerializer(FlexFieldsModelSerializer):
+class MembershipSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer()
 
     class Meta:
@@ -83,7 +83,7 @@ class StripeError(APIException):
     default_detail = "Stripe error"
 
 
-class ChargeSerializer(FlexFieldsModelSerializer):
+class ChargeSerializer(serializers.ModelSerializer):
     token = serializers.CharField(write_only=True, required=False)
     save_card = serializers.BooleanField(write_only=True, required=False)
     organization = serializers.SlugRelatedField(
@@ -136,7 +136,7 @@ class ChargeSerializer(FlexFieldsModelSerializer):
 # PressPass
 
 
-class PressPassOrganizationSerializer(FlexFieldsModelSerializer):
+class PressPassOrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
         fields = (
@@ -164,7 +164,7 @@ class PressPassOrganizationSerializer(FlexFieldsModelSerializer):
         }
 
 
-class PressPassMembershipSerializer(FlexFieldsModelSerializer):
+class PressPassMembershipSerializer(serializers.ModelSerializer):
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
 
     class Meta:
@@ -173,7 +173,7 @@ class PressPassMembershipSerializer(FlexFieldsModelSerializer):
         extra_kwargs = {"admin": {"default": False}}
 
 
-class PressPassNestedInvitationSerializer(FlexFieldsModelSerializer):
+class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
 
     class Meta:
@@ -242,7 +242,7 @@ class PressPassInvitationSerializer(FlexFieldsModelSerializer):
         return attrs
 
 
-class PressPassPlanSerializer(FlexFieldsModelSerializer):
+class PressPassPlanSerializer(serializers.ModelSerializer):
     class Meta:
         model = Plan
         fields = (
@@ -259,7 +259,7 @@ class PressPassPlanSerializer(FlexFieldsModelSerializer):
         )
 
 
-class PressPassClientSerializer(FlexFieldsModelSerializer):
+class PressPassClientSerializer(serializers.ModelSerializer):
     class Meta:
         model = Client
         fields = ("name", "client_type", "website_url")
@@ -285,7 +285,7 @@ class PressPassEntitlmentSerializer(FlexFieldsModelSerializer):
             self.fields["client"].queryset = Client.objects.none()
 
 
-class PressPassSubscriptionSerializer(FlexFieldsModelSerializer):
+class PressPassSubscriptionSerializer(serializers.ModelSerializer):
     token = serializers.CharField(write_only=True, required=False)
 
     class Meta:

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -273,7 +273,6 @@ class PressPassEntitlmentSerializer(serializers.ModelSerializer):
         super().__init__(*args, **kwargs)
         context = kwargs.get("context", {})
         request = context.get("request")
-        view = context.get("view")
 
         # may only create entitlements for your own clients
         if request and request.user and request.user.is_authenticated:

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -177,7 +177,6 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invitation
         fields = (
-            "uuid",
             "email",
             "user",
             "request",

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -264,20 +264,22 @@ class PressPassClientSerializer(serializers.ModelSerializer):
 
 
 class PressPassEntitlmentSerializer(serializers.ModelSerializer):
-    client = serializers.SerializerMethodField()
+    client_data = serializers.SerializerMethodField()
 
-    def get_client(self, obj):
+    def get_client_data(self, obj):
         return PressPassClientSerializer(obj.client).data
 
     class Meta:
         model = Entitlement
-        fields = ("name", "slug", "client", "description")
+        fields = ("name", "slug", "client", "description", "client_data")
         extra_kwargs = {"slug": {"read_only": True}}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         context = kwargs.get("context", {})
         request = context.get("request")
+        view = context.get("view")
+
         # may only create entitlements for your own clients
         if request and request.user and request.user.is_authenticated:
             self.fields["client"].queryset = Client.objects.filter(owner=request.user)

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -263,14 +263,10 @@ class PressPassClientSerializer(serializers.ModelSerializer):
 
 
 class PressPassEntitlmentSerializer(serializers.ModelSerializer):
-    client_data = serializers.SerializerMethodField()
-
-    def get_client_data(self, obj):
-        return PressPassClientSerializer(obj.client).data
 
     class Meta:
         model = Entitlement
-        fields = ("name", "slug", "client", "description", "client_data")
+        fields = ("name", "slug", "client", "description")
         extra_kwargs = {"slug": {"read_only": True}}
 
     def __init__(self, *args, **kwargs):

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -178,7 +178,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invitation
         fields = (
-            "uuid", 
+            "uuid",
             "email",
             "user",
             "request",

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -3,6 +3,8 @@ import stripe
 from oidc_provider.models import Client
 from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
+from rest_flex_fields import FlexFieldsModelSerializer
+
 
 # Squarelet
 from squarelet.organizations.choices import StripeAccounts
@@ -17,7 +19,7 @@ from squarelet.organizations.models import (
 )
 
 
-class OrganizationSerializer(serializers.ModelSerializer):
+class OrganizationSerializer(FlexFieldsModelSerializer):
     uuid = serializers.UUIDField(required=False)
     # XXX remove plan once muckrock is updated to handle entitlements
     plan = serializers.SerializerMethodField()
@@ -58,7 +60,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
         return obj.customer(StripeAccounts.muckrock).card_display
 
 
-class MembershipSerializer(serializers.ModelSerializer):
+class MembershipSerializer(FlexFieldsModelSerializer):
     organization = OrganizationSerializer()
 
     class Meta:
@@ -81,7 +83,7 @@ class StripeError(APIException):
     default_detail = "Stripe error"
 
 
-class ChargeSerializer(serializers.ModelSerializer):
+class ChargeSerializer(FlexFieldsModelSerializer):
     token = serializers.CharField(write_only=True, required=False)
     save_card = serializers.BooleanField(write_only=True, required=False)
     organization = serializers.SlugRelatedField(
@@ -134,7 +136,7 @@ class ChargeSerializer(serializers.ModelSerializer):
 # PressPass
 
 
-class PressPassOrganizationSerializer(serializers.ModelSerializer):
+class PressPassOrganizationSerializer(FlexFieldsModelSerializer):
     class Meta:
         model = Organization
         fields = (
@@ -162,7 +164,7 @@ class PressPassOrganizationSerializer(serializers.ModelSerializer):
         }
 
 
-class PressPassMembershipSerializer(serializers.ModelSerializer):
+class PressPassMembershipSerializer(FlexFieldsModelSerializer):
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
 
     class Meta:
@@ -171,7 +173,7 @@ class PressPassMembershipSerializer(serializers.ModelSerializer):
         extra_kwargs = {"admin": {"default": False}}
 
 
-class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
+class PressPassNestedInvitationSerializer(FlexFieldsModelSerializer):
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
 
     class Meta:
@@ -204,7 +206,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
         return value
 
 
-class PressPassInvitationSerializer(serializers.ModelSerializer):
+class PressPassInvitationSerializer(FlexFieldsModelSerializer):
     organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
     accept = serializers.BooleanField(write_only=True)
@@ -229,6 +231,7 @@ class PressPassInvitationSerializer(serializers.ModelSerializer):
             "rejected_at": {"read_only": True},
             "email": {"read_only": True},
         }
+        expandable_fields = { 'organization': PressPassOrganizationSerializer }
 
     def validate(self, attrs):
         """Must not try to accept and reject"""
@@ -239,7 +242,7 @@ class PressPassInvitationSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class PressPassPlanSerializer(serializers.ModelSerializer):
+class PressPassPlanSerializer(FlexFieldsModelSerializer):
     class Meta:
         model = Plan
         fields = (
@@ -256,18 +259,19 @@ class PressPassPlanSerializer(serializers.ModelSerializer):
         )
 
 
-class PressPassClientSerializer(serializers.ModelSerializer):
+class PressPassClientSerializer(FlexFieldsModelSerializer):
     class Meta:
         model = Client
         fields = ("name", "client_type", "website_url")
 
 
-class PressPassEntitlmentSerializer(serializers.ModelSerializer):
+class PressPassEntitlmentSerializer(FlexFieldsModelSerializer):
 
     class Meta:
         model = Entitlement
         fields = ("name", "slug", "client", "description")
         extra_kwargs = {"slug": {"read_only": True}}
+        expandable_fields = { 'client': PressPassClientSerializer }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -281,7 +285,7 @@ class PressPassEntitlmentSerializer(serializers.ModelSerializer):
             self.fields["client"].queryset = Client.objects.none()
 
 
-class PressPassSubscriptionSerializer(serializers.ModelSerializer):
+class PressPassSubscriptionSerializer(FlexFieldsModelSerializer):
     token = serializers.CharField(write_only=True, required=False)
 
     class Meta:

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -1,10 +1,9 @@
 # Third Party
 import stripe
 from oidc_provider.models import Client
+from rest_flex_fields import FlexFieldsModelSerializer
 from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
-from rest_flex_fields import FlexFieldsModelSerializer
-
 
 # Squarelet
 from squarelet.organizations.choices import StripeAccounts
@@ -231,7 +230,7 @@ class PressPassInvitationSerializer(FlexFieldsModelSerializer):
             "rejected_at": {"read_only": True},
             "email": {"read_only": True},
         }
-        expandable_fields = { 'organization': PressPassOrganizationSerializer }
+        expandable_fields = {"organization": PressPassOrganizationSerializer}
 
     def validate(self, attrs):
         """Must not try to accept and reject"""
@@ -266,12 +265,11 @@ class PressPassClientSerializer(serializers.ModelSerializer):
 
 
 class PressPassEntitlmentSerializer(FlexFieldsModelSerializer):
-
     class Meta:
         model = Entitlement
         fields = ("name", "slug", "client", "description")
         extra_kwargs = {"slug": {"read_only": True}}
-        expandable_fields = { 'client': PressPassClientSerializer }
+        expandable_fields = {"client": PressPassClientSerializer}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -177,6 +177,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invitation
         fields = (
+            "uuid",
             "email",
             "user",
             "request",
@@ -190,6 +191,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
             "created_at": {"read_only": True},
             "accepted_at": {"read_only": True},
             "rejected_at": {"read_only": True},
+            "uuid": {"read_only": True},
         }
 
     def validate_email(self, value):

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -178,6 +178,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invitation
         fields = (
+            "uuid", 
             "email",
             "user",
             "request",

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -230,6 +230,13 @@ class TestPPInvitationAPI:
         assert invitation.accepted_at
         assert invitation.organization.has_member(user)
 
+    def test_retrieve_with_expanded_organization(self, api_client, invitation):
+        """Get an invitation with expanded organization data"""
+        response = api_client.get(f"/pp-api/invitations/{invitation.uuid}/?expand=organization")
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert ("name" in response_json["organization"])
+
 
 @pytest.mark.django_db()
 class TestPPPlanAPI:

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -230,12 +230,14 @@ class TestPPInvitationAPI:
         assert invitation.accepted_at
         assert invitation.organization.has_member(user)
 
-    def test_retrieve_with_expanded_organization(self, api_client, invitation):
+    def test_retrieve_expand_org(self, api_client, invitation):
         """Get an invitation with expanded organization data"""
-        response = api_client.get(f"/pp-api/invitations/{invitation.uuid}/?expand=organization")
+        response = api_client.get(
+            f"/pp-api/invitations/{invitation.uuid}/?expand=organization"
+        )
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
-        assert ("name" in response_json["organization"])
+        assert "name" in response_json["organization"]
 
 
 @pytest.mark.django_db()
@@ -272,7 +274,7 @@ class TestPPEntitlementAPI:
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == size
 
-    def test_list_with_expanded_clients(self, api_client, mocker):
+    def test_list_expand_clients(self, api_client, mocker):
         """List entitlements"""
         size = 10
         entitlements = EntitlementFactory.create_batch(size)
@@ -284,8 +286,8 @@ class TestPPEntitlementAPI:
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == size
-        for e in response_json["results"]:
-            assert "name" in e["client"]
+        for entitlement in response_json["results"]:
+            assert "name" in entitlement["client"]
 
     def test_create(self, api_client, client):
         """Create an entitlement"""
@@ -318,16 +320,18 @@ class TestPPEntitlementAPI:
         response = api_client.get(f"/pp-api/entitlements/{entitlement.pk}/")
         assert response.status_code == status.HTTP_200_OK
 
-    def test_retrieve_with_expanded_client(self, api_client, entitlement, mocker):
+    def test_retrieve_expand_client(self, api_client, entitlement, mocker):
         """Test retrieving an entitlement"""
         mocker.patch("stripe.Plan.create")
         # make entitlement public by adding it to a public plan
         plan = PlanFactory(public=True)
         plan.entitlements.add(entitlement)
-        response = api_client.get(f"/pp-api/entitlements/{entitlement.pk}/?expand=client")
+        response = api_client.get(
+            f"/pp-api/entitlements/{entitlement.pk}/?expand=client"
+        )
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
-        assert ("name" in response_json["client"])
+        assert "name" in response_json["client"]
 
     def test_retrieve_bad(self, api_client, entitlement):
         """Test retrieving a private entitlement"""

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -167,5 +167,5 @@ class PressPassUserInvitationsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Invitation
-        fields = ("uuid", "organization", "request", "accepted_at", "rejected_at", "created_at")
+        fields = ("uuid", "user", "organization", "request", "accepted_at", "rejected_at", "created_at")
         extra_kwargs = {"request": {"default": False}}

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -9,6 +9,9 @@ from rest_framework import serializers
 # Squarelet
 from squarelet.organizations.serializers import MembershipSerializer
 from squarelet.users.models import User
+from squarelet.organizations.models import (
+    Membership,
+)
 
 
 class UserBaseSerializer(serializers.ModelSerializer):
@@ -147,3 +150,12 @@ class PressPassUserSerializer(serializers.ModelSerializer):
             if self.instance and not self.instance.can_change_username:
                 # pylint: disable=invalid-sequence-index
                 self.fields["username"].read_only = True
+
+
+class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
+
+    class Meta:
+        model = Membership
+        fields = ("organization", "admin")
+        extra_kwargs = {"admin": {"default": False}}

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -167,5 +167,5 @@ class PressPassUserInvitationsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Invitation
-        fields = ("organization", "request", "accepted_at", "rejected_at", "created_at")
+        fields = ("uuid", "organization", "request", "accepted_at", "rejected_at", "created_at")
         extra_kwargs = {"request": {"default": False}}

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -7,14 +7,12 @@ import string
 from rest_framework import serializers
 
 # Squarelet
+from squarelet.organizations.models import Membership
 from squarelet.organizations.serializers import (
     MembershipSerializer,
-    PressPassOrganizationSerializer
+    PressPassOrganizationSerializer,
 )
 from squarelet.users.models import User
-from squarelet.organizations.models import (
-    Membership
-)
 
 
 class UserBaseSerializer(serializers.ModelSerializer):

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -156,10 +156,7 @@ class PressPassUserSerializer(serializers.ModelSerializer):
 
 
 class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
-    organization = serializers.SerializerMethodField()
-
-    def get_organization(self, obj):
-        return PressPassOrganizationSerializer(obj.organization).data
+    organization = PressPassOrganizationSerializer(read_only=True)
 
     class Meta:
         model = Membership

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -11,6 +11,7 @@ from squarelet.organizations.serializers import MembershipSerializer
 from squarelet.users.models import User
 from squarelet.organizations.models import (
     Membership,
+    Invitation
 )
 
 
@@ -159,3 +160,12 @@ class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
         model = Membership
         fields = ("organization", "admin")
         extra_kwargs = {"admin": {"default": False}}
+
+
+class PressPassUserInvitationsSerializer(serializers.ModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
+
+    class Meta:
+        model = Invitation
+        fields = ("organization", "request")
+        extra_kwargs = {"request": {"default": False}}

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -7,7 +7,10 @@ import string
 from rest_framework import serializers
 
 # Squarelet
-from squarelet.organizations.serializers import MembershipSerializer
+from squarelet.organizations.serializers import (
+    MembershipSerializer,
+    PressPassOrganizationSerializer
+)
 from squarelet.users.models import User
 from squarelet.organizations.models import (
     Membership,
@@ -154,7 +157,10 @@ class PressPassUserSerializer(serializers.ModelSerializer):
 
 
 class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
-    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
+    organization = serializers.SerializerMethodField()
+
+    def get_organization(self, obj):
+        return PressPassOrganizationSerializer(obj.organization).data
 
     class Meta:
         model = Membership

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -160,12 +160,3 @@ class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
         model = Membership
         fields = ("organization", "admin")
         extra_kwargs = {"admin": {"default": False}}
-
-
-class PressPassUserInvitationsSerializer(serializers.ModelSerializer):
-    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
-
-    class Meta:
-        model = Invitation
-        fields = ("uuid", "user", "organization", "request", "accepted_at", "rejected_at", "created_at")
-        extra_kwargs = {"request": {"default": False}}

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -13,8 +13,7 @@ from squarelet.organizations.serializers import (
 )
 from squarelet.users.models import User
 from squarelet.organizations.models import (
-    Membership,
-    Invitation
+    Membership
 )
 
 

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -167,5 +167,5 @@ class PressPassUserInvitationsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Invitation
-        fields = ("organization", "request")
+        fields = ("organization", "request", "accepted_at", "rejected_at", "created_at")
         extra_kwargs = {"request": {"default": False}}

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -21,7 +21,7 @@ from rest_framework.response import Response
 from squarelet.core.mail import send_mail
 from squarelet.core.permissions import DjangoObjectPermissionsOrAnonReadOnly
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import Membership, Plan, Invitation
+from squarelet.organizations.models import Membership, Plan
 from squarelet.users.models import User
 from squarelet.users.serializers import (
     PressPassUserSerializer,

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -28,7 +28,6 @@ from squarelet.users.serializers import (
     UserReadSerializer,
     UserWriteSerializer,
     PressPassUserMembershipsSerializer,
-    PressPassUserInvitationsSerializer,
 )
 
 
@@ -128,23 +127,6 @@ class PressPassUserMembershipViewSet(
             uuid=self.kwargs["user_uuid"],
         )
         return user.memberships.all()
-
-
-class PressPassUserInvitationViewSet(
-    mixins.ListModelMixin,
-    viewsets.GenericViewSet,
-):
-    queryset = Invitation.objects.none()
-    serializer_class = PressPassUserInvitationsSerializer
-    permission_classes = (DjangoObjectPermissionsOrAnonReadOnly,)
-    lookup_field = "user__uuid"
-
-    def get_queryset(self):
-        user = get_object_or_404(
-            User,
-            uuid=self.kwargs["user_uuid"],
-        )
-        return user.invitations.all()
 
 
 class PressPassRegisterView(RegisterView):

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -118,7 +118,7 @@ class PressPassUserMembershipViewSet(
 ):
     queryset = Membership.objects.none()
     serializer_class = PressPassUserMembershipsSerializer
-    permission_classes = (DjangoObjectPermissionsOrAnonReadOnly,)
+    permission_classes = (DjangoObjectPermissions,)
     lookup_field = "user__uuid"
 
     def get_queryset(self):

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -19,15 +19,14 @@ from rest_framework.response import Response
 
 # Squarelet
 from squarelet.core.mail import send_mail
-from squarelet.core.permissions import DjangoObjectPermissionsOrAnonReadOnly
 from squarelet.oidc.permissions import ScopePermission
 from squarelet.organizations.models import Membership, Plan
 from squarelet.users.models import User
 from squarelet.users.serializers import (
+    PressPassUserMembershipsSerializer,
     PressPassUserSerializer,
     UserReadSerializer,
     UserWriteSerializer,
-    PressPassUserMembershipsSerializer,
 )
 
 
@@ -113,8 +112,7 @@ class PressPassUserViewSet(
 
 
 class PressPassUserMembershipViewSet(
-    mixins.ListModelMixin,
-    viewsets.GenericViewSet,
+    mixins.ListModelMixin, viewsets.GenericViewSet,
 ):
     queryset = Membership.objects.none()
     serializer_class = PressPassUserMembershipsSerializer
@@ -122,10 +120,7 @@ class PressPassUserMembershipViewSet(
     lookup_field = "user__uuid"
 
     def get_queryset(self):
-        user = get_object_or_404(
-            User,
-            uuid=self.kwargs["user_uuid"],
-        )
+        user = get_object_or_404(User, uuid=self.kwargs["user_uuid"],)
         return user.memberships.all()
 
 


### PR DESCRIPTION
Hi all, this PR builds on my previous (still open) PR #32. I needed the changes made there, and I wasn't sure how you usually dealt with still in-progress work. 

So this is really 2 commits, one that adds [drf-flex-fields](https://github.com/rsinger86/drf-flex-fields) as a local dependency, the other that implements it for the organizations serializers. I figured it made sense to only add the `expandable_fields` declarations where I knew for sure that I needed them now instead of guessing across the board. 

I also wanted to get feedback sooner than later on how I've done this:

* does a new package go into `local.in` and `local.txt` first? 
* should I have added it somewhere else as well or instead of `local.in`?
* one final note: I couldn't get `inv pip-compile` to work so I had to run this locally `python manage.py runserver`; I'd love to know if this all works for others in docker.