### PR TITLE
fix bug when modifying cancelled subscription

### DIFF
--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -246,6 +246,8 @@ class Subscription(models.Model):
                 metadata={"action": f"Subscription ({self.plan})"},
                 days_until_due=30 if self.plan.annual else None,
             )
+            self.cancelled = False
+            self.save()
 
 
 class Plan(models.Model):


### PR DESCRIPTION
There was a bug where if you cancelled your subscription, than resubscribed before your current subscription lapsed at the end of the billing period, it would get marked as cancelled in our database and be out of sync with stripe.