### PR TITLE
Move websockets instructions in nginx config

### DIFF
--- a/compose/local/nginx/nginx.conf
+++ b/compose/local/nginx/nginx.conf
@@ -14,11 +14,6 @@ http {
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $server_name;
 
-    # To enable frontend dev-mode websockets to work
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
     server {
         listen 80;
         server_name localhost;
@@ -44,7 +39,12 @@ http {
             proxy_set_header X-Forwarded-Proto https;
 			proxy_set_header Host $http_host;
             proxy_pass http://internal.$1;
-        }
+
+            # To enable frontend dev-mode websockets to work
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+       }
     }
 
 }


### PR DESCRIPTION
This change was necessary to get the websockets used by Big Local News' React frontend to work via Squarelet's NGINX instance. 