### PR TITLE
Adds `pip-audit` package and task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ wheels/
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Pip Audit
+.pip-audit-cache
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -8,6 +8,7 @@ django-test-plus
 factory-boy
 flake8
 pip-tools
+pip-audit
 pylint
 pylint_celery
 pylint_django

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -76,6 +76,8 @@ bz2file==0.98
     # via
     #   -r requirements/base.txt
     #   smart-open
+cachecontrol[filecache]==0.14.2
+    # via pip-audit
 celery==5.4.0
     # via -r requirements/base.txt
 certifi==2018.4.16
@@ -134,6 +136,8 @@ cssutils==1.0.2
     # via
     #   -r requirements/base.txt
     #   premailer
+cyclonedx-python-lib==2.7.1
+    # via pip-audit
 decorator==4.3.2
     # via
     #   -r requirements/base.txt
@@ -247,6 +251,8 @@ factory-boy==3.2.1
     #   pytest-factoryboy
 faker==11.3.0
     # via factory-boy
+filelock==3.16.1
+    # via cachecontrol
 flake8==3.5.0
     # via -r requirements/local.in
 fonttools[woff]==4.38.0
@@ -268,6 +274,7 @@ html2text==2018.1.9
 html5lib==1.1
     # via
     #   -r requirements/base.txt
+    #   pip-audit
     #   weasyprint
 idna==2.7
     # via
@@ -317,6 +324,8 @@ lxml==4.9.1
     #   premailer
 markdown==3.6
     # via -r requirements/base.txt
+markdown-it-py==2.2.0
+    # via rich
 markupsafe==1.1.1
     # via jinja2
 matplotlib-inline==0.1.3
@@ -327,8 +336,12 @@ mccabe==0.6.1
     # via
     #   flake8
     #   pylint
+mdurl==0.1.2
+    # via markdown-it-py
 memoize==1.0.0
     # via -r requirements/base.txt
+msgpack==1.1.0
+    # via cachecontrol
 mypy-extensions==0.4.3
     # via black
 oauthlib==3.2.2
@@ -339,11 +352,15 @@ orderedmultidict==1.0.1
     # via
     #   -r requirements/base.txt
     #   furl
+packageurl-python==0.16.0
+    # via cyclonedx-python-lib
 packaging==24.1
     # via
     #   -r requirements/base.txt
     #   black
     #   build
+    #   pip-audit
+    #   pip-requirements-parser
     #   pytest
     #   redis
     #   sphinx
@@ -365,6 +382,12 @@ pillow==9.2.0
     # via
     #   -r requirements/base.txt
     #   weasyprint
+pip-api==0.0.34
+    # via pip-audit
+pip-audit==2.5.5
+    # via -r requirements/local.in
+pip-requirements-parser==32.0.1
+    # via pip-audit
 pip-tools==7.4.1
     # via -r requirements/local.in
 platformdirs==2.4.0
@@ -428,6 +451,7 @@ pygments==2.12.0
     # via
     #   -r requirements/base.txt
     #   ipython
+    #   rich
     #   sphinx
 pyjwkest==1.4.0
     # via
@@ -453,6 +477,8 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
+pyparsing==3.2.1
+    # via pip-requirements-parser
 pyphen==0.13.2
     # via
     #   -r requirements/base.txt
@@ -510,7 +536,9 @@ redis==4.1.0
 requests==2.28.1
     # via
     #   -r requirements/base.txt
+    #   cachecontrol
     #   django-allauth
+    #   pip-audit
     #   premailer
     #   pyairtable
     #   pyjwkest
@@ -522,6 +550,8 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   django-allauth
+rich==13.2.0
+    # via pip-audit
 rjsmin==1.2.1
     # via
     #   -r requirements/base.txt
@@ -555,6 +585,8 @@ snowballstemmer==1.2.1
     # via sphinx
 sorl-thumbnail==12.9.0
     # via -r requirements/base.txt
+sortedcontainers==2.4.0
+    # via cyclonedx-python-lib
 sphinx==1.7.5
     # via -r requirements/local.in
 sphinxcontrib-websupport==1.1.0
@@ -583,7 +615,9 @@ tinycss2==1.2.1
 toml==0.10.2
     # via
     #   -r requirements/base.txt
+    #   cyclonedx-python-lib
     #   ipdb
+    #   pip-audit
     #   pytest
 tomli==2.0.1
     # via

--- a/tasks.py
+++ b/tasks.py
@@ -228,6 +228,19 @@ def pip_compile(c, upgrade=False, package=None):
         )
     )
 
+@task(name="pip-audit")
+def pip_audit(c):
+    """Run pip-audit"""
+    c.run(
+        DJANGO_RUN_USER.format(
+            cmd='sh -c "'
+            f"pip-audit -r requirements/base.txt && "
+            f"pip-audit -r requirements/local.txt && "
+            f"pip-audit -r requirements/production.txt"
+            '"'
+        )
+    )
+
 
 @task
 def build(c):


### PR DESCRIPTION
This adds `pip-audit` as a local dependency so we can better prioritize package upgrades to address known vulnerabilities.

Here is the output from the initial run:
```sh
Name                          Version   ID                  Fix Versions
----------------------------- --------- ------------------- -------------------
certifi                       2018.4.16 PYSEC-2022-42986    2022.12.7
certifi                       2018.4.16 PYSEC-2023-135      2023.7.22
cryptography                  3.4.8     PYSEC-2023-254      41.0.6
cryptography                  3.4.8     GHSA-w7pp-m8wf-vj6r 39.0.1
cryptography                  3.4.8     GHSA-x4qr-2fvf-3mr5 39.0.1
cryptography                  3.4.8     GHSA-5cpq-8wj7-hf2v 41.0.0
cryptography                  3.4.8     GHSA-jm77-qphf-c4w8 41.0.3
cryptography                  3.4.8     GHSA-3ww4-gg4f-jr7f 42.0.0
cryptography                  3.4.8     GHSA-v8gr-m533-ghj9 41.0.4
cryptography                  3.4.8     GHSA-9v9h-cgj8-h64p 42.0.2
django                        4.2       PYSEC-2023-61       3.2.19,4.1.9,4.2.1
django                        4.2       PYSEC-2023-100      3.2.20,4.1.10,4.2.3
django                        4.2       PYSEC-2023-222      3.2.23,4.1.13,4.2.7
django                        4.2       PYSEC-2023-225      3.2.21,4.1.11,4.2.5
django                        4.2       PYSEC-2023-226      3.2.22,4.1.12,4.2.6
django                        4.2       PYSEC-2024-28       3.2.24,4.2.10,5.0.2
django                        4.2       PYSEC-2024-47       3.2.25,4.2.11,5.0.3
django                        4.2       PYSEC-2024-58       4.2.14,5.0.7
django                        4.2       PYSEC-2024-57       4.2.14,5.0.7
django                        4.2       PYSEC-2024-56       4.2.14,5.0.7
django                        4.2       PYSEC-2024-59       4.2.14,5.0.7
django                        4.2       PYSEC-2024-69       4.2.15,5.0.8
django                        4.2       PYSEC-2024-70       4.2.15,5.0.8
django                        4.2       PYSEC-2024-68       4.2.15,5.0.8
django                        4.2       PYSEC-2024-67       4.2.15,5.0.8
django                        4.2       PYSEC-2024-102      4.2.16,5.0.9,5.1.1
django                        4.2       PYSEC-2024-157      4.2.17,5.0.10,5.1.4
django                        4.2       PYSEC-2024-156      4.2.17,5.0.10,5.1.4
django                        4.2       PYSEC-2025-1        4.2.18,5.0.11,5.1.5
django                        4.2       GHSA-rrqc-c2jx-6jgv 4.2.16,5.0.9,5.1.1
djangorestframework           3.14.0    GHSA-gw84-84pc-xp82 3.15.2
djangorestframework-simplejwt 4.8.0     GHSA-5vcc-86wm-547q
fonttools                     4.38.0    GHSA-6673-4983-2vx5 4.43.0
future                        0.16.0    PYSEC-2022-42991    0.18.3
idna                          2.7       PYSEC-2024-60       3.7
ipython                       8.4.0     GHSA-29gw-9793-fvw7 8.10.0
pillow                        9.2.0     PYSEC-2022-42980    9.3.0
pillow                        9.2.0     PYSEC-2023-175      10.0.1
pillow                        9.2.0     PYSEC-2023-227      10.0.0
pillow                        9.2.0   Found 53 known vulnerabilities in 15 packages
  OSV-2022-715
pillow                        9.2.0     OSV-2022-1074
pillow                        9.2.0     GHSA-3f63-hfp8-52jq 10.2.0
pillow                        9.2.0     GHSA-j7hp-h8jx-5ppr 10.0.1
pillow                        9.2.0     GHSA-56pw-mpj4-fxww 10.0.1
pillow                        9.2.0     GHSA-44wm-f244-xhp3 10.3.0
pycryptodomex                 3.15.0    PYSEC-2024-3        3.19.1
pygments                      2.12.0    PYSEC-2023-117      2.15.1
requests                      2.28.1    PYSEC-2023-74       2.31.0
requests                      2.28.1    GHSA-9wx4-h78v-vm56 2.32.0
sqlparse                      0.4.4     GHSA-2m57-hf25-phgg 0.5.0
urllib3                       1.26.10   PYSEC-2023-192      1.26.17,2.0.6
urllib3                       1.26.10   PYSEC-2023-212      1.26.18,2.0.7
urllib3                       1.26.10   GHSA-34jh-p97f-mpxf 1.26.19,2.2.2
```

This would suggest we prioritize upgrades for `django` from `4.2` to `4.2.18`, `cryptography`, `pillow`, `requests`, and `urlllib3`, in addition to other libraries listed here.