### PR TITLE
Fixes query parameters for sign up and sign in links

### DIFF
--- a/squarelet/core/templatetags/pass_query.py
+++ b/squarelet/core/templatetags/pass_query.py
@@ -1,28 +1,32 @@
+# Django
 from django import template
+
+# Standard Library
 from urllib.parse import urlencode
 
 register = template.Library()
+
 
 @register.simple_tag(takes_context=True)
 def pass_query(context, *args, **kwargs):
     """
     Creates a URL query string based on current request's query parameters.
-    
+
+    Returns: a formatted query string starting with '?' or empty string if no parameters
+
     Usage:
+
     {% pass_query %}  # Passes all current query parameters
     {% pass_query intent='squarelet' %}  # Overrides or adds intent parameter
     {% pass_query plan=None %}  # Removes plan parameter
-    
-    Returns:
-    A formatted query string starting with '?' or empty string if no parameters
     """
-    request = context.get('request')
+    request = context.get("request")
     if not request:
-        return ''
-        
+        return ""
+
     # Start with current GET parameters
     params = request.GET.dict()
-    
+
     # Update with any explicitly provided parameters
     for key, value in kwargs.items():
         if value is None and key in params:
@@ -30,12 +34,12 @@ def pass_query(context, *args, **kwargs):
             del params[key]
         else:
             params[key] = value
-    
+
     # Ensure intent exists with default value if not provided
-    if 'intent' not in params:
-        params['intent'] = 'squarelet'
-            
+    if "intent" not in params:
+        params["intent"] = "squarelet"
+
     # Convert to query string
     if params:
-        return '?' + urlencode(params)
-    return ''
+        return "?" + urlencode(params)
+    return ""

--- a/squarelet/core/templatetags/tests/test_pass_query.py
+++ b/squarelet/core/templatetags/tests/test_pass_query.py
@@ -1,0 +1,128 @@
+# Django
+from django.http import HttpRequest
+from django.template import Context, Template
+from django.test import RequestFactory, SimpleTestCase
+
+# Standard Library
+from urllib.parse import parse_qs
+
+# Squarelet
+from squarelet.core.templatetags.pass_query import pass_query
+
+
+class PassQueryTemplateTagTest(SimpleTestCase):
+    """Test the pass_query template tag"""
+
+    def setUp(self):
+        """Set up RequestFactory for all tests"""
+        self.factory = RequestFactory()
+
+    def test_empty_request(self):
+        """Test with empty request parameters"""
+        request = self.factory.get("/")
+        context = Context({"request": request})
+        result = pass_query(context)
+
+        # Should add default intent parameter
+        self.assertEqual(result, "?intent=squarelet")
+
+    def test_existing_parameters(self):
+        """Test preserving existing parameters"""
+        request = self.factory.get("/?plan=pro&next=/dashboard/")
+        context = Context({"request": request})
+        result = pass_query(context)
+
+        # Parse query string into dict for easier comparison
+        query_dict = parse_qs(result[1:])  # Remove leading '?'
+
+        self.assertIn("plan", query_dict)
+        self.assertEqual(query_dict["plan"][0], "pro")
+        self.assertIn("next", query_dict)
+        self.assertEqual(query_dict["next"][0], "/dashboard/")
+        self.assertIn("intent", query_dict)
+        self.assertEqual(query_dict["intent"][0], "squarelet")
+
+    def test_override_parameters(self):
+        """Test overriding existing parameters"""
+        request = self.factory.get("/?plan=pro&intent=muckrock")
+        context = Context({"request": request})
+        result = pass_query(context, intent="documentcloud")
+
+        query_dict = parse_qs(result[1:])
+
+        self.assertEqual(query_dict["intent"][0], "documentcloud")
+        self.assertEqual(query_dict["plan"][0], "pro")
+
+    def test_add_new_parameters(self):
+        """Test adding new parameters"""
+        request = self.factory.get("/?plan=pro")
+        context = Context({"request": request})
+        result = pass_query(context, next="/account/settings/")
+
+        query_dict = parse_qs(result[1:])
+
+        self.assertEqual(query_dict["plan"][0], "pro")
+        self.assertEqual(query_dict["next"][0], "/account/settings/")
+        self.assertIn("intent", query_dict)
+
+    def test_remove_parameters(self):
+        """Test removing parameters by setting to None"""
+        request = self.factory.get("/?plan=pro&next=/dashboard/")
+        context = Context({"request": request})
+        result = pass_query(context, plan=None)
+
+        query_dict = parse_qs(result[1:])
+
+        self.assertNotIn("plan", query_dict)
+        self.assertIn("next", query_dict)
+        self.assertIn("intent", query_dict)
+
+    def test_default_intent(self):
+        """Test that intent is added with default if missing"""
+        request = self.factory.get("/?plan=pro")
+        context = Context({"request": request})
+        result = pass_query(context)
+
+        query_dict = parse_qs(result[1:])
+
+        self.assertIn("intent", query_dict)
+        self.assertEqual(query_dict["intent"][0], "squarelet")
+
+    def test_no_request(self):
+        """Test behavior when request is not in context"""
+        context = Context({})
+        result = pass_query(context)
+        self.assertEqual(result, "")
+
+    def test_as_template_tag(self):
+        """Test using the tag in a template"""
+        request = self.factory.get("/?plan=pro&next=/dashboard/")
+        context = Context({"request": request})
+
+        # Render a template with the tag
+        template = Template("{% load pass_query %}{% pass_query %}")
+        rendered = template.render(context)
+
+        self.assertIn("plan", rendered)
+        self.assertIn("next", rendered)
+        self.assertIn("intent", rendered)
+
+    def test_unicode_parameters(self):
+        """Test with unicode characters in parameters"""
+        request = self.factory.get("/?search=测试&category=café")
+        context = Context({"request": request})
+        result = pass_query(context)
+
+        self.assertIn("search=", result)
+        self.assertIn("category=", result)
+        self.assertIn("intent=", result)
+        self.assertIn("%E6%B5%8B%E8%AF%95", result)  # URL-encoded "测试"
+        self.assertIn("caf%C3%A9", result)  # URL-encoded "café"
+
+    def test_special_characters(self):
+        """Test with special characters that need URL encoding"""
+        request = self.factory.get("/?q=test&filter=date:>2023")
+        context = Context({"request": request})
+        result = pass_query(context)
+
+        self.assertIn("filter=date%3A%3E2023", result)  # URL-encoded "date:>2023"

--- a/squarelet/templates/account/login.html
+++ b/squarelet/templates/account/login.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load account socialaccount %}
-{% load handleintent %}
+{% load handleintent pass_query %}
 
 {% block title %}{% trans "Sign In" %}{% endblock %}
 
@@ -262,7 +262,7 @@
 
       <footer class="flex row wrap">
         <button class="button primary">{% trans 'Sign in' %}</button>
-        <a class="button primary ghost" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
+        <a class="button primary ghost" href="{% url 'account_signup' %}{% pass_query %}">
           {% blocktrans %}Create an account{% endblocktrans %}
         </a>
       </footer>

--- a/squarelet/templates/account/login.html
+++ b/squarelet/templates/account/login.html
@@ -262,7 +262,7 @@
 
       <footer class="flex row wrap">
         <button class="button primary">{% trans 'Sign in' %}</button>
-        <a class="button primary ghost" href="{% url 'select_plan' %}">
+        <a class="button primary ghost" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
           {% blocktrans %}Create an account{% endblocktrans %}
         </a>
       </footer>

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -140,7 +140,7 @@
 
       <footer>
         <button class="button primary">{% trans 'Sign up' %}</button>
-        <a class="button primary ghost" href="{% url 'account_login' %}">
+        <a class="button primary ghost" href="{% url 'account_login' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
           {% blocktrans %}Already have an account? Sign in{% endblocktrans %}
         </a>
       </footer>

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -2,7 +2,7 @@
 
 {% load i18n static %}
 {% load crispy_forms_tags %}
-{% load handleintent %}
+{% load handleintent pass_query %}
 {% load planinfo %}
 
 {% block head_title %}{% trans "Signup" %}{% endblock %}
@@ -140,7 +140,7 @@
 
       <footer>
         <button class="button primary">{% trans 'Sign up' %}</button>
-        <a class="button primary ghost" href="{% url 'account_login' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
+        <a class="button primary ghost" href="{% url 'account_login' %}{% pass_query %}">
           {% blocktrans %}Already have an account? Sign in{% endblocktrans %}
         </a>
       </footer>

--- a/squarelet/templates/core/component/navigation.html
+++ b/squarelet/templates/core/component/navigation.html
@@ -43,16 +43,10 @@
       </nav>
       {% else %}
       <nav class="_cls-navItems _cls-accountItems _cls-anonymous">
-        {% if request.get_full_path == "/election-hub/" %}
-          <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'election-hub' %}&next={{ request.get_full_path }}">
-            {% trans "Sign Up" %}
-          </a>
-        {% else %}
-          <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}&next={% firstof request.GET.next request.get_full_path %}">
-            {% trans "Sign Up" %}
-          </a>
-        {% endif %}
-        <a title="{% trans 'Sign In' %}" class="_cls-navItem" href="{% url 'account_login' %}?next={{ request.get_full_path }}">
+        <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
+          {% trans "Sign Up" %}
+        </a>
+        <a title="{% trans 'Sign In' %}" class="_cls-navItem" href="{% url 'account_login' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
           {% trans "Sign In" %}
         </a>
       </nav>

--- a/squarelet/templates/core/component/navigation.html
+++ b/squarelet/templates/core/component/navigation.html
@@ -1,4 +1,4 @@
-{% load static i18n avatar %}
+{% load static i18n avatar pass_query %}
 
 <header class="_cls-heading">
   <div class="_cls-headingContainer">
@@ -43,10 +43,10 @@
       </nav>
       {% else %}
       <nav class="_cls-navItems _cls-accountItems _cls-anonymous">
-        <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
+        <a title="{% trans 'Sign Up' %}" class="_cls-navItem" href="{% url 'account_signup' %}{% pass_query %}">
           {% trans "Sign Up" %}
         </a>
-        <a title="{% trans 'Sign In' %}" class="_cls-navItem" href="{% url 'account_login' %}?intent={% firstof request.GET.intent 'squarelet' %}{% if request.GET.plan %}&plan={{request.GET.plan }}{% endif %}{% if request.GET.next %}&next={{request.GET.next }}{% endif %}">
+        <a title="{% trans 'Sign In' %}" class="_cls-navItem" href="{% url 'account_login' %}{% pass_query %}">
           {% trans "Sign In" %}
         </a>
       </nav>

--- a/squarelet/users/templatetags/pass_query.py
+++ b/squarelet/users/templatetags/pass_query.py
@@ -1,0 +1,41 @@
+from django import template
+from urllib.parse import urlencode
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def pass_query(context, *args, **kwargs):
+    """
+    Creates a URL query string based on current request's query parameters.
+    
+    Usage:
+    {% pass_query %}  # Passes all current query parameters
+    {% pass_query intent='squarelet' %}  # Overrides or adds intent parameter
+    {% pass_query plan=None %}  # Removes plan parameter
+    
+    Returns:
+    A formatted query string starting with '?' or empty string if no parameters
+    """
+    request = context.get('request')
+    if not request:
+        return ''
+        
+    # Start with current GET parameters
+    params = request.GET.dict()
+    
+    # Update with any explicitly provided parameters
+    for key, value in kwargs.items():
+        if value is None and key in params:
+            # Remove the parameter if None is specified
+            del params[key]
+        else:
+            params[key] = value
+    
+    # Ensure intent exists with default value if not provided
+    if 'intent' not in params:
+        params['intent'] = 'squarelet'
+            
+    # Convert to query string
+    if params:
+        return '?' + urlencode(params)
+    return ''


### PR DESCRIPTION
Closes #297

Adds a new `pass_query` template tag for improved control over persisting querystrings between routes.

Removes setting next URL param to the current route in templates, fixes `/selectplan/` forwarding after logging in from the homepage.