### PR TITLE
PP Subscriptions endpoint can expand plan data

### DIFF
--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -293,7 +293,7 @@ class PressPassEntitlmentSerializer(FlexFieldsModelSerializer):
             self.fields["client"].queryset = Client.objects.none()
 
 
-class PressPassSubscriptionSerializer(serializers.ModelSerializer):
+class PressPassSubscriptionSerializer(FlexFieldsModelSerializer):
     token = serializers.CharField(write_only=True, required=False)
 
     class Meta:
@@ -303,6 +303,7 @@ class PressPassSubscriptionSerializer(serializers.ModelSerializer):
             "update_on": {"read_only": True},
             "cancelled": {"read_only": True},
         }
+        expandable_fields = {"plan": PressPassPlanSerializer}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -418,6 +418,20 @@ class TestPPSubscriptionAPI:
         assert len(response_json["results"]) == size
         assert "id" in response_json["results"][0]
 
+    def test_list_expand_plans(self, api_client, user):
+        """List subscriptions expanding plans"""
+        size = 10
+        organization = OrganizationFactory(admins=[user])
+        api_client.force_authenticate(user=user)
+        SubscriptionFactory.create_batch(size, organization=organization)
+        response = api_client.get(
+            f"/pp-api/organizations/{organization.uuid}/subscriptions/?expand=plan"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == size
+        assert "name" in response_json["results"][0]["plan"]
+
     def test_create(self, api_client, user, mocker):
         """Create a subscription"""
         mocker.patch("stripe.Plan.create")


### PR DESCRIPTION
This PR makes the subscriptions endpoint for the PP API allow expanding of `plan` data, and it includes a test for this feature. 

FYI @TylerFisher this allows our "Manage Organization" page to properly render the "SubscriptionCard" with the plan's title.