### PR TITLE
fix stripe token double use

### DIFF
--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -380,7 +380,8 @@ class Organization(AvatarMixin, models.Model):
 
         if not self.plan and plan:
             # create a subscription going from no plan to plan
-            self.create_subscription(token, plan, user)
+            # Don't pass the token in here, as we already saved it above
+            self.create_subscription(None, plan, user)
         elif self.plan and not plan:
             # cancel a subscription going from plan to no plan
             self.subscription.cancel()

--- a/squarelet/organizations/tests/test_models.py
+++ b/squarelet/organizations/tests/test_models.py
@@ -217,7 +217,7 @@ class TestOrganization:
         max_users = 10
         token = "token"
         organization.set_subscription(token, plan, max_users, user)
-        mocked.assert_called_with(token, plan, user)
+        mocked.assert_called_with(None, plan, user)
 
     @pytest.mark.django_db
     def test_set_subscription_cancel(


### PR DESCRIPTION
Fix a bug where the stripe token is used twice, which will throw an error