### PR TITLE
Displays alert messages on landing and resource pages

### DIFF
--- a/squarelet/core/models.py
+++ b/squarelet/core/models.py
@@ -21,6 +21,19 @@ class Interval(Func):
         super().__init__(Value(expression), **extra)
 
 
+class Alert(Model):
+    uid = F.AutoNumberField("ID")
+    message = F.RichTextField("Message")
+    expiration_date = F.DatetimeField("Expiration Date")
+    segment = F.SelectField("Segment")
+    status = F.SelectField("Status")
+
+    class Meta:
+        api_key = settings.AIRTABLE_ACCESS_TOKEN
+        base_id = settings.AIRTABLE_ERH_BASE_ID
+        table_name = "Alerts"
+
+
 class Provider(Model):
     name = F.TextField("Name")
     logo = F.AttachmentsField("Logo")

--- a/squarelet/core/views.py
+++ b/squarelet/core/views.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from pyairtable import Api as AirtableApi
 
 # Squarelet
-from squarelet.core.models import Provider, Resource, Alert
+from squarelet.core.models import Alert, Provider, Resource
 
 
 class HomeView(RedirectView):

--- a/squarelet/core/views.py
+++ b/squarelet/core/views.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from pyairtable import Api as AirtableApi
 
 # Squarelet
-from squarelet.core.models import Provider, Resource
+from squarelet.core.models import Provider, Resource, Alert
 
 
 class HomeView(RedirectView):
@@ -52,6 +52,20 @@ class ERHLandingView(TemplateView):
             params += [f'FIND("{provider}", {{Provider ID}})']
         formula = f"AND({', '.join(params)})"
         return formula
+
+    def get_alerts(self, user):
+        """Fetch relevant alert messages"""
+        view = "Logged Out"
+        if user.is_authenticated:
+            view = "Logged In"
+            if user.is_hub_eligible():
+                view = "Hub Eligible"
+        alerts = cache.get(f"erh_alerts/{view}")
+        if not alerts:
+            print("Cache miss. Fetching alerts…")
+            alerts = Alert.all(view=view)
+            cache.set(f"erh_alerts/{view}", alerts, settings.AIRTABLE_CACHE_TTL)
+        return alerts
 
     def get_all_resources(self):
         resources = cache.get("erh_resources")
@@ -138,6 +152,7 @@ class ERHLandingView(TemplateView):
                 resources = self.get_all_resources()
             context["resources"] = resources
             context["categories"] = self.resources_by_category(resources)
+            context["alerts"] = self.get_alerts(self.request.user)
         return context
 
 

--- a/squarelet/templates/core/component/alerts.html
+++ b/squarelet/templates/core/component/alerts.html
@@ -1,0 +1,44 @@
+{% load markdown %}
+
+{% if alerts|length > 1 %}
+<aside class="alerts">
+  <ul>
+  {% for alert in alerts %}
+    <li>{{alert.message|markdown}}</li>
+  {% endfor %}
+  </ul>
+</aside>
+{% elif alerts|length == 1 %}
+<aside class="alerts">
+  {% for alert in alerts %}
+    {{alert.message|markdown}}
+  {% endfor %}
+</aside>
+{% endif %}
+
+<style>
+  .alerts {
+    width: 100%;
+    max-width: var(--max-width, 1000px);
+    margin: 0 auto;
+    border: 1px solid var(--purple-2, #DFD5FA);
+    background: var(--purple-1, #F4F1FE);
+    color: var(--purple-5, #1E2B60);
+    padding: 1rem 3rem;
+    border-radius: 1rem;
+    box-sizing: border-box;
+  }
+  .alerts ul {
+    margin: 0;
+    padding: 0;
+  }
+  .alerts li {
+    margin: .5rem 0;
+  }
+  .alerts li:last-child {
+    margin-bottom: 0;
+  }
+  .alerts p {
+    margin: 0;
+  }
+</style>

--- a/squarelet/templates/core/erh_landing.html
+++ b/squarelet/templates/core/erh_landing.html
@@ -40,6 +40,9 @@
       </a>
     </div>
   </header>
+  <aside>
+    {{alerts}}
+  </aside>
   {% if not can_access_hub %}
   <div class="_cls-body _cls-erh--description">
     <p>The Knight Election Hub is a collection of curated products and services that will help you cover the election better than you thought possible. And in cases where a resource costs money, Knight Foundation is picking up the check.</p>

--- a/squarelet/templates/core/erh_landing.html
+++ b/squarelet/templates/core/erh_landing.html
@@ -40,9 +40,9 @@
       </a>
     </div>
   </header>
-  <aside>
-    {{alerts}}
-  </aside>
+  <header class="_cls-erh--header">
+    {% include "core/component/alerts.html" %}
+  </header>
   {% if not can_access_hub %}
   <div class="_cls-body _cls-erh--description">
     <p>The Knight Election Hub is a collection of curated products and services that will help you cover the election better than you thought possible. And in cases where a resource costs money, Knight Foundation is picking up the check.</p>

--- a/squarelet/templates/core/erh_resource.html
+++ b/squarelet/templates/core/erh_resource.html
@@ -36,6 +36,9 @@
       </a>
     </div>
   </header>
+  <header class="_cls-erh--header">
+    {% include "core/component/alerts.html" %}
+  </header>
   {% url 'organizations:detail' group_orgs.first.slug as organization_account_url %}
   <main class="_cls-erh--resourceBody">
     <header class="_cls-erh--resourceHeader">


### PR DESCRIPTION
This adds a new table, Alerts, with configurable messages. By checking each view in the table, we can get a list of messages to display for each user segment ("Logged In", "Hub Eligible", "Logged Out").

Alerts are rendered in the header of both the landing page and resource page templates. When there is only one alert, it's rendered as a paragraph of text. When there are multiple, they are rendered as a list of paragraphs.


<img width="1270" alt="Screenshot 2024-08-28 at 7 32 08 PM" src="https://github.com/user-attachments/assets/63ee6819-826c-44d3-815d-74d82c072295">
