### PR TITLE
Feature/update presspass confirmation email

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -366,7 +366,7 @@ SQUARELET_URL = env("SQUARELET_URL", default="http://dev.squarelet.com")
 MUCKROCK_URL = env("MUCKROCK_URL", default="http://dev.muckrock.com")
 FOIAMACHINE_URL = env("FOIAMACHINE_URL", default="http://dev.foiamachine.org")
 DOCCLOUD_URL = env("DOCCLOUD_URL", default="http://dev.documentcloud.org")
-PRESSPASS_URL = env("PRESSPASS_URL", default="http://dev.presspass.com")
+PRESSPASS_URL = env("PRESSPASS_URL", default="http://dev.presspass.com:3000")
 
 # stripe
 # ------------------------------------------------------------------------------

--- a/squarelet/templates/presspass/account/email/email_confirmation_signup_message.html
+++ b/squarelet/templates/presspass/account/email/email_confirmation_signup_message.html
@@ -8,7 +8,6 @@
 {% autologin url_email user as url_email_ %}
 {% url "account_set_password" as url_password %}
 {% autologin url_password user as url_password_ %}
-{% autologin activate_url user as activate_url_ %}
 {% blocktrans with username=user.username %}
 <p>
   Just a reminder, your username is
@@ -16,20 +15,14 @@
     {{ username }} </a
   >.
 </p>
+<p>{{ settings.PRESSPASS_URL }}</p>
 <p>
   We ask that you please
-  <a href="{{ activate_url_ }}">verify your email</a>. You can also verify your
-  email from your <a href="{{ url_email_ }}">account email settings</a>.
+  <a href="{{ activate_url }}">verify your email</a>. 
 </p>
 {% endblocktrans %}
 {% if minireg %}
 {% blocktrans %}
-<p>
-  You should also
-  <a href="{{ url_password_ }}">
-    set your password </a
-  >.
-</p>
 
 <p>
   {% endblocktrans %}
@@ -45,8 +38,7 @@
 </p>
 <p><a href="https://www.twitter.com/newscatalyst/">Tweet at us</a>.</p>
 <p>
-  Once again, welcome to the PressPass community. We're excited to see what you
-  do with the tools we've built.
+  Once again, welcome to the PressPass community. TKTK
 </p>
 <p>Sincerely,<br />The PressPass Team</p>
 {% endblocktrans %}

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -62,17 +62,18 @@ class AccountAdapter(DefaultAccountAdapter):
         activate_url = self.get_email_confirmation_url(request, emailconfirmation)
 
         source_site = request.get_host()
-        squarelet_source = "muckrock"
-        if source_site == furl(settings.PRESSPASS_URL).host:
-            squarelet_source = "presspass"
 
         ctx = {
             "user": emailconfirmation.email_address.user,
             "activate_url": activate_url,
             "current_site": current_site,
             "key": emailconfirmation.key,
-            "source": squarelet_source,
+            "source": "muckrock",
         }
+        if source_site == furl(settings.PRESSPASS_URL).host:
+            ctx["source"] = "presspass"
+            ctx["activate_url"] = f"{settings.PRESSPASS_URL}/verify-email"
+
         if signup:
             email_template = "account/email/email_confirmation_signup"
         else:

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -72,7 +72,7 @@ class AccountAdapter(DefaultAccountAdapter):
         }
         if source_site == furl(settings.PRESSPASS_URL).host:
             ctx["source"] = "presspass"
-            ctx["activate_url"] = f"{settings.PRESSPASS_URL}/verify-email"
+            ctx["activate_url"] = f"{settings.PRESSPASS_URL}/profile/welcome"
 
         if signup:
             email_template = "account/email/email_confirmation_signup"


### PR DESCRIPTION
This PR has minor changes to update the confirmation email sent to PressPass users:

* the PRESSPASS_URL is corrected to the current valid dev URL
* the activation URL is updated to point at a new PressPass landing page _when source is presspass_
* some language is updated in the PressPass version of the email template