### PR TITLE
Polish services list styling

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1628,19 +1628,25 @@ textarea {
   line-height: normal;
 }
 
-.service-providers {
-  width: 100%;
-  margin: 3rem 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 3rem;
-}
-
 .service-provider {
   display: flex;
   flex-direction: column;
   gap: 1rem;
   align-items: flex-start;
+  padding: .75rem;
+}
+
+a.service-provider {
+  color: currentColor;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  transition: background 0.2s ease;
+  background: transparent;
+}
+
+a.service-provider:hover, a.service-provider:focus {
+  background: rgba(255, 255, 255, .15);
+  text-shadow: 0px 1px 4px var(--shadow, rgba(30, 48, 56, 0.15));
 }
 
 .service-provider * {
@@ -1676,7 +1682,7 @@ textarea {
 
   /* Title */
   font-family: var(--font-sans, "Source Sans Pro");
-  font-size: var(--font-xl, 1.5rem);
+  font-size: var(--font-l, 1.25rem);
   font-style: normal;
   font-weight: 600;
   line-height: normal;
@@ -1684,11 +1690,11 @@ textarea {
 
 .service-provider p {
   color: currentcolor;
-  opacity: 0.7;
+  opacity: 0.9;
 
   /* Small Label */
   font-family: var(--font-sans, "Source Sans Pro");
-  font-size: var(--font-sm, 0.875rem);
+  font-size: var(--font-md, 0.875rem);
   font-style: normal;
   font-weight: 400;
   line-height: normal;

--- a/squarelet/templates/account/login.html
+++ b/squarelet/templates/account/login.html
@@ -149,7 +149,15 @@
   }
 
   .wrapper#form {
-    align-self: center;
+    box-sizing: border-box;
+  }
+
+  /* Gives the form a little breathing room
+  when it is side-by-side with the service gallery */
+  @media (min-width: 72rem) {
+    .wrapper#form {
+      padding-top: 2rem;
+    }
   }
 
   .wrapper#service-gallery {
@@ -157,16 +165,22 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    /*
+    These rules allow the service gallery to overflow smoothly,
+    in case we ever want to restore that functionality:
     overflow-y: auto;
     min-height: 70vh;
+    */
   }
 
   .service-gallery {
     flex: 1 1 0;
-    min-height: 70vh;
     max-height: 100%;
     padding: 3rem 4rem;
     color: var(--blue-1, #EEF3F9);
+    /* If the service gallery wrapper is set to overflow,
+    the gallery needs to set its own minimum height. */ 
+    /* min-height: 70vh; */
   }
 
   .service-gallery header {

--- a/squarelet/templates/account/login.html
+++ b/squarelet/templates/account/login.html
@@ -90,26 +90,11 @@
     font-size: var(--font-lg, 1.25rem);
   }
 
-  .login-layout > .form-wrapper,
-  .login-layout > .service-gallery-wrapper {
-    flex: 1 1 28rem;
-    min-height: 0;
+  .login-layout > * {
+    flex: 1 1 36rem;
   }
 
-  .form-wrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-
-  .service-gallery-wrapper {
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    background: linear-gradient(180deg, #1367D0 0%, #4294F0 100%);
-  }
-
-  .login-form {
+  .login-form, .signup-form {
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -163,16 +148,51 @@
     font-weight: 600;
   }
 
-  .service-gallery {
+  .wrapper#form {
+    align-self: center;
+  }
+
+  .wrapper#service-gallery {
+    background: linear-gradient(180deg, #1367D0 0%, #4294F0 100%);
     display: flex;
-    max-width: 40rem;
-    margin: 0 auto;
-    padding: 3rem 4rem;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
+    overflow-y: auto;
+    min-height: 70vh;
+  }
 
+  .service-gallery {
+    flex: 1 1 0;
+    min-height: 70vh;
+    max-height: 100%;
+    padding: 3rem 4rem;
     color: var(--blue-1, #EEF3F9);
+  }
+
+  .service-gallery header {
+    max-width: 32rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 0 auto 2rem;
+  }
+
+  .service-gallery .service-providers {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding-bottom: 3rem;
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+    justify-content: center;
+    align-content: flex-start;
+    gap: 1.5rem;
+  }
+
+  .service-provider {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 
   .service-gallery h2 {
@@ -184,8 +204,13 @@
     font-size: var(--font-lg, 1.25rem);
     font-style: normal;
     font-weight: 600;
-    line-height: 2rem;
-    max-width: 33rem;
+    line-height: 1.75rem; /* 140% */
+    max-width: 28.75rem;
+    width: 100%;
+  }
+
+  .service-gallery h2.secondary-heading {
+    font-size: 1.125rem;
   }
 </style>
 {% endblock %}
@@ -193,7 +218,7 @@
 {% block content %}
 <div class="flex login-layout">
   {% block login_step %}
-  <div class="form-wrapper">
+  <div class="wrapper" id="form">
     <form class="login-form" id="login_form" method="POST">
       {% sign_in_message %}
 
@@ -235,15 +260,22 @@
   </div>
   {% endblock %}
   {% block login_promo %}
-  <div class="service-gallery-wrapper">
+  <div class="wrapper" id="service-gallery">
     <div class="service-gallery">
-      <h2>
-        {% blocktrans %}
-        Your MuckRock account is a passport to essential services that support research, reporting, collaboration and
-        civic engagement. Your MuckRock account gives you access to tools and resources from MuckRock and our trusted
-        partners.
-        {% endblocktrans %}
-      </h2>
+      <header>
+        <h2>
+          {% blocktrans %}
+          Your MuckRock account is a passport to essential services that support research, reporting, collaboration and
+          civic engagement.
+          {% endblocktrans %}
+        </h2>
+        <h2 class="secondary-heading">
+          {% blocktrans %}
+          Your MuckRock account gives you access to tools and resources from MuckRock and our trusted
+          partners:
+          {% endblocktrans %}
+        </h2>
+      </header>
       {% services_list %}
     </div>
   </div>

--- a/squarelet/templates/account/login.html
+++ b/squarelet/templates/account/login.html
@@ -208,10 +208,6 @@
     max-width: 28.75rem;
     width: 100%;
   }
-
-  .service-gallery h2.secondary-heading {
-    font-size: 1.125rem;
-  }
 </style>
 {% endblock %}
 

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -13,14 +13,14 @@
   .pad-b-3 {
     padding-bottom: 3rem;
   }
-  .form-wrapper, .signup-form, header {
+  .wrapper#form, .signup-form, header {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: 3rem;
   }
-  .form-wrapper {
+  .wrapper#form {
     box-sizing: border-box;
     padding: 4rem;
   }
@@ -88,11 +88,11 @@
 {% endblock %}
 
 {% block login_step %}
-  <div class="form-wrapper">
-    <header>
-      {% sign_up_message %}
-    </header>
+  <div class="wrapper" id="form">
     <form class="signup-form m-0" id="signup_form" method="POST">
+      <header>
+        {% sign_up_message %}
+      </header>
       <main class="fields">
         {% csrf_token %}
         {{form.non_field_errors}}

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -20,13 +20,8 @@
     justify-content: center;
     gap: 3rem;
   }
-  .wrapper#form {
-    box-sizing: border-box;
-    padding: 4rem;
-  }
   .signup-form {
     margin-top: 0;
-    width: 100%;
     max-width: 24rem;
   }
   header {

--- a/squarelet/templates/templatetags/services_list.html
+++ b/squarelet/templates/templatetags/services_list.html
@@ -1,11 +1,21 @@
 <div class="service-providers">
   {% for provider in service_providers %}
-  <div class="service-provider">
-    <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
-    <div class="service-provider-text">
-      <h3>{{ provider.name }}</h3>
-      <p>{{ provider.description }}</p>
-    </div>
-  </div>
+    {% if provider.base_url %}
+      <a href="{{provider.base_url}}" target="_blank" class="service-provider">
+        <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+        <div class="service-provider-text">
+          <h3>{{ provider.name }}</h3>
+          <p>{{ provider.description }}</p>
+        </div>
+      </a>
+    {% else %}
+      <div class="service-provider">
+        <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+        <div class="service-provider-text">
+          <h3>{{ provider.name }}</h3>
+          <p>{{ provider.description }}</p>
+        </div>
+      </div>
+    {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
- Services list now adapts to the height of the login/signup step it's presented alongside. This will enable overflow scrolling on most pages when we have a longer list of services.
- Services now link out when they have a `base_url`.
- Typography and layout refinements.

### Test & review
- **[Sign Up](https://squarelet-pi-allanlasse-qqivzh.herokuapp.com/accounts/signup/?intent=squarelet)**: note how the services list is shorter than the page's form
- **[Sign In](https://squarelet-pi-allanlasse-qqivzh.herokuapp.com/accounts/login/?intent=documentcloud)**: note how the services list is longer than the page's form

### Questions

1. Should services link to their `base_url` or their sign-in intent?
