### PR TITLE
User invitations endpoint

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -28,12 +28,12 @@ from squarelet.organizations.viewsets import (
     PressPassOrganizationViewSet,
     PressPassPlanViewSet,
     PressPassSubscriptionViewSet,
+    PressPassUserInvitationViewSet,
     PressPassUserMembershipViewSet,
 )
 from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     PressPassRegisterView,
-    PressPassUserInvitationViewSet,
     PressPassUserViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,

--- a/config/urls.py
+++ b/config/urls.py
@@ -33,6 +33,7 @@ from squarelet.organizations.viewsets import (
 from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     PressPassRegisterView,
+    PressPassUserInvitationViewSet,
     PressPassUserViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,
@@ -72,6 +73,7 @@ organization_router.register("invitations", PressPassNestedInvitationViewSet)
 organization_router.register("subscriptions", PressPassSubscriptionViewSet)
 
 user_router = routers.NestedDefaultRouter(presspass_router, "users", lookup="user")
+user_router.register("invitations", PressPassUserInvitationViewSet)
 user_router.register("memberships", PressPassUserMembershipViewSet)
 
 urlpatterns = [

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -250,6 +250,21 @@ class PressPassInvitationSerializer(FlexFieldsModelSerializer):
         return attrs
 
 
+class PressPassUserInvitationsSerializer(FlexFieldsModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
+
+    class Meta:
+        model = Invitation
+        fields = (
+            "uuid",
+            "organization",
+            "request",
+            "accepted_at",
+            "rejected_at",
+            "created_at",
+        )
+        expandable_fields = {"organization": PressPassOrganizationSerializer}
+
 class PressPassPlanSerializer(serializers.ModelSerializer):
     class Meta:
         model = Plan

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -265,6 +265,7 @@ class PressPassUserInvitationsSerializer(FlexFieldsModelSerializer):
         )
         expandable_fields = {"organization": PressPassOrganizationSerializer}
 
+
 class PressPassPlanSerializer(serializers.ModelSerializer):
     class Meta:
         model = Plan

--- a/squarelet/organizations/tests/factories.py
+++ b/squarelet/organizations/tests/factories.py
@@ -129,6 +129,17 @@ class InvitationFactory(factory.django.DjangoModelFactory):
         model = "organizations.Invitation"
 
 
+class InvitationRequestFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory("squarelet.users.tests.factories.UserFactory")
+    organization = factory.SubFactory(
+        "squarelet.organizations.tests.factories.OrganizationFactory"
+    )
+    request = True
+
+    class Meta:
+        model = "organizations.Invitation"
+
+
 class ChargeFactory(factory.django.DjangoModelFactory):
     organization = factory.SubFactory(
         "squarelet.organizations.tests.factories.OrganizationFactory"

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -502,9 +502,7 @@ class TestPPUserMembershipAPI:
         organization = OrganizationFactory(admins=[user], private=True)
         new_user = UserFactory()
         MembershipFactory(organization=organization, user=new_user, admin=False)
-        response = api_client.get(
-            f"/pp-api/users/me/memberships/"
-        )
+        response = api_client.get(f"/pp-api/users/me/memberships/")
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         # will return individual organization membership
@@ -518,9 +516,7 @@ class TestPPUserInvitationAPI:
         """List user invitations"""
         api_client.force_authenticate(user=user)
         InvitationRequestFactory(user=user)
-        response = api_client.get(
-            f"/pp-api/users/me/invitations/"
-        )
+        response = api_client.get(f"/pp-api/users/me/invitations/")
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == 1
@@ -530,9 +526,7 @@ class TestPPUserInvitationAPI:
         """List user invitations and expand organization data"""
         api_client.force_authenticate(user=user)
         InvitationRequestFactory(user=user)
-        response = api_client.get(
-            f"/pp-api/users/me/invitations/?expand=organization"
-        )
+        response = api_client.get(f"/pp-api/users/me/invitations/?expand=organization")
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == 1

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -14,6 +14,7 @@ from squarelet.organizations.models import Charge, Entitlement, Organization
 from squarelet.organizations.tests.factories import (
     EntitlementFactory,
     InvitationFactory,
+    InvitationRequestFactory,
     MembershipFactory,
     OrganizationFactory,
     OrganizationPlanFactory,
@@ -502,8 +503,38 @@ class TestPPUserMembershipAPI:
         new_user = UserFactory()
         MembershipFactory(organization=organization, user=new_user, admin=False)
         response = api_client.get(
-            f"/pp-api/users/{new_user.individual_organization_id}/memberships/"
+            f"/pp-api/users/me/memberships/"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        # will return individual organization membership
+        # and membership from organization created above
+        assert len(response_json["results"]) == 2
+
+
+@pytest.mark.django_db()
+class TestPPUserInvitationAPI:
+    def test_list_invitations(self, api_client, user):
+        """List user invitations"""
+        api_client.force_authenticate(user=user)
+        InvitationRequestFactory(user=user)
+        response = api_client.get(
+            f"/pp-api/users/me/invitations/"
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == 1
+        assert response_json["results"][0]["request"]
+
+    def test_list_invitations_expand_org(self, api_client, user):
+        """List user invitations and expand organization data"""
+        api_client.force_authenticate(user=user)
+        InvitationRequestFactory(user=user)
+        response = api_client.get(
+            f"/pp-api/users/me/invitations/?expand=organization"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == 1
+        assert response_json["results"][0]["request"]
+        assert "name" in response_json["results"][0]["organization"]

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -28,6 +28,7 @@ from squarelet.organizations.serializers import (
     PressPassPlanSerializer,
     PressPassSubscriptionSerializer,
     PressPassUserMembershipsSerializer,
+    PressPassUserInvitationsSerializer
 )
 from squarelet.users.models import User
 
@@ -120,17 +121,6 @@ class PressPassMembershipViewSet(
             uuid=self.kwargs["organization_uuid"],
         )
         return organization.memberships.all()
-
-
-class PressPassUserMembershipViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
-    queryset = Membership.objects.none()
-    serializer_class = PressPassUserMembershipsSerializer
-    permission_classes = (DjangoObjectPermissions,)
-    lookup_field = "user__uuid"
-
-    def get_queryset(self):
-        user = get_object_or_404(User, uuid=self.kwargs["user_uuid"])
-        return user.memberships.get_viewable(self.request.user)
 
 
 class PressPassNestedInvitationViewSet(
@@ -228,6 +218,41 @@ class PressPassPlanViewSet(viewsets.ReadOnlyModelViewSet):
             fields = ["organization", "account"]
 
     filterset_class = Filter
+
+
+
+class PressPassUserInvitationViewSet(
+    mixins.ListModelMixin, viewsets.GenericViewSet,
+):
+    queryset = Invitation.objects.none()
+    serializer_class = PressPassUserInvitationsSerializer
+    permission_classes = (DjangoObjectPermissions,)
+    lookup_field = "user__uuid"
+
+    def get_queryset(self):
+        if self.kwargs["user_uuid"] == "me" or self.kwargs["user_uuid"] == str(
+            self.request.user.uuid
+        ):
+            user = self.request.user
+            return user.invitations.all()
+        else:
+            return self.queryset
+
+
+class PressPassUserMembershipViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    queryset = Membership.objects.none()
+    serializer_class = PressPassUserMembershipsSerializer
+    permission_classes = (DjangoObjectPermissions,)
+    lookup_field = "user__uuid"
+
+    def get_queryset(self):
+        if self.kwargs["user_uuid"] == "me" or self.kwargs["user_uuid"] == str(
+            self.request.user.uuid
+        ):
+            user = self.request.user
+            return user.memberships.get_viewable(self.request.user)
+        else:
+            return self.queryset
 
 
 class PressPassEntitlmentViewSet(viewsets.ModelViewSet):

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -27,8 +27,8 @@ from squarelet.organizations.serializers import (
     PressPassOrganizationSerializer,
     PressPassPlanSerializer,
     PressPassSubscriptionSerializer,
+    PressPassUserInvitationsSerializer,
     PressPassUserMembershipsSerializer,
-    PressPassUserInvitationsSerializer
 )
 from squarelet.users.models import User
 
@@ -220,7 +220,6 @@ class PressPassPlanViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = Filter
 
 
-
 class PressPassUserInvitationViewSet(
     mixins.ListModelMixin, viewsets.GenericViewSet,
 ):
@@ -230,10 +229,11 @@ class PressPassUserInvitationViewSet(
     lookup_field = "user__uuid"
 
     def get_queryset(self):
+        user = self.request.user
+
         if self.kwargs["user_uuid"] == "me" or self.kwargs["user_uuid"] == str(
-            self.request.user.uuid
+            user.uuid
         ):
-            user = self.request.user
             return user.invitations.all()
         else:
             return self.queryset
@@ -246,11 +246,12 @@ class PressPassUserMembershipViewSet(mixins.ListModelMixin, viewsets.GenericView
     lookup_field = "user__uuid"
 
     def get_queryset(self):
+        user = self.request.user
+
         if self.kwargs["user_uuid"] == "me" or self.kwargs["user_uuid"] == str(
-            self.request.user.uuid
+            user.uuid
         ):
-            user = self.request.user
-            return user.memberships.get_viewable(self.request.user)
+            return user.memberships.get_viewable(user)
         else:
             return self.queryset
 

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -155,33 +155,6 @@ class PressPassUserSerializer(serializers.ModelSerializer):
                 self.fields["username"].read_only = True
 
 
-class PressPassUserInvitationsSerializer(FlexFieldsModelSerializer):
-    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
-
-    class Meta:
-        model = Invitation
-        fields = (
-            "uuid",
-            "user",
-            "organization",
-            "request",
-            "accepted_at",
-            "rejected_at",
-            "created_at",
-        )
-        extra_kwargs = {"request": {"default": False}}
-        expandable_fields = {"organization": PressPassOrganizationSerializer}
-
-
-class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
-    organization = PressPassOrganizationSerializer(read_only=True)
-
-    class Meta:
-        model = Membership
-        fields = ("organization", "admin")
-        extra_kwargs = {"admin": {"default": False}}
-
-
 class PressPassUserWriteSerializer(RegisterSerializer):
     """
     Override dj-rest-auth's user serializer so that we can pass

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -5,10 +5,11 @@ import string
 
 # Third Party
 from dj_rest_auth.registration.serializers import RegisterSerializer
+from rest_flex_fields import FlexFieldsModelSerializer
 from rest_framework import serializers
 
 # Squarelet
-from squarelet.organizations.models import Membership
+from squarelet.organizations.models import Invitation, Membership
 from squarelet.organizations.serializers import (
     MembershipSerializer,
     PressPassOrganizationSerializer,
@@ -152,6 +153,24 @@ class PressPassUserSerializer(serializers.ModelSerializer):
             if self.instance and not self.instance.can_change_username:
                 # pylint: disable=invalid-sequence-index
                 self.fields["username"].read_only = True
+
+
+class PressPassUserInvitationsSerializer(FlexFieldsModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
+
+    class Meta:
+        model = Invitation
+        fields = (
+            "uuid",
+            "user",
+            "organization",
+            "request",
+            "accepted_at",
+            "rejected_at",
+            "created_at",
+        )
+        extra_kwargs = {"request": {"default": False}}
+        expandable_fields = {"organization": PressPassOrganizationSerializer}
 
 
 class PressPassUserMembershipsSerializer(serializers.ModelSerializer):

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 # Squarelet
+from squarelet.organizations.tests.factories import InvitationRequestFactory
 from squarelet.users.serializers import PressPassUserSerializer
 from squarelet.users.tests.factories import UserFactory
 
@@ -101,3 +102,15 @@ class TestPPUserAPI:
             f"/pp-api/users/{other_user.individual_organization_id}/", {"name": name}
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_invitations(self, api_client, user):
+        """List user invitations"""
+        api_client.force_authenticate(user=user)
+        InvitationRequestFactory(user=user)
+        response = api_client.get(
+            f"/pp-api/users/{user.individual_organization_id}/invitations/"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == 1
+        assert response_json["results"][0]["request"]

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -114,3 +114,16 @@ class TestPPUserAPI:
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == 1
         assert response_json["results"][0]["request"]
+
+    def test_list_invitations_expand_org(self, api_client, user):
+        """List user invitations and expand organization data"""
+        api_client.force_authenticate(user=user)
+        InvitationRequestFactory(user=user)
+        response = api_client.get(
+            f"/pp-api/users/{user.individual_organization_id}/invitations/?expand=organization"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == 1
+        assert response_json["results"][0]["request"]
+        assert "name" in response_json["results"][0]["organization"]

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -102,28 +102,3 @@ class TestPPUserAPI:
             f"/pp-api/users/{other_user.individual_organization_id}/", {"name": name}
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_list_invitations(self, api_client, user):
-        """List user invitations"""
-        api_client.force_authenticate(user=user)
-        InvitationRequestFactory(user=user)
-        response = api_client.get(
-            f"/pp-api/users/{user.individual_organization_id}/invitations/"
-        )
-        assert response.status_code == status.HTTP_200_OK
-        response_json = json.loads(response.content)
-        assert len(response_json["results"]) == 1
-        assert response_json["results"][0]["request"]
-
-    def test_list_invitations_expand_org(self, api_client, user):
-        """List user invitations and expand organization data"""
-        api_client.force_authenticate(user=user)
-        InvitationRequestFactory(user=user)
-        response = api_client.get(
-            f"/pp-api/users/{user.individual_organization_id}/invitations/?expand=organization"
-        )
-        assert response.status_code == status.HTTP_200_OK
-        response_json = json.loads(response.content)
-        assert len(response_json["results"]) == 1
-        assert response_json["results"][0]["request"]
-        assert "name" in response_json["results"][0]["organization"]

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -20,11 +20,9 @@ from rest_framework.response import Response
 # Squarelet
 from squarelet.core.mail import send_mail
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import Invitation, Membership, Plan
+from squarelet.organizations.models import  Membership, Plan
 from squarelet.users.models import User
 from squarelet.users.serializers import (
-    PressPassUserInvitationsSerializer,
-    PressPassUserMembershipsSerializer,
     PressPassUserSerializer,
     PressPassUserWriteSerializer,
     UserReadSerializer,
@@ -111,30 +109,6 @@ class PressPassUserViewSet(
             return self.request.user
         else:
             return super().get_object()
-
-
-class PressPassUserInvitationViewSet(
-    mixins.ListModelMixin, viewsets.GenericViewSet,
-):
-    queryset = Invitation.objects.none()
-    serializer_class = PressPassUserInvitationsSerializer
-    permission_classes = (DjangoObjectPermissions,)
-    lookup_field = "user__uuid"
-
-    def get_queryset(self):
-        user = get_object_or_404(User, uuid=self.kwargs["user_uuid"],)
-        return user.invitations.all()
-
-
-class PressPassUserMembershipViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
-    queryset = Membership.objects.none()
-    serializer_class = PressPassUserMembershipsSerializer
-    permission_classes = (DjangoObjectPermissions,)
-    lookup_field = "user__uuid"
-
-    def get_queryset(self):
-        user = get_object_or_404(User, uuid=self.kwargs["user_uuid"])
-        return user.memberships.all()
 
 
 class PressPassRegisterView(RegisterView):

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -20,9 +20,10 @@ from rest_framework.response import Response
 # Squarelet
 from squarelet.core.mail import send_mail
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import Membership, Plan
+from squarelet.organizations.models import Invitation, Membership, Plan
 from squarelet.users.models import User
 from squarelet.users.serializers import (
+    PressPassUserInvitationsSerializer,
     PressPassUserMembershipsSerializer,
     PressPassUserSerializer,
     PressPassUserWriteSerializer,
@@ -110,6 +111,19 @@ class PressPassUserViewSet(
             return self.request.user
         else:
             return super().get_object()
+
+
+class PressPassUserInvitationViewSet(
+    mixins.ListModelMixin, viewsets.GenericViewSet,
+):
+    queryset = Invitation.objects.none()
+    serializer_class = PressPassUserInvitationsSerializer
+    permission_classes = (DjangoObjectPermissions,)
+    lookup_field = "user__uuid"
+
+    def get_queryset(self):
+        user = get_object_or_404(User, uuid=self.kwargs["user_uuid"],)
+        return user.invitations.all()
 
 
 class PressPassUserMembershipViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 # Squarelet
 from squarelet.core.mail import send_mail
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import  Membership, Plan
+from squarelet.organizations.models import Membership, Plan
 from squarelet.users.models import User
 from squarelet.users.serializers import (
     PressPassUserSerializer,


### PR DESCRIPTION
This PR adds a new endpoint to the API, as discussed on slack. It returns invitations for a user, complementing the existing organization-oriented invitations endpoint.

I made this endpoint data expandable on organization. There are tests for it with and without the `expand` parameter, and I ran `format` and `pylint` before committing.

`GET /pp-api/users/{user_uuid}/invitations/`