### PR TITLE
Pluralized Stripe environment variable names

### DIFF
--- a/initialize_dotenvs.py
+++ b/initialize_dotenvs.py
@@ -49,9 +49,9 @@ CONFIG = [
                 "url": "https://stripe.com",
                 "description": "Stripe is used for payment processing",
                 "envvars": [
-                    ("STRIPE_SECRET_KEY", ""),
-                    ("STRIPE_PUB_KEY", ""),
-                    ("STRIPE_WEBHOOK_SECRET", ""),
+                    ("STRIPE_SECRET_KEYS", ""),
+                    ("STRIPE_PUB_KEYS", ""),
+                    ("STRIPE_WEBHOOK_SECRETS", ""),
                 ],
             },
         ],


### PR DESCRIPTION
I'm not sure if this is on my end or a legitimate issue, but while setting up Squarelet I encountered an error that complained that I had not set certain environment variables: `STRIPE_SECRET_KEYS`, `STRIPE_PUB_KEYS`, and `STRIPE_WEBHOOK_SECRETS`. 

I had indeed set the values of `STRIPE_SECRET_KEY`, `STRIPE_PUB_KEY`, and `STRIPE_WEBHOOK_SECRET` in my local environment variables file which was generated when I ran `initialize_dotenvs.py`. I discovered that the Stripe environment variable names generated by this script were singular, but the Squarelet repository expects them to be plural. 

I'm creating this pull request in case changing the `initialize_dotenvs.py` file to reflect the expectation of plural Stripe environment variables would speed up development for others, though acknowledge the problem may lie within my setup. 