### PR TITLE
Logout fixes and improvements

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1305,14 +1305,17 @@ a._cls-dropdownItem {
 }
 
 ._cls-navItem,
-a._cls-navItem {
+a._cls-navItem,
+button._cls-navItem {
   display: flex;
   padding: 4px 8px;
   border-radius: 4px;
   align-items: center;
   text-decoration: none;
   gap: 8px;
+  border: none;
   border-bottom: none;
+  background: transparent;
   color: var(--gray-5, #233944);
   fill: var(--gray-5, #233944);
   font-feature-settings: "ss04" on;
@@ -1325,7 +1328,8 @@ a._cls-navItem {
   white-space: nowrap;
 }
 
-a._cls-navItem:hover {
+a._cls-navItem:hover,
+button._cls-navItem:hover {
   text-decoration: none;
   color: var(--blue-5, #053775);
   fill: var(--blue-5, #053775);
@@ -1929,4 +1933,8 @@ textarea {
   .website-footer .link-group {
     margin-bottom: 1rem;
   }
+}
+
+.m-0 {
+  margin: 0;
 }

--- a/squarelet/templates/account/logout.html
+++ b/squarelet/templates/account/logout.html
@@ -7,7 +7,7 @@
 {% block inner %}
     <h1>{% trans "Sign Out" %}</h1>
 
-    <p>{% trans 'Are you sure you want to sign out?' %} <a onclick="back()">{% trans 'Go back.' %}</a></p>
+    <p>{% trans 'Are you sure you want to sign out?' %} <a onclick="history.back()">{% trans 'Go back.' %}</a></p>
 
     <form method="post" action="{% url 'account_logout' %}">
       {% csrf_token %}

--- a/squarelet/templates/core/component/navigation.html
+++ b/squarelet/templates/core/component/navigation.html
@@ -36,9 +36,10 @@
           {% avatar request.user 25 %}
           {{ request.user.username }}
         </a>
-        <a href="{% url 'account_logout' %}" class="_cls-navItem">
-          {% trans "Sign Out" %}
-        </a>
+        <form class="m-0" method="post" action="{% url 'account_logout' %}">
+          {% csrf_token %}
+          <button class="_cls-navItem">{% trans 'Sign Out' %}</button>
+        </form>
       </nav>
       {% else %}
       <nav class="_cls-navItems _cls-accountItems _cls-anonymous">


### PR DESCRIPTION
Closes #300 
Closes #301 

This improves the UX for logging out of an account:

1. If the user visits the logout page, the "Go back" link now works.
2. In the top navigation, logout is now a form that sends a POST to the logout route. This skips a step during logout; currently, logout is a link to the logout page, which has a similar POST form on it.