### PR TITLE
Clone staging database into review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,5 +32,8 @@
     {
       "url": "heroku/python"
     }
-  ]
+  ],
+  "scripts": {
+    "postdeploy": "./postdeploy.sh"
+  }
 }

--- a/app.json
+++ b/app.json
@@ -31,6 +31,9 @@
     },
     {
       "url": "heroku/python"
+    },
+    {
+      "url": "heroku-community/cli"
     }
   ],
   "scripts": {

--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ -n "$HEROKU_APP_NAME" ]; then
-  heroku pg:copy squarelet-staging::DATABASE_URL DATABASE_URL --app $HEROKU_APP_NAME
+  heroku run "heroku pg:copy squarelet-staging::$DATABASE_URL $DATABASE_URL --app $HEROKU_APP_NAME --confirm $HEROKU_APP_NAME" -a $HEROKU_APP_NAME
 fi

--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "Build static files to be collected"
-npm ci --include dev
-npm run build
-ls -la frontend/dist # debug
-
-echo "Setup Django"
-python manage.py migrate --noinput
-python manage.py collectstatic --noinput -v 3 # verbose for debugging
+if [ -n "$HEROKU_APP_NAME" ]; then
+  heroku pg:copy squarelet-staging::DATABASE_URL DATABASE_URL --app $HEROKU_APP_NAME
+fi

--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -10,6 +10,7 @@
 if [ -n "$HEROKU_APP_NAME" ] && [ "$DJANGO_ENV" = "staging" ]; then
   # Copy the data from the staging app database to the review app database.
   heroku pg:copy squarelet-staging::DATABASE_URL DATABASE_URL --app $HEROKU_APP_NAME --confirm $HEROKU_APP_NAME
-  # Migrate the review app database.
-  heroku run "python manage.py migrate" -a $HEROKU_APP_NAME
 fi
+
+# No matter what environment we're in, ensure we run any Django migrations.
+python manage.py migrate --noinput

--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ -n "$HEROKU_APP_NAME" ]; then
-  heroku run "heroku pg:copy squarelet-staging::$DATABASE_URL $DATABASE_URL --app $HEROKU_APP_NAME --confirm $HEROKU_APP_NAME" -a $HEROKU_APP_NAME
+  heroku run "heroku pg:copy squarelet-staging::DATABASE_URL DATABASE_URL --app $HEROKU_APP_NAME --confirm $HEROKU_APP_NAME" -a $HEROKU_APP_NAME
 fi

--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
-if [ -n "$HEROKU_APP_NAME" ]; then
-  heroku run "heroku pg:copy squarelet-staging::DATABASE_URL DATABASE_URL --app $HEROKU_APP_NAME --confirm $HEROKU_APP_NAME" -a $HEROKU_APP_NAME
+# Check that the script is running in a Heroku review app.
+#
+# This is inferred from the presence of a HEROKU_APP_NAME environment variable,
+# which is automatically injected by Heroku into review apps.
+# 
+# By checking that we're in a "staging" environment, we have confidence that we're
+# only copying staging data into an environment that expects to receive it.
+if [ -n "$HEROKU_APP_NAME" ] && [ "$DJANGO_ENV" = "staging" ]; then
+  # Copy the data from the staging app database to the review app database.
+  heroku pg:copy squarelet-staging::DATABASE_URL DATABASE_URL --app $HEROKU_APP_NAME --confirm $HEROKU_APP_NAME
+  # Migrate the review app database.
+  heroku run "python manage.py migrate" -a $HEROKU_APP_NAME
 fi


### PR DESCRIPTION
Closes #225 

This updates our Heroku Pipeline, running a `postdeploy` script that copies the staging database into the review app's database. This should only run when `HEROKU_APP_NAME` env var is present, which should only be in the context of a review app.

This allows us to deploy review apps that contain migrations, without messing up the schema of the staging database.