### PR TITLE
Added ID to plan and subscription API responses for PressPass

### DIFF
--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -254,6 +254,7 @@ class PressPassPlanSerializer(serializers.ModelSerializer):
     class Meta:
         model = Plan
         fields = (
+            "id",
             "name",
             "slug",
             "minimum_users",
@@ -297,7 +298,7 @@ class PressPassSubscriptionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Subscription
-        fields = ("plan", "update_on", "cancelled", "token")
+        fields = ("id", "plan", "update_on", "cancelled", "token")
         extra_kwargs = {
             "update_on": {"read_only": True},
             "cancelled": {"read_only": True},

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -250,6 +250,7 @@ class TestPPPlanAPI:
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == size
+        assert "id" in response_json["results"][0]
 
     def test_retrieve(self, api_client, mocker):
         """Test retrieving a plan"""
@@ -257,6 +258,8 @@ class TestPPPlanAPI:
         plan = PlanFactory()
         response = api_client.get(f"/pp-api/plans/{plan.id}/")
         assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert "id" in response_json
 
 
 @pytest.mark.django_db()
@@ -368,6 +371,7 @@ class TestPPSubscriptionAPI:
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == size
+        assert "id" in response_json["results"][0]
 
     def test_create(self, api_client, user, mocker):
         """Create a subscription"""
@@ -407,6 +411,8 @@ class TestPPSubscriptionAPI:
             f"{subscription.pk}/"
         )
         assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert "id" in response_json
 
     def test_destroy(self, api_client, user, mocker):
         """Test cancelling a subscription"""

--- a/squarelet/organizations/tests/test_querysets.py
+++ b/squarelet/organizations/tests/test_querysets.py
@@ -1,5 +1,7 @@
 # Third Party
 # Django
+# Django
+# Django
 from django.test import TestCase
 
 import pytest


### PR DESCRIPTION
This PR adds `id`s to the API responses for plans and subscriptions, as we discussed in our chat yesterday (the API overview discussion). I've added tests for these 4 (list/retrieve) endpoints as well to verify they return an id, and ran `inv format` on the code. The formatting made a whitespace change to the `test_querysets.py` which is the only reason why it's included here ✌️ 