### PR TITLE
Limit entitlements list (DRAFT)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -21,7 +21,7 @@ from squarelet.oidc.viewsets import ClientViewSet
 from squarelet.organizations.viewsets import (
     ChargeViewSet,
     OrganizationViewSet,
-    PressPassEntitlmentViewSet,
+    PressPassEntitlementViewSet,
     PressPassInvitationViewSet,
     PressPassMembershipViewSet,
     PressPassNestedInvitationViewSet,
@@ -62,7 +62,7 @@ presspass_router.register("users", PressPassUserViewSet)
 presspass_router.register("organizations", PressPassOrganizationViewSet)
 presspass_router.register("invitations", PressPassInvitationViewSet)
 presspass_router.register("plans", PressPassPlanViewSet)
-presspass_router.register("entitlements", PressPassEntitlmentViewSet)
+presspass_router.register("entitlements", PressPassEntitlementViewSet)
 
 organization_router = routers.NestedDefaultRouter(
     presspass_router, "organizations", lookup="organization"

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -97,7 +97,10 @@ class EntitlementQuerySet(models.QuerySet):
         if user.is_staff:
             return self
         elif user.is_authenticated:
-            return self.filter(Q(plans__organizations__in=user.organizations.all()) | Q(plans__private_organizations__in=user.organizations.all()) | Q(client__owner=user))
+            return self.filter(
+                Q(plans__organizations__in=user.organizations.all())
+                | Q(client__owner=user)
+            ).distinct()
         else:
             return self.filter(plans__public=True)
 

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -97,7 +97,7 @@ class EntitlementQuerySet(models.QuerySet):
         if user.is_staff:
             return self
         elif user.is_authenticated:
-            return self.filter(Q(plans__public=True) | Q(client__owner=user)).distinct()
+            return self.filter(Q(plans__organizations__in=user.organizations.all()) | Q(plans__private_organizations__in=user.organizations.all()) | Q(client__owner=user))
         else:
             return self.filter(plans__public=True)
 

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -317,19 +317,17 @@ class TestPPEntitlementAPI:
         my_plan = PlanFactory(for_individuals=False, for_groups=True, public=False)
         my_plan.private_organizations.add(org)
 
-        my_entitlements = EntitlementFactory.create_batch(5)
+        my_entitlements = EntitlementFactory.create_batch(size)
         my_plan.entitlements.set(my_entitlements)
 
-        entitlements = EntitlementFactory.create_batch(5)
+        entitlements = EntitlementFactory.create_batch(size)
         plan = PlanFactory(public=True)
         plan.entitlements.set(entitlements)
 
-        # mocker.patch("stripe.Plan.create")
-        # make entitlements public by adding it to a public plan
         response = api_client.get(f"/pp-api/entitlements/")
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
-        assert len(response_json["results"]) == 5
+        assert len(response_json["results"]) == size
 
     def test_list_expand_clients(self, api_client, mocker):
         """List entitlements"""

--- a/squarelet/organizations/tests/test_api.py
+++ b/squarelet/organizations/tests/test_api.py
@@ -309,18 +309,27 @@ class TestPPPlanAPI:
 
 @pytest.mark.django_db()
 class TestPPEntitlementAPI:
-    def test_list(self, api_client, mocker):
+    def test_list(self, api_client, user):
         """List entitlements"""
         size = 10
-        entitlements = EntitlementFactory.create_batch(size)
-        mocker.patch("stripe.Plan.create")
-        # make entitlements public by adding it to a public plan
+        org = OrganizationFactory(admins=[user])
+
+        my_plan = PlanFactory(for_individuals=False, for_groups=True, public=False)
+        my_plan.private_organizations.add(org)
+
+        my_entitlements = EntitlementFactory.create_batch(5)
+        my_plan.entitlements.set(my_entitlements)
+
+        entitlements = EntitlementFactory.create_batch(5)
         plan = PlanFactory(public=True)
         plan.entitlements.set(entitlements)
+
+        # mocker.patch("stripe.Plan.create")
+        # make entitlements public by adding it to a public plan
         response = api_client.get(f"/pp-api/entitlements/")
         assert response.status_code == status.HTTP_200_OK
         response_json = json.loads(response.content)
-        assert len(response_json["results"]) == size
+        assert len(response_json["results"]) == 5
 
     def test_list_expand_clients(self, api_client, mocker):
         """List entitlements"""

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -230,7 +230,7 @@ class PressPassPlanViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = Filter
 
 
-class PressPassEntitlmentViewSet(viewsets.ModelViewSet):
+class PressPassEntitlementViewSet(viewsets.ModelViewSet):
     queryset = Entitlement.objects.none()
     serializer_class = PressPassEntitlmentSerializer
     permission_classes = (DjangoObjectPermissionsOrAnonReadOnly,)


### PR DESCRIPTION
This aims to limit the entitlements returned by the API to those: 

* my (public or private) organization's plans have access to
* or, I'm the (client) owner of

@TylerFisher do you mind having a look at this before I mark this as a PR ready for review? I was reaching with both my django and squarelet-data-model knowledge here 🤞 