### PR TITLE
Update tasks.py to use docker<space>compose

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -2,7 +2,7 @@
 from invoke import task
 from pathlib import Path
 
-DOCKER_COMPOSE_RUN_OPT = "docker-compose -f local.yml run {opt} --rm {service} {cmd}"
+DOCKER_COMPOSE_RUN_OPT = "docker compose -f local.yml run {opt} --rm {service} {cmd}"
 DOCKER_COMPOSE_RUN_OPT_USER = DOCKER_COMPOSE_RUN_OPT.format(
     opt="-u $(id -u):$(id -g) {opt}", service="{service}", cmd="{cmd}"
 )
@@ -115,7 +115,7 @@ def format(c):
 @task
 def up(c):
     """Start the docker images"""
-    c.run("docker-compose up -d")
+    c.run("docker compose up -d")
 
 
 @task
@@ -230,7 +230,7 @@ def pip_compile(c, upgrade=False, package=None):
 @task
 def build(c):
     """Build the docker images"""
-    c.run("docker-compose -f local.yml build")
+    c.run("docker compose -f local.yml build")
 
 
 # Database populating


### PR DESCRIPTION
Update tasks.py to use docker<space>compose because docker<dash>compose is deprecated. `docker-compose` is thus difficult (impossible?) to update now, and if you have a `docker-compose` too old to run the local.yaml, you're in a tough spot.