### PR TITLE
Double worker memory for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
     },
     "worker": {
       "quantity": 1,
-      "size": "standard-1x"
+      "size": "standard-2x"
     }
   },
   "addons": [


### PR DESCRIPTION
The `standard-1x` config for a basic worker dyno product produced to the recurring error messages:

```
2025-02-08T02:06:49.183597+00:00 heroku[worker.1]: Process running mem=609M(118.2%)
2025-02-08T02:06:49.185821+00:00 heroku[worker.1]: Error R14 (Memory quota exceeded)
```

At 2x, the worker dyno stops producing this error.