### PR TITLE
Expandable user data on presspass nested invitations

### DIFF
--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -181,7 +181,7 @@ class PressPassUserMembershipsSerializer(serializers.ModelSerializer):
         extra_kwargs = {"admin": {"default": False}}
 
 
-class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
+class PressPassNestedInvitationSerializer(FlexFieldsModelSerializer):
     user = serializers.SlugRelatedField(slug_field="uuid", read_only=True)
 
     class Meta:
@@ -202,6 +202,7 @@ class PressPassNestedInvitationSerializer(serializers.ModelSerializer):
             "accepted_at": {"read_only": True},
             "rejected_at": {"read_only": True},
         }
+        expandable_fields = {"user": "squarelet.users.PressPassUserSerializer"}
 
     def validate_email(self, value):
         request = self.context.get("request")

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -180,6 +180,20 @@ class TestPPInvitationAPI:
         response_json = json.loads(response.content)
         assert len(response_json["results"]) == size
 
+    def test_list_expand_users(self, api_client, user):
+        """List invitations for an organization expanding user data"""
+        organization = OrganizationFactory(admins=[user])
+        api_client.force_authenticate(user=user)
+        size = 10
+        InvitationFactory.create_batch(size, user=user, organization=organization)
+        response = api_client.get(
+            f"/pp-api/organizations/{organization.uuid}/invitations/?expand=user"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = json.loads(response.content)
+        assert len(response_json["results"]) == size
+        assert "username" in response_json["results"][0]["user"]
+
     def test_create_admin_invite(self, api_client, user, mailoutbox):
         """Admin invites a user to join"""
         organization = OrganizationFactory(admins=[user])


### PR DESCRIPTION
This PR adds FlexFields to the PressPassNestedInvitationSerializer to allow expanding user data on demand. This change addresses a need we have in our frontend: to enable organization admins to manage requests to join, we need the username and/or email for these requests to make sense. To avoid making `n` API requests to retrieve each user's data, this seemed like a better solution.

I've added a test for the expanded nested invitation endpoint.