### PR TITLE
Limit clients api to admin-only users

### DIFF
--- a/squarelet/oidc/rules.py
+++ b/squarelet/oidc/rules.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-unary-operand-type
 
 # Third Party
-from rules import add_perm, is_staff, predicate
+from rules import add_perm, is_authenticated, is_staff, predicate
 
 # Squarelet
 from squarelet.core.rules import skip_if_not_obj
@@ -13,7 +13,7 @@ def is_owner(user, client):
     return user == client.owner
 
 
-add_perm("oidc_provider.view_client", is_staff)
+add_perm("oidc_provider.view_client", is_authenticated & is_owner)
 add_perm("oidc_provider.add_client", is_staff)
 add_perm("oidc_provider.change_client", is_staff)
 add_perm("oidc_provider.delete_client", is_staff)

--- a/squarelet/oidc/rules.py
+++ b/squarelet/oidc/rules.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-unary-operand-type
 
 # Third Party
-from rules import add_perm, is_authenticated, predicate
+from rules import add_perm, is_staff, predicate
 
 # Squarelet
 from squarelet.core.rules import skip_if_not_obj
@@ -13,7 +13,7 @@ def is_owner(user, client):
     return user == client.owner
 
 
-add_perm("oidc_provider.view_client", is_authenticated & is_owner)
-add_perm("oidc_provider.add_client", is_authenticated)
-add_perm("oidc_provider.change_client", is_authenticated & is_owner)
-add_perm("oidc_provider.delete_client", is_authenticated & is_owner)
+add_perm("oidc_provider.view_client", is_staff)
+add_perm("oidc_provider.add_client", is_staff)
+add_perm("oidc_provider.change_client", is_staff)
+add_perm("oidc_provider.delete_client", is_staff)

--- a/squarelet/oidc/tests/factories.py
+++ b/squarelet/oidc/tests/factories.py
@@ -9,7 +9,7 @@ import factory
 
 class ClientFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Client {n}")
-    owner = factory.SubFactory("squarelet.users.tests.factories.UserFactory")
+    owner = factory.SubFactory("squarelet.users.tests.factories.UserFactory", is_staff=True)
     client_type = "confidential"
     client_id = factory.LazyFunction(lambda: str(randint(1, 999999)).zfill(6))
     client_secret = factory.LazyFunction(

--- a/squarelet/oidc/tests/test_api.py
+++ b/squarelet/oidc/tests/test_api.py
@@ -13,9 +13,10 @@ from squarelet.oidc.tests.factories import ClientFactory
 
 @pytest.mark.django_db()
 class TestClientAPI:
-    def test_list(self, api_client, user):
+    def test_list(self, api_client, user_factory):
         """List your clients"""
         size = 2
+        user = user_factory(is_staff=True)
         api_client.force_authenticate(user=user)
         ClientFactory.create_batch(size, owner=user)
         # Create some client by other users, these should not be listed
@@ -27,8 +28,17 @@ class TestClientAPI:
         for result in response_json["results"]:
             assert result["owner"] == str(user.individual_organization_id)
 
-    def test_create(self, api_client, user):
+    def test_list_nonadmin(self, api_client, user_factory):
+        """List your clients"""
+        size = 2
+        user = user_factory(is_staff=False)
+        api_client.force_authenticate(user=user)
+        response = api_client.get(f"/pp-api/clients/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_create(self, api_client, user_factory):
         """Create a client"""
+        user = user_factory(is_staff=True)
         api_client.force_authenticate(user=user)
         data = {
             "name": "Test",
@@ -78,8 +88,9 @@ class TestClientAPI:
         serializer = ClientSerializer(client)
         assert response_json == serializer.data
 
-    def test_retrieve_bad(self, api_client, client, user):
+    def test_retrieve_bad(self, api_client, client, user_factory):
         """Test retrieving a client you do not have access to"""
+        user = user_factory(is_staff=True)
         api_client.force_authenticate(user=user)
         response = api_client.get(f"/pp-api/clients/{client.pk}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -93,8 +104,9 @@ class TestClientAPI:
         client.refresh_from_db()
         assert client.name == name
 
-    def test_update_bad(self, api_client, client, user):
+    def test_update_bad(self, api_client, client, user_factory):
         """Test updating a client you do not have access to"""
+        user = user_factory(is_staff=True)
         api_client.force_authenticate(user=user)
         name = "New Name"
         response = api_client.patch(f"/pp-api/clients/{client.pk}/", {"name": name})
@@ -107,8 +119,9 @@ class TestClientAPI:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Client.objects.filter(pk=client.pk).exists()
 
-    def test_destroy_bad(self, api_client, client, user):
+    def test_destroy_bad(self, api_client, client, user_factory):
         """Test destroying a client you do not have access to"""
+        user = user_factory(is_staff=True)
         api_client.force_authenticate(user=user)
         response = api_client.delete(f"/pp-api/clients/{client.pk}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/squarelet/oidc/tests/test_api.py
+++ b/squarelet/oidc/tests/test_api.py
@@ -29,7 +29,7 @@ class TestClientAPI:
             assert result["owner"] == str(user.individual_organization_id)
 
     def test_list_nonadmin(self, api_client, user_factory):
-        """List your clients"""
+        """List your clients fails for non-admins"""
         size = 2
         user = user_factory(is_staff=False)
         api_client.force_authenticate(user=user)
@@ -61,6 +61,23 @@ class TestClientAPI:
         assert Client.objects.filter(pk=response_json["id"]).exists()
         client = Client.objects.get(pk=response_json["id"])
         assert client.response_types.first().value == "code"
+
+    def test_create_nonadmin(self, api_client, user_factory):
+        """Create a client fails for non-admins"""
+        user = user_factory(is_staff=False)
+        api_client.force_authenticate(user=user)
+        data = {
+            "name": "Test",
+            "client_type": "confidential",
+            "website_url": "https://www.example.com/",
+            "terms_url": "https://www.example.com/tos/",
+            "contact_email": "admin@example.com",
+            "reuse_consent": True,
+            "redirect_uris": "https://www.example.com/accounts/complete/squarelet",
+            "post_logout_redirect_uris": "https://www.example.com/",
+        }
+        response = api_client.post(f"/pp-api/clients/", data)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_create_anonymous(self, api_client):
         """Must be authenticated to create a client"""
@@ -95,6 +112,13 @@ class TestClientAPI:
         response = api_client.get(f"/pp-api/clients/{client.pk}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_retrieve_nonadmin(self, api_client, client, user_factory):
+        """Test retrieving a client when non-admin"""
+        user = user_factory(is_staff=False)
+        api_client.force_authenticate(user=user)
+        response = api_client.get(f"/pp-api/clients/{client.pk}/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_update(self, api_client, client):
         """Test updating a client"""
         api_client.force_authenticate(user=client.owner)
@@ -112,6 +136,13 @@ class TestClientAPI:
         response = api_client.patch(f"/pp-api/clients/{client.pk}/", {"name": name})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_update_nonadmin(self, api_client, client, user_factory):
+        """Test updating a client for non-admins"""
+        user = user_factory(is_staff=False)
+        api_client.force_authenticate(user=user)
+        response = api_client.patch(f"/pp-api/clients/{client.pk}/", {"name": "test"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_destroy(self, api_client, client):
         """Test destroying a client"""
         api_client.force_authenticate(user=client.owner)
@@ -125,3 +156,10 @@ class TestClientAPI:
         api_client.force_authenticate(user=user)
         response = api_client.delete(f"/pp-api/clients/{client.pk}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_destroy_nonadmin(self, api_client, client, user_factory):
+        """Test destroying a client for non-admins"""
+        user = user_factory(is_staff=False)
+        api_client.force_authenticate(user=user)
+        response = api_client.delete(f"/pp-api/clients/{client.pk}/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/squarelet/oidc/viewsets.py
+++ b/squarelet/oidc/viewsets.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 # Third Party
 from oidc_provider.models import Client, ResponseType
 from rest_framework import viewsets
-from rest_framework.permissions import DjangoObjectPermissions
+from rest_framework.permissions import DjangoObjectPermissions, IsAdminUser
 
 # Squarelet
 from squarelet.oidc.serializers import ClientSerializer
@@ -19,7 +19,7 @@ class ClientViewSet(viewsets.ModelViewSet):
 
     queryset = Client.objects.none()
     serializer_class = ClientSerializer
-    permission_classes = (DjangoObjectPermissions,)
+    permission_classes = (IsAdminUser,)
 
     def get_queryset(self):
         return Client.objects.filter(owner=self.request.user).order_by("name")

--- a/squarelet/oidc/viewsets.py
+++ b/squarelet/oidc/viewsets.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 # Third Party
 from oidc_provider.models import Client, ResponseType
 from rest_framework import viewsets
-from rest_framework.permissions import DjangoObjectPermissions, IsAdminUser
+from rest_framework.permissions import DjangoObjectPermissions
 
 # Squarelet
 from squarelet.oidc.serializers import ClientSerializer
@@ -19,7 +19,7 @@ class ClientViewSet(viewsets.ModelViewSet):
 
     queryset = Client.objects.none()
     serializer_class = ClientSerializer
-    permission_classes = (IsAdminUser,)
+    permission_classes = (DjangoObjectPermissions,)
 
     def get_queryset(self):
         return Client.objects.filter(owner=self.request.user).order_by("name")


### PR DESCRIPTION
This PR changes who can access the `/pp-api/clients` endpoints in the API, restricting access to admins only. I've updated the tests to reflect this in general, and I've also added an additional test for each endpoint.