### PR TITLE
Update CI GitHub Action to run on pushes to the master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 env:
   DJANGO_SECRET_KEY: ${{secrets.DJANGO_SECRET_KEY}}


### PR DESCRIPTION
Closes #234 

Because of branch protection rules, checks on this commit need to pass before I can cleanly merge into `master`. In addition to changes here:

1. I've disabled Codeship from building on pushes to `master`. The final branch it builds on is `dev`.
2. I've updated Heroku to add the `squarelet` app as a production app in our `squarelet-pipeline`. It will automatically deploy whenever `master` is updated with commits passing any required checks set up in GitHub.

The `dev` branch doesn't interact with Heroku pipelines at all.