### PR TITLE
Whitelist the <br /> tag

### DIFF
--- a/squarelet/core/templatetags/markdown.py
+++ b/squarelet/core/templatetags/markdown.py
@@ -39,6 +39,7 @@ def markdown_filter(text, _safe=None):
         "img",
         "iframe",
         "a",
+        "br",
     ]
     allowed_attributes = bleach.ALLOWED_ATTRIBUTES.copy()
     allowed_attributes.update(


### PR DESCRIPTION
This allows linebreaks to be rendered when parsing Markdown content.