### PR TITLE
Make invitations data uniform in PP API endpoints

### DIFF
--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -243,7 +243,10 @@ class PressPassInvitationSerializer(FlexFieldsModelSerializer):
             "rejected_at": {"read_only": True},
             "email": {"read_only": True},
         }
-        expandable_fields = {"organization": PressPassOrganizationSerializer}
+        expandable_fields = {
+            "user": "squarelet.users.PressPassUserSerializer",
+            "organization": PressPassOrganizationSerializer,
+        }
 
     def validate(self, attrs):
         """Must not try to accept and reject"""

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -202,7 +202,10 @@ class PressPassNestedInvitationSerializer(FlexFieldsModelSerializer):
             "accepted_at": {"read_only": True},
             "rejected_at": {"read_only": True},
         }
-        expandable_fields = {"user": "squarelet.users.PressPassUserSerializer"}
+        expandable_fields = {
+            "user": "squarelet.users.PressPassUserSerializer",
+            "organization": PressPassOrganizationSerializer,
+        }
 
     def validate_email(self, value):
         request = self.context.get("request")
@@ -264,7 +267,10 @@ class PressPassUserInvitationsSerializer(FlexFieldsModelSerializer):
             "rejected_at",
             "created_at",
         )
-        expandable_fields = {"organization": PressPassOrganizationSerializer}
+        expandable_fields = {
+            "organization": PressPassOrganizationSerializer,
+            "user": "squarelet.users.PressPassUserSerializer",
+        }
 
 
 class PressPassPlanSerializer(serializers.ModelSerializer):

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -5,14 +5,11 @@ import string
 
 # Third Party
 from dj_rest_auth.registration.serializers import RegisterSerializer
-from rest_flex_fields import FlexFieldsModelSerializer
 from rest_framework import serializers
 
 # Squarelet
-from squarelet.organizations.models import Invitation, Membership
 from squarelet.organizations.serializers import (
     MembershipSerializer,
-    PressPassOrganizationSerializer,
 )
 from squarelet.users.models import User
 

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -8,9 +8,7 @@ from dj_rest_auth.registration.serializers import RegisterSerializer
 from rest_framework import serializers
 
 # Squarelet
-from squarelet.organizations.serializers import (
-    MembershipSerializer,
-)
+from squarelet.organizations.serializers import MembershipSerializer
 from squarelet.users.models import User
 
 

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -8,7 +8,6 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 # Squarelet
-from squarelet.organizations.tests.factories import InvitationRequestFactory
 from squarelet.users.serializers import PressPassUserSerializer
 from squarelet.users.tests.factories import UserFactory
 


### PR DESCRIPTION
This change aims to address an issue we've had in building PressPass features around invitations: in order for our store to have consistent invitation data regardless of which API endpoint supplies it, each invitation-endpoint needs both organization and user data expandable. 

So this PR ensures that all presspass api endpoints for invitations allow expansion of both user and organization data using flex fields. It also adds tests for these endpoints for expanding either or both of the fields.