### PR TITLE
Updates Sign Up page

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1729,6 +1729,7 @@ textarea {
 }
 
 .button {
+  box-sizing: border-box;
   display: flex;
   padding: 0.375em 0.75em;
   justify-content: center;

--- a/squarelet/core/templatetags/handleintent.py
+++ b/squarelet/core/templatetags/handleintent.py
@@ -40,6 +40,7 @@ def match_service_to_intent(context):
     except Service.DoesNotExist:
         return None
 
+
 @register.inclusion_tag("templatetags/sign_in_message.html", takes_context=True)
 def sign_in_message(context):
     no_match = {
@@ -51,10 +52,10 @@ def sign_in_message(context):
     }
 
     service = match_service_to_intent(context)
-    
+
     if not service:
         return no_match
-    
+
     return {
         "header": f"""
             Sign in with your MuckRock account 
@@ -62,6 +63,7 @@ def sign_in_message(context):
             """.strip(),
         "service": service,
     }
+
 
 @register.inclusion_tag("templatetags/sign_up_message.html", takes_context=True)
 def sign_up_message(context):
@@ -71,10 +73,10 @@ def sign_up_message(context):
     }
 
     service = match_service_to_intent(context)
-    
+
     if not service:
         return no_match
-    
+
     return {
         "header": "Access this and other services by creating a MuckRock account",
         "service": service,

--- a/squarelet/templates/account/login.html
+++ b/squarelet/templates/account/login.html
@@ -76,6 +76,39 @@
     font-weight: 400;
   }
 
+  .login-layout {
+    flex: 1;
+    gap: 0;
+    display: flex;
+    flex-flow: row-reverse wrap;
+    align-items: stretch;
+  }
+
+  .login-layout h2 {
+    font-weight: 600;
+    text-align: center;
+    font-size: var(--font-lg, 1.25rem);
+  }
+
+  .login-layout > .form-wrapper,
+  .login-layout > .service-gallery-wrapper {
+    flex: 1 1 28rem;
+    min-height: 0;
+  }
+
+  .form-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .service-gallery-wrapper {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    background: linear-gradient(180deg, #1367D0 0%, #4294F0 100%);
+  }
+
   .login-form {
     display: flex;
     flex-direction: column;
@@ -128,34 +161,6 @@
     padding: 0.5rem 1rem;
     border-radius: 0.25rem;
     font-weight: 600;
-  }
-
-  .login-layout {
-    flex: 1;
-    gap: 0;
-    display: flex;
-    flex-flow: row-reverse wrap;
-  }
-
-  .login-layout h2 {
-    font-weight: 600;
-    text-align: center;
-    font-size: var(--font-lg, 1.25rem);
-  }
-
-  .login-layout>* {
-    flex: 1 1 28rem;
-  }
-
-  .form-wrapper {
-    display: flex;
-    align-items: center;
-  }
-
-  .service-gallery-wrapper {
-    max-height: 90vh;
-    overflow-y: auto;
-    background: linear-gradient(180deg, #1367D0 0%, #4294F0 100%);
   }
 
   .service-gallery {

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "account/login.html" %}
 
 {% load i18n static %}
 {% load crispy_forms_tags %}
@@ -13,59 +13,142 @@
   .pad-b-3 {
     padding-bottom: 3rem;
   }
+  .form-wrapper, .signup-form, header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3rem;
+  }
+  .form-wrapper {
+    box-sizing: border-box;
+    padding: 4rem;
+  }
+  .signup-form {
+    margin-top: 0;
+    width: 100%;
+    max-width: 24rem;
+  }
+  header {
+    text-align: center;
+  }
+  header h2 {
+    max-width: 18rem;
+  }
+  .help.link {
+    font-size: var(--font-md, 1rem);
+    font-weight: var(--font-semibold, 600);
+    color: var(--primary);
+    text-decoration: none;
+  }
+  .help.text {
+    font-size: var(--font-sm, 0.875rem);
+    line-height: 1.4;
+    color: var(--gray-4);
+    font-weight: var(--font-regular, 400);
+  }
+  .help.text ul {
+    margin: .5em 0;
+    padding-left: 2em;
+  }
+  .help.text li {
+    margin-bottom: 0.25em;
+  }
+  .label {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+  .required {
+    font-size: var(--font-xs, 0.75rem);
+    font-weight: var(--font-semibold, 600);
+    color: var(--orange-3);
+  }
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+  }
+  footer {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+  footer .button {
+    display: block;
+    width: 100%;
+  }
+  .errorlist {
+    margin: 0;
+  }
 </style>
 {% endblock %}
 
-{% block inner %}
+{% block login_step %}
+  <div class="form-wrapper">
+    <header>
+      {% sign_up_message %}
+    </header>
+    <form class="signup-form m-0" id="signup_form" method="POST">
+      <main class="fields">
+        {% csrf_token %}
+        {{form.non_field_errors}}
+        {{form.plan}}
+        <label class="field">
+          <span class="label">
+            {{form.email.label}}
+            {% if form.email.field.required %}<span class="required">Required</span>{% endif %}
+          </span>
+          {{form.email}}
+          {{form.email.errors}}
+          <div class="help text">
+            {{ form.email.help_text }}
+          </div>
+        </label>
+        <label class="field">
+          <span class="label">
+            {{form.name.label}}
+            {% if form.name.field.required %}<span class="required">Required</span>{% endif %}
+          </span>
+          {{form.name}}
+          {{form.name.errors}}
+          <div class="help text">
+            {{ form.name.help_text }}
+          </div>
+        </label>
+        <label class="field">
+          <span class="label">
+            {{form.username.label}}
+            {% if form.username.field.required %}<span class="required">Required</span>{% endif %}
+          </span>
+          {{form.username}}
+          {{form.username.errors}}
+          <div class="help text">
+            {{ form.username.help_text }}
+          </div>
+        </label>
+        <label class="field">
+          <span class="label">
+            {{form.password1.label}}
+            {% if form.password1.field.required %}<span class="required">Required</span>{% endif %}
+          </span>
+          {{form.password1}}
+          {{form.password1.errors}}
+          <div class="help text">
+            {{ form.password1.help_text }}
+          </div>
+        </label>
+      </main>
 
-{% trans "Create an account for" as intent_header %}
-{% trans "You’ll also be able to sign into" as intent_text %}
-{% handleintent intent_header intent_text %}
-
-<!-- Start form -->
-<form id="stripe-form" class="pad-b-3" method="post">
-
-  {# this field is explicit so we can grab the plan from the get parameter #}
-  <input type="hidden" name="plan" id="id_plan" value="{{ request.GET.plan|default:"" }}">
-
-  {% if form.errors.plan %}
-  <span class="invalid-feedback">
-    <strong>Something went wrong. Please contact <a href="mailto:info@muckrock.com">info@muckrock.com</a>.</strong>
-  </span>
-  {% endif %}
-  {% crispy form form.helper %}
-
-  {% if request.GET.plan == "organization" or request.GET.plan == "organization-plus" %}
-  <div class="_cls-field">
-    <input class="_cls-organizationInput form-control" placeholder="Organization name" name="organization_name"
-      max_length="255" type="text">
+      <footer>
+        <button class="button primary">{% trans 'Sign up' %}</button>
+        <a class="button primary ghost" href="{% url 'account_login' %}">
+          {% blocktrans %}Already have an account? Sign in{% endblocktrans %}
+        </a>
+      </footer>
+    </form>
   </div>
-  {% endif %}
-
-  {% if request.GET.plan %}
-  <div id="_id-planProjection" class="_cls-planProjection">
-    <b>Cost: <span id="_id-totalCost"></span></b>
-    <div class="_cls-breakdown" id="_id-costBreakdown"></div>
-  </div>
-  <div id="card-container">
-    <h3 class="_cls-smallHeading">{% blocktrans %}Billing information{% endblocktrans %}</h3>
-    <div class="_cls-field">
-      <div id="card-element" class="_cls-fieldInput"></div>
-    </div>
-    <!-- Used to display Element errors. -->
-    <div id="card-errors" role="alert"></div>
-  </div>
-  {% endif %}
-
-  <div class="_cls-actionBig">
-    <button>{% trans 'Sign Up' %}</button>
-  </div>
-  <div class="_cls-center">
-    <div class="_cls-minorInfo">{% blocktrans %}Already have an account?{% endblocktrans %}</div>
-    <a href="{% url 'account_login' %}">
-      <div class="_cls-action">{% blocktrans %}Log&nbsp;In{% endblocktrans %}</div>
-    </a>
-  </div>
-</form>
-{% planinfo field="slug" %}
 {% endblock %}

--- a/squarelet/templates/core/component/navigation.html
+++ b/squarelet/templates/core/component/navigation.html
@@ -47,7 +47,7 @@
             {% trans "Sign Up" %}
           </a>
         {% else %}
-          <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}&next={{ request.get_full_path }}">
+          <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}&next={% firstof request.GET.next request.get_full_path %}">
             {% trans "Sign Up" %}
           </a>
         {% endif %}

--- a/squarelet/templates/templatetags/sign_up_message.html
+++ b/squarelet/templates/templatetags/sign_up_message.html
@@ -1,0 +1,14 @@
+{% if service %}
+<div class="intent-container">
+  <div class="service-info">
+    <img src="{{ service.icon.url }}" alt="{{ service.name }}">
+    <h3>{{ service.name }}</h3>
+    <p class="service-owner">by {{ service.provider_name }}</p>
+  </div>
+</div>
+{% endif %}
+
+<div>
+  <h2>{{ header }}</h2>
+  <a class="help link" href="">What is a MuckRock account?</a>
+</div>

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -14,7 +14,6 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout
 
 # Squarelet
-from squarelet.core.forms import StripeForm
 from squarelet.core.layout import Field
 from squarelet.organizations.models import Plan
 from squarelet.users.models import User
@@ -22,11 +21,11 @@ from squarelet.users.models import User
 logger = logging.getLogger(__name__)
 
 
-class SignupForm(allauth.SignupForm, StripeForm):
+class SignupForm(allauth.SignupForm):
     """Add a name field to the sign up form"""
 
     name = forms.CharField(
-        max_length=255, widget=forms.TextInput(attrs={"placeholder": "Full name"})
+        label=_("Full name"), max_length=255, widget=forms.TextInput(attrs={"placeholder": "Full name"})
     )
 
     plan = forms.ModelChoiceField(
@@ -46,12 +45,9 @@ class SignupForm(allauth.SignupForm, StripeForm):
             data["plan"] = ""
             kwargs["data"] = data
         super().__init__(*args, **kwargs)
-        self.fields["stripe_token"].required = False
 
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            Field("stripe_token"),
-            Field("stripe_pk"),
             Field("name"),
             Field("username"),
             Field("email", type="email"),
@@ -59,6 +55,17 @@ class SignupForm(allauth.SignupForm, StripeForm):
         )
         self.fields["username"].widget.attrs.pop("autofocus", None)
         self.helper.form_tag = False
+        self.fields["username"].widget.attrs["placeholder"] = ""
+        self.fields["username"].help_text = _(
+            "Your username must be unique; it will be used in URLs."
+        )
+        self.fields["name"].widget.attrs["placeholder"] = ""
+        self.fields["name"].help_text = _(
+            """Your full name will be displayed on your profile
+            and used to identify you within organizations."""
+        )
+        self.fields["email"].widget.attrs["placeholder"] = ""
+        self.fields["password1"].widget.attrs["placeholder"] = ""
 
     def clean(self):
         data = super().clean()

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -25,7 +25,9 @@ class SignupForm(allauth.SignupForm):
     """Add a name field to the sign up form"""
 
     name = forms.CharField(
-        label=_("Full name"), max_length=255, widget=forms.TextInput(attrs={"placeholder": "Full name"})
+        label=_("Full name"),
+        max_length=255,
+        widget=forms.TextInput(attrs={"placeholder": "Full name"}),
     )
 
     plan = forms.ModelChoiceField(
@@ -73,10 +75,6 @@ class SignupForm(allauth.SignupForm):
             log_data = self.data.copy()
             log_data.pop("password1", None)
             logger.warning("Failed signup attempt:\n\t%r\n\t%s", self.errors, log_data)
-        plan = data.get("plan")
-        # Save the plan in session storage for future onboarding step #267
-        if plan and plan.requires_payment():
-            self.request.session["plan"] = plan.slug
         return data
 
     @transaction.atomic()
@@ -88,6 +86,11 @@ class SignupForm(allauth.SignupForm):
         user_data.update(self.cleaned_data)
 
         user, _, error = User.objects.register_user(user_data)
+
+        plan = self.cleaned_data.get("plan")
+        # Save the plan in session storage for future onboarding step #267
+        if plan and plan.requires_payment():
+            request.session["plan"] = plan.slug
 
         setup_user_email(request, user, [])
 

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -83,7 +83,7 @@ class SignupForm(allauth.SignupForm):
     def save(self, request):
 
         user_data = {
-            "source": request.GET.get("intent", "squarelet").lower().strip()[:13]
+            "source": request.GET.get("intent", "squarelet").lower().strip()[:255]
         }
         user_data.update(self.cleaned_data)
 

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -74,22 +74,9 @@ class SignupForm(allauth.SignupForm):
             log_data.pop("password1", None)
             logger.warning("Failed signup attempt:\n\t%r\n\t%s", self.errors, log_data)
         plan = data.get("plan")
-        if plan and plan.requires_payment() and not data.get("stripe_token"):
-            self.add_error(
-                "plan",
-                _(
-                    "You must supply a credit card number to sign up for a "
-                    "non-free plan"
-                ),
-            )
-        if plan and not plan.for_individuals and not data.get("organization_name"):
-            self.add_error(
-                "organization_name",
-                _(
-                    "Organization name is required if registering an "
-                    "organizational account"
-                ),
-            )
+        # Save the plan in session storage for future onboarding step #267
+        if plan and plan.requires_payment():
+            self.request.session["plan"] = plan.slug
         return data
 
     @transaction.atomic()

--- a/squarelet/users/tests/test_forms.py
+++ b/squarelet/users/tests/test_forms.py
@@ -36,12 +36,10 @@ def test_clean_bad_no_pay(professional_plan_factory, mocker):
         "username": "john",
         "email": "doe@example.com",
         "password1": "squarelet",
-        "stripe_pk": "key",
         "plan": "professional",
     }
     form = forms.SignupForm(data)
-    assert not form.is_valid()
-    assert len(form.errors["plan"]) == 1
+    assert form.is_valid()
 
 
 @pytest.mark.django_db
@@ -53,13 +51,10 @@ def test_clean_bad_no_org_name(organization_plan_factory, mocker):
         "username": "john",
         "email": "doe@example.com",
         "password1": "squarelet",
-        "stripe_pk": "key",
         "plan": "organization",
-        "stripe_token": "token",
     }
     form = forms.SignupForm(data)
-    assert not form.is_valid()
-    assert len(form.errors["organization_name"]) == 1
+    assert form.is_valid()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #248 

Updates Sign Up page to bring the design inline with the new login page.

Now after signup, the user will enter the onboarding flow because the `post_login` function is called during signup. At a minimum, the user will see a nice message asking them to confirm their email address before continuing on.

This removes the Stripe fields from `SignupForm` but leaves the hidden `plan` field in place. If `plan` has a value when saving the form, the Plan slug is added to session storage for use during the onboarding flow. See #267 for more.

- Fixes a bug where the "Signup" navigation link would create incorrect URL params.