### PR TITLE
Expandable user data on nested organization invitations

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -33,6 +33,7 @@ from squarelet.organizations.viewsets import (
 from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     PressPassRegisterView,
+    PressPassUserInvitationViewSet,
     PressPassUserViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,
@@ -72,6 +73,7 @@ organization_router.register("invitations", PressPassNestedInvitationViewSet)
 organization_router.register("subscriptions", PressPassSubscriptionViewSet)
 
 user_router = routers.NestedDefaultRouter(presspass_router, "users", lookup="user")
+user_router.register("invitations", PressPassUserInvitationViewSet)
 user_router.register("memberships", PressPassUserMembershipViewSet)
 
 urlpatterns = [

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -181,7 +181,7 @@ class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
         extra_kwargs = {"admin": {"default": False}}
 
 
-class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
+class PressPassNestedInvitationSerializer(FlexFieldsModelSerializer):
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
 
     class Meta:
@@ -202,6 +202,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
             "accepted_at": {"read_only": True},
             "rejected_at": {"read_only": True},
         }
+        expandable_fields = {"user": "squarelet.users.PressPassUserSerializer"}
 
     def validate_email(self, value):
         request = self.context.get("request")

--- a/squarelet/organizations/tests/factories.py
+++ b/squarelet/organizations/tests/factories.py
@@ -129,6 +129,17 @@ class InvitationFactory(factory.django.DjangoModelFactory):
         model = "organizations.Invitation"
 
 
+class InvitationRequestFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory("squarelet.users.tests.factories.UserFactory")
+    organization = factory.SubFactory(
+        "squarelet.organizations.tests.factories.OrganizationFactory"
+    )
+    request = True
+
+    class Meta:
+        model = "organizations.Invitation"
+
+
 class ChargeFactory(factory.django.DjangoModelFactory):
     organization = factory.SubFactory(
         "squarelet.organizations.tests.factories.OrganizationFactory"

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -180,6 +180,20 @@ class TestPPInvitationAPI:
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == size
 
+    def test_list_expand_users(self, api_client, user):
+        """List invitations for an organization expanding user data"""
+        organization = OrganizationFactory(admins=[user])
+        api_client.force_authenticate(user=user)
+        size = 10
+        InvitationFactory.create_batch(size, user=user, organization=organization)
+        response = api_client.get(
+            f"/pp-api/organizations/{organization.uuid}/invitations/?expand=user"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == size
+        assert "username" in response_json["results"][0]["user"]
+
     def test_create_admin_invite(self, api_client, user, mailoutbox):
         """Admin invites a user to join"""
         organization = OrganizationFactory(admins=[user])

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -5,10 +5,11 @@ import string
 
 # Third Party
 from dj_rest_auth.registration.serializers import RegisterSerializer
+from rest_flex_fields import FlexFieldsModelSerializer
 from rest_framework import serializers
 
 # Squarelet
-from squarelet.organizations.models import Membership
+from squarelet.organizations.models import Invitation, Membership
 from squarelet.organizations.serializers import (
     MembershipSerializer,
     PressPassOrganizationSerializer,
@@ -152,6 +153,24 @@ class PressPassUserSerializer(serializers.ModelSerializer):
             if self.instance and not self.instance.can_change_username:
                 # pylint: disable=invalid-sequence-index
                 self.fields["username"].read_only = True
+
+
+class PressPassUserInvitationsSerializer(FlexFieldsModelSerializer):
+    organization = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
+
+    class Meta:
+        model = Invitation
+        fields = (
+            "uuid",
+            "user",
+            "organization",
+            "request",
+            "accepted_at",
+            "rejected_at",
+            "created_at",
+        )
+        extra_kwargs = {"request": {"default": False}}
+        expandable_fields = {"organization": PressPassOrganizationSerializer}
 
 
 class PressPassUserMembershipsSerializer(serializers.ModelSerializer):

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 # Squarelet
+from squarelet.organizations.tests.factories import InvitationRequestFactory
 from squarelet.users.serializers import PressPassUserSerializer
 from squarelet.users.tests.factories import UserFactory
 
@@ -101,3 +102,15 @@ class TestPPUserAPI:
             f"/pp-api/users/{other_user.individual_organization_id}/", {"name": name}
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_invitations(self, api_client, user):
+        """List user invitations"""
+        api_client.force_authenticate(user=user)
+        InvitationRequestFactory(user=user)
+        response = api_client.get(
+            f"/pp-api/users/{user.individual_organization_id}/invitations/"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == 1
+        assert response_json["results"][0]["request"]

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -114,3 +114,16 @@ class TestPPUserAPI:
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == 1
         assert response_json["results"][0]["request"]
+
+    def test_list_invitations_expand_org(self, api_client, user):
+        """List user invitations and expand organization data"""
+        api_client.force_authenticate(user=user)
+        InvitationRequestFactory(user=user)
+        response = api_client.get(
+            f"/pp-api/users/{user.individual_organization_id}/invitations/?expand=organization"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == 1
+        assert response_json["results"][0]["request"]
+        assert "name" in response_json["results"][0]["organization"]

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -20,9 +20,10 @@ from rest_framework.response import Response
 # Squarelet
 from squarelet.core.mail import send_mail
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import Membership, Plan
+from squarelet.organizations.models import Invitation, Membership, Plan
 from squarelet.users.models import User
 from squarelet.users.serializers import (
+    PressPassUserInvitationsSerializer,
     PressPassUserMembershipsSerializer,
     PressPassUserSerializer,
     PressPassUserWriteSerializer,
@@ -110,6 +111,19 @@ class PressPassUserViewSet(
             return self.request.user
         else:
             return super().get_object()
+
+
+class PressPassUserInvitationViewSet(
+    mixins.ListModelMixin, viewsets.GenericViewSet,
+):
+    queryset = Invitation.objects.none()
+    serializer_class = PressPassUserInvitationsSerializer
+    permission_classes = (DjangoObjectPermissions,)
+    lookup_field = "user__uuid"
+
+    def get_queryset(self):
+        user = get_object_or_404(User, uuid=self.kwargs["user_uuid"],)
+        return user.invitations.all()
 
 
 class PressPassUserMembershipViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
This PR adds FlexFields to the PressPassNestedInvitationSerializer to allow expanding user data on demand. This change addresses a need we have in our frontend: to enable organization admins to manage requests to join, we need the username and/or email for these requests to make sense. To avoid making `n` API requests to retrieve each user's data, this seemed like a better solution.

I've added a test for the expanded nested invitation endpoint.