### PR TITLE
Fixes for 2FA opt-in

### DIFF
--- a/squarelet/templates/account/onboarding/mfa_setup.html
+++ b/squarelet/templates/account/onboarding/mfa_setup.html
@@ -91,7 +91,7 @@
     <input type="hidden" name="secret" value="{{ form.secret }}" />
     <label class="field">
       {% trans "Enter your 6-digit code" %}
-      <input type="text" name="code" placeholder="{% trans "######" %}" required />
+      <input type="text" name="code" placeholder="{% trans "######" %}" />
     </label>
     <button class="button primary" type="submit" name="mfa_setup" value="code">{% trans "Submit" %}</button>
     <button class="button primary ghost" type="submit" name="mfa_setup" value="skip">{% trans "Skip" %}</button>

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -222,19 +222,21 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
 
 
 class MfaAdapter(DefaultMFAAdapter):
-    # pylint: disable=line-too-long
     error_messages = {
         "add_email_blocked": _(
-            "You cannot add an email address to an account protected by two-factor authentication."
+            "You cannot add an email address to an account "
+            "protected by two-factor authentication."
         ),
         "cannot_delete_authenticator": _(
             "You cannot deactivate two-factor authentication."
         ),
         "cannot_generate_recovery_codes": _(
-            "You cannot generate recovery codes without having two-factor authentication enabled."
+            "You cannot generate recovery codes without "
+            "having two-factor authentication enabled."
+        ),
+        "unverified_email": _(
+            "All email addresses associated with your account "
+            "must be confirmed before enabling two-factor authentication."
         ),
         "incorrect_code": _("Incorrect code."),
-        "unverified_email": _(
-            "You cannot activate two-factor authentication until you have verified your email address."
-        ),
     }

--- a/squarelet/users/admin.py
+++ b/squarelet/users/admin.py
@@ -99,7 +99,7 @@ class MyUserAdmin(VersionAdmin, AuthUserAdmin):
         ),
         (
             _("Important dates"),
-            {"fields": ("last_login", "created_at", "updated_at")},
+            {"fields": ("last_login", "last_mfa_prompt", "created_at", "updated_at")},
         ),
     )
     readonly_fields = (

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -178,10 +178,7 @@ class UserOnboardingView(TemplateView):
 
         # MFA check
         # Check if this is user's first login
-        is_first_login = (
-            user.last_login is None
-            or user.date_joined.date() == user.last_login.date()
-        )
+        is_first_login = user.last_login is None
         is_snoozed = (
             user.last_mfa_prompt
             and timezone.now() - user.last_mfa_prompt

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -292,13 +292,9 @@ class UserOnboardingView(TemplateView):
             # User has confirmed their email, mark as completed
             request.session["onboarding"]["email_check_completed"] = True
             request.session.modified = True
-            print(
-                "confirm email", request.session["onboarding"]["email_check_completed"]
-            )
 
         elif step == "mfa_opt_in":
             choice = request.POST.get("enable_mfa")
-            print(choice)
             if choice == "yes":
                 # User opted-in for MFA, move to next step
                 request.session["onboarding"]["mfa_step"] = "opted_in"

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -29,12 +29,12 @@ import json
 import time
 
 # Third Party
+from allauth.account.models import EmailAddress
 from allauth.account.utils import (
     get_next_redirect_url,
     has_verified_email,
     send_email_confirmation,
 )
-from allauth.account.models import EmailAddress
 from allauth.account.views import LoginView as AllAuthLoginView
 from allauth.mfa.adapter import get_adapter
 from allauth.mfa.totp.forms import ActivateTOTPForm

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -310,8 +310,12 @@ class UserOnboardingView(TemplateView):
         elif step == "mfa_setup":
             # Check if the user skipped the MFA setup step
             if request.POST.get("mfa_setup") == "skip":
+                # User skipped MFA, mark as completed
                 request.session["onboarding"]["mfa_step"] = "completed"
                 request.session.modified = True
+                # Update last_mfa_prompt to now
+                request.user.last_mfa_prompt = timezone.now()
+                request.user.save(update_fields=["last_mfa_prompt"])
                 messages.info(request, "Two-factor authentication skipped.")
                 return redirect("account_onboarding")
             # Process MFA setup - validate the code

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -197,10 +197,7 @@ class UserOnboardingView(TemplateView):
         # Otherwise, if the user has MFA enabled, or if it's
         # not the right time to prompt, mark step as checked
         elif (
-            is_mfa_enabled(user)
-            or is_first_login
-            or is_snoozed
-            or has_unverified_email
+            is_mfa_enabled(user) or is_first_login or is_snoozed or has_unverified_email
         ):
             onboarding["mfa_step"] = "completed"
             session.modified = True

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -34,6 +34,7 @@ from allauth.account.utils import (
     has_verified_email,
     send_email_confirmation,
 )
+from allauth.account.models import EmailAddress
 from allauth.account.views import LoginView as AllAuthLoginView
 from allauth.mfa.adapter import get_adapter
 from allauth.mfa.totp.forms import ActivateTOTPForm
@@ -180,6 +181,9 @@ class UserOnboardingView(TemplateView):
         is_first_login = (
             user.last_login is None or user.date_joined.date() == user.last_login.date()
         )
+        # 2FA setup will fail if the user has any unverified emails,
+        # even if they are not the primary email
+        has_unverified_email = EmailAddress.objects.filter(user=user, verified=False).exists()
         mfa_step = onboarding.get("mfa_step", None)
         # Check for the "code_submitted" step first, since
         # is_mfa_enabled will be true when the step is active
@@ -190,6 +194,7 @@ class UserOnboardingView(TemplateView):
         elif (
             is_mfa_enabled(user)
             or is_first_login
+            or has_unverified_email
             or not has_verified_email(user)
             or (
                 user.last_mfa_prompt


### PR DESCRIPTION
Closes #302 
Closes #303 

This improves our 2FA opt-in during onboarding by:

1. Checking for any unverified emails on the user's account; if they exist, the form will not be accepted by `allauth`'s standard rules.
2. Allowing users to skip submitting the code during the "opt-in" step.
3. Setting the `last_mfa_date` when users skip during the "opt-in" step.
4. Showing the `last_mfa_data` field in the User model's admin interface.