### PR TITLE
Stripe env variables should be pluralized

### DIFF
--- a/initialize_dotenvs.py
+++ b/initialize_dotenvs.py
@@ -49,9 +49,9 @@ CONFIG = [
                 "url": "https://stripe.com",
                 "description": "Stripe is used for payment processing",
                 "envvars": [
-                    ("STRIPE_SECRET_KEY", ""),
-                    ("STRIPE_PUB_KEY", ""),
-                    ("STRIPE_WEBHOOK_SECRET", ""),
+                    ("STRIPE_SECRET_KEYS", ""),
+                    ("STRIPE_PUB_KEYS", ""),
+                    ("STRIPE_WEBHOOK_SECRETS", ""),
                 ],
             },
         ],


### PR DESCRIPTION
My understanding of the docs and app are that these variables should be pluralized going forward. Correct me if I've got this wrong. 