### PR TITLE
Readme install

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,85 @@
+{
+    "version": "2.0.0",
+    "presentation": {
+      "echo": false,
+      "reveal": "always",
+      "focus": false,
+      "panel": "dedicated",
+      "showReuseMessage": true
+    },
+    "tasks": [
+      {
+        "label": "Create MuckRock terminals",
+        "dependsOn": [
+          "Squarelet",
+          "DocCloud",
+          "Frontend"
+        ],
+        // Mark as the default build task so cmd/ctrl+shift+b will create them
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        // Try start the task on folder open
+        "runOptions": {
+          "runOn": "folderOpen"
+        }
+      },
+      {
+        // The name that shows up in terminal tab
+        "label": "Squarelet",
+        // The task will launch a shell
+        "type": "shell",
+        "command": "export COMPOSE_FILE=local.yml && docker-compose up",
+        // Set the shell type
+        "options": {
+          "shell": {
+            // "executable": "sh",
+            "args": []
+          }
+        },
+        // Mark as a background task to avoid the spinner animation on the terminal tab
+        "isBackground": false,
+        "problemMatcher": [],
+        // Create the tasks in a terminal group
+        "presentation": {
+          "group": "my-group"
+        }
+      },
+      {
+        // "dependsOn": [
+        //   "First"
+        // ],
+        "label": "DocCloud",
+        "type": "shell",
+        "command": "cd ../documentcloud && export COMPOSE_FILE=local.yml && echo 'wait 20sec for network' && sleep 20 &&  docker-compose up",
+        "options": {
+          "shell": {
+            // "executable": "bash",
+            "args": []
+          }
+        },
+        "isBackground": false,
+        "problemMatcher": [],
+        "presentation": {
+          "group": "my-group"
+        }
+      },
+      {
+        "label": "Frontend",
+        "type": "shell",
+        "command": "cd ../documentcloud-frontend  && echo 'wait 20sec for network' && sleep 20  && make dev",
+        "options": {
+          "shell": {
+            // "executable": "bash",
+            "args": []
+          }
+        },
+        "isBackground": false,
+        "problemMatcher": [],
+        "presentation": {
+          "group": "my-group"
+        }
+      }
+    ]
+  }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -52,7 +52,7 @@
         // ],
         "label": "DocCloud",
         "type": "shell",
-        "command": "cd ../documentcloud && export COMPOSE_FILE=local.yml && echo 'wait 20sec for network' && sleep 20 &&  docker-compose up",
+        "command": "cd ../documentcloud && export COMPOSE_FILE=local.yml && echo 'wait 10sec for network' && sleep 20 &&  docker-compose up",
         "options": {
           "shell": {
             // "executable": "bash",
@@ -68,7 +68,7 @@
       {
         "label": "Frontend",
         "type": "shell",
-        "command": "cd ../documentcloud-frontend  && echo 'wait 20sec for network' && sleep 20  && make dev",
+        "command": "cd ../documentcloud-frontend  && echo 'wait 20sec for network' && sleep 10  && make dev",
         "options": {
           "shell": {
             // "executable": "bash",

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ User account service for MuckRock and DocumentCloud
 2. Enter the directory - `cd squarelet`
 3. Run the dotenv initialization script - `python initialize_dotenvs.py`
 This will create files with the environment variables needed to run the development environment.
-4. You may need to provide valid testing values for `STRIPE_PUB_KEYS`, `STRIPE_SECRET_KEYS` and set `STRIPE_WEBHOOK_SECRETS=None` from the MuckRock team (multiple values are comma separated only, no square braces) 
+4. You need to provide valid testing values for `STRIPE_PUB_KEYS`, `STRIPE_SECRET_KEYS` and set `STRIPE_WEBHOOK_SECRETS=None` from the MuckRock team (multiple values are comma separated only, no square braces) 
       - You must always fully `docker-compose down` or Ctrl-C each time you change a `.django` file of a docker-compose session for it to take effect (as far as I know).
-      - Avoid changing Squarelet's `.django` file frequently to prevent Docker network problems from `docker-compose down`.
 5. Set the environment variable `export COMPOSE_FILE=local.yml` in each of your command lines.
 5. Start the docker images - `inv up`
 This will build and start all of the Squarelet session docker images using docker-compose.  It will bind to port 80 on localhost, so you must not have anything else running on port 80. The "invoke" tasks from `tasks.py` specify the `local.yml` configuration file for docker-compose.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ User account service for MuckRock and DocumentCloud
 3. Run the dotenv initialization script - `python initialize_dotenvs.py`
 This will create files with the environment variables needed to run the development environment.
 4. You may need to provide valid testing values for `STRIPE_PUB_KEYS`, `STRIPE_SECRET_KEYS` and set `STRIPE_WEBHOOK_SECRETS=None` from the MuckRock team (multiple values are comma separated only, no square braces) 
+      - You must always fully `docker-compose down` or Ctrl-C each time you change a `.django` file of a docker-compose session for it to take effect (as far as I know).
+      - Avoid changing Squarelet's `.django` file frequently to prevent Docker network problems from `docker-compose down`.
+5. Set the environment variable `export COMPOSE_FILE=local.yml` in each of your command lines.
 5. Start the docker images - `inv up`
-This will build and start all of the docker images using docker-compose.  It will bind to port 80 on localhost, so you must not have anything else running on port 80. The invoke tasks specify the `local.yml` configuration file for docker-compose.  If you would like to run docker-compose commands directly, set the environment variable `export COMPOSE_FILE=local.yml`.
+This will build and start all of the Squarelet session docker images using docker-compose.  It will bind to port 80 on localhost, so you must not have anything else running on port 80. The "invoke" tasks from `tasks.py` specify the `local.yml` configuration file for docker-compose.
 6. Set `dev.squarelet.local` and `dev.squarelet.com` to point to localhost - `sudo echo "127.0.0.1   dev.squarelet.com dev.squarelet.local" >> /etc/hosts`
 7. Enter `dev.squarelet.local` into your browser - you should see the Muckrock Squarelet home page.
 8. Follow the instructions for integration in a platform app such as ["Squarelet Integration" on MuckRock](https://github.com/muckrock/muckrock/#squarelet-integration) documentation or in [the DocumentCloud](https://github.com/muckRock/documentcloud) documentation.
-
 ## Docker info
 
 The development environment is managed via [docker][docker] and [docker compose][docker-compose].  Please read up on them if you are unfmiliar with them.  The docker compose file is `local.yml`.  If you would like to run `docker-compose` commands directly, please run `export COMPOSE_FILE=local.yml` so you don't need to specify it in every command.
@@ -52,9 +54,6 @@ This is the [Django][django] application
 The celery beat image is responsible for queueing up periodic celery tasks.
 
 All systems can be brought up using `inv up`.  You can rebuild all images using `inv build`.  There are various other invoke commands for common tasks interacting with docker, which you can view in the `tasks.py` file.
-
-In your first few runs after environment creation, if you see `no configuration file provided: not found` then check the Docker volumes for squarelet to make sure they match the generated instances. Consider erasing them if needed to match early on, before they have important data.
-
 ### Networking Setup
 
 Nginx is run in front of Django in this development environment in order to allow development of squarelet and client applications at the same time.  This works by aliasing all needed domains to localhost, and allowing Nginx to properly route them.  Other projects have their own docker compose files which will have their containers join the squarelet network, so the containers can communicate with each other properly.  For me detail, see the Nginx config file at `compose/local/nginx/nginx.conf`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This will create files with the environment variables needed to run the developm
 This will build and start all of the docker images using docker-compose.  It will bind to port 80 on localhost, so you must not have anything else running on port 80. The invoke tasks specify the `local.yml` configuration file for docker-compose.  If you would like to run docker-compose commands directly, set the environment variable `export COMPOSE_FILE=local.yml`.
 5. Set `dev.squarelet.com` to point to localhost - `sudo echo "127.0.0.1   dev.squarelet.com" >> /etc/hosts`
 6. Enter `dev.squarelet.com` into your browser - you should see the Squarelet home page.
+7. Follow the instructions for integration in a platform app such as ["Squarelet Integration" on MuckRock](https://github.com/muckrock/muckrock/#squarelet-integration) documentation or in [the DocumentCloud](https://github.com/muckRock/documentcloud) documentation.
 
 ## Docker info
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ User account service for MuckRock and DocumentCloud
 2. Enter the directory - `cd squarelet`
 3. Run the dotenv initialization script - `python initialize_dotenvs.py`
 This will create files with the environment variables needed to run the development environment.
-4. Start the docker images - `inv up`
+4. You may need to provide valid testing values for `STRIPE_PUB_KEYS`, `STRIPE_SECRET_KEYS` and set `STRIPE_WEBHOOK_SECRETS=None` from the MuckRock team (multiple values are comma separated only, no square braces) 
+5. Start the docker images - `inv up`
 This will build and start all of the docker images using docker-compose.  It will bind to port 80 on localhost, so you must not have anything else running on port 80. The invoke tasks specify the `local.yml` configuration file for docker-compose.  If you would like to run docker-compose commands directly, set the environment variable `export COMPOSE_FILE=local.yml`.
-5. Set `dev.squarelet.com` to point to localhost - `sudo echo "127.0.0.1   dev.squarelet.com" >> /etc/hosts`
-6. Enter `dev.squarelet.com` into your browser - you should see the Squarelet home page.
-7. Follow the instructions for integration in a platform app such as ["Squarelet Integration" on MuckRock](https://github.com/muckrock/muckrock/#squarelet-integration) documentation or in [the DocumentCloud](https://github.com/muckRock/documentcloud) documentation.
+6. Set `dev.squarelet.local` and `dev.squarelet.com` to point to localhost - `sudo echo "127.0.0.1   dev.squarelet.com dev.squarelet.local" >> /etc/hosts`
+7. Enter `dev.squarelet.local` into your browser - you should see the Muckrock Squarelet home page.
+8. Follow the instructions for integration in a platform app such as ["Squarelet Integration" on MuckRock](https://github.com/muckrock/muckrock/#squarelet-integration) documentation or in [the DocumentCloud](https://github.com/muckRock/documentcloud) documentation.
 
 ## Docker info
 
@@ -52,6 +53,7 @@ The celery beat image is responsible for queueing up periodic celery tasks.
 
 All systems can be brought up using `inv up`.  You can rebuild all images using `inv build`.  There are various other invoke commands for common tasks interacting with docker, which you can view in the `tasks.py` file.
 
+In your first few runs after environment creation, if you see `no configuration file provided: not found` then check the Docker volumes for squarelet to make sure they match the generated instances. Consider erasing them if needed to match early on, before they have important data.
 
 ### Networking Setup
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -367,7 +367,7 @@ REST_FRAMEWORK = {
 
 # first party urls
 # ------------------------------------------------------------------------------
-SQUARELET_URL = env("SQUARELET_URL", default="http://dev.squarelet.com")
+SQUARELET_URL = env("SQUARELET_URL", default="http://dev.squarelet.local")
 MUCKROCK_URL = env("MUCKROCK_URL", default="http://dev.muckrock.com")
 FOIAMACHINE_URL = env("FOIAMACHINE_URL", default="http://dev.foiamachine.org")
 DOCCLOUD_URL = env("DOCCLOUD_URL", default="http://www.dev.documentcloud.org")

--- a/local.yml
+++ b/local.yml
@@ -43,6 +43,7 @@ services:
         aliases:
           - dev.squarelet.com
           - dev.presspass.com
+          - dev.squarelet.local
 
   squarelet_postgres:
     build:


### PR DESCRIPTION
This PR clarifies a few things in the readme and also adds a [tasks.json](https://code.visualstudio.com/Docs/editor/tasks), which I'm still testing, that enables you to run all the docker-compose sessions for DocumentCloud at once using `Cmd-Shift-B` or `Ctrl-Shift-B` (win/linux) in VS Code and probably Github Codingspaces. 