### PR TITLE
Squarelet api changes

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -112,7 +112,9 @@ AWS_LOCATION = "static"
 if AWS_S3_CUSTOM_DOMAIN:
     STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/static/"
 elif CI_GIT_BRANCH:
-    STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/b/{CI_GIT_BRANCH}/"
+    STATIC_URL = (
+        f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/b/{CI_GIT_BRANCH}/"
+    )
     AWS_LOCATION = f"b/{CI_GIT_BRANCH}"
 else:
     STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,7 +15,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 # Squarelet
 from squarelet.core.views import HomeView
 from squarelet.oidc.views import token_view
-from squarelet.organizations.viewsets import ChargeViewSet, OrganizationViewSet
+from squarelet.organizations.viewsets import ChargeViewSet, OrganizationViewSet, InvitationViewSet
 from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     RefreshTokenViewSet,
@@ -29,6 +29,7 @@ router.register("url_auth_tokens", UrlAuthTokenViewSet, basename="url_auth_token
 router.register("refresh_tokens", RefreshTokenViewSet, basename="refresh_token")
 router.register("organizations", OrganizationViewSet)
 router.register("charges", ChargeViewSet)
+router.register(r'invitations', InvitationViewSet)
 
 
 def redirect_erh(request, path=''):

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,7 +15,11 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 # Squarelet
 from squarelet.core.views import HomeView
 from squarelet.oidc.views import token_view
-from squarelet.organizations.viewsets import ChargeViewSet, OrganizationViewSet, InvitationViewSet
+from squarelet.organizations.viewsets import (
+    ChargeViewSet,
+    InvitationViewSet,
+    OrganizationViewSet,
+)
 from squarelet.users.views import LoginView
 from squarelet.users.viewsets import (
     RefreshTokenViewSet,
@@ -29,11 +33,13 @@ router.register("url_auth_tokens", UrlAuthTokenViewSet, basename="url_auth_token
 router.register("refresh_tokens", RefreshTokenViewSet, basename="refresh_token")
 router.register("organizations", OrganizationViewSet)
 router.register("charges", ChargeViewSet)
-router.register(r'invitations', InvitationViewSet)
+router.register(r"invitations", InvitationViewSet)
 
 
-def redirect_erh(request, path=''):
-    return redirect('https://www.muckrock.com/project/elections-2024-1169/', permanent=True)
+def redirect_erh(request, path=""):
+    return redirect(
+        "https://www.muckrock.com/project/elections-2024-1169/", permanent=True
+    )
 
 
 urlpatterns = [

--- a/squarelet/organizations/permissions.py
+++ b/squarelet/organizations/permissions.py
@@ -1,0 +1,56 @@
+from rest_framework.permissions import BasePermission
+
+class IsInvitationTarget(BasePermission):
+    """
+    Accept:
+      - Invitation must be an admin invite (`request=False`)
+      - Email must match a verified email on the user
+    Reject:
+      - User matches invitation.user
+      - OR email matches a verified email on the user
+    """
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        verified_emails = user.emailaddress_set.filter(verified=True).values_list("email", flat=True)
+
+        if view.action == "accept":
+            return not obj.request and obj.email in verified_emails
+
+        elif view.action == "reject":
+            return obj.user == user or obj.email in verified_emails
+
+        return False
+
+
+class CanAcceptOrRejectInvitation(BasePermission):
+    """
+        Invites can only be accepted or rejected 
+        - If the user is the subject of the invitation and it isn't a request to join.
+          We don't want users accepting their own request to joins. 
+
+
+    """
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        user_verified_emails = user.emailaddress_set.filter(verified=True).values_list("email", flat=True)
+        is_target = obj.email in user_verified_emails and not obj.request
+        is_admin = obj.organization.has_admin(user)
+        is_request = obj.request
+
+        return (is_target) or (is_admin and is_request)
+
+class CanRevokeInvitation(BasePermission):
+    """
+    Allows revocation if:
+    - It's a join request and the requesting user is the one revoking.
+    - It's an admin invitation and the user is an admin
+      of the organization the invitation pertains to.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        return (
+            (obj.request and obj.user == user) or
+            (not obj.request and obj.organization.has_admin(user))
+        )

--- a/squarelet/organizations/permissions.py
+++ b/squarelet/organizations/permissions.py
@@ -1,4 +1,6 @@
+# Third Party
 from rest_framework.permissions import BasePermission
+
 
 class IsInvitationTarget(BasePermission):
     """
@@ -12,7 +14,9 @@ class IsInvitationTarget(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         user = request.user
-        verified_emails = user.emailaddress_set.filter(verified=True).values_list("email", flat=True)
+        verified_emails = user.emailaddress_set.filter(verified=True).values_list(
+            "email", flat=True
+        )
 
         if view.action == "accept":
             return not obj.request and obj.email in verified_emails
@@ -25,20 +29,24 @@ class IsInvitationTarget(BasePermission):
 
 class CanAcceptOrRejectInvitation(BasePermission):
     """
-        Invites can only be accepted or rejected 
-        - If the user is the subject of the invitation and it isn't a request to join.
-          We don't want users accepting their own request to joins. 
+    Invites can only be accepted or rejected
+    - If the user is the subject of the invitation and it isn't a request to join.
+      We don't want users accepting their own request to joins.
 
 
     """
+
     def has_object_permission(self, request, view, obj):
         user = request.user
-        user_verified_emails = user.emailaddress_set.filter(verified=True).values_list("email", flat=True)
+        user_verified_emails = user.emailaddress_set.filter(verified=True).values_list(
+            "email", flat=True
+        )
         is_target = obj.email in user_verified_emails and not obj.request
         is_admin = obj.organization.has_admin(user)
         is_request = obj.request
 
         return (is_target) or (is_admin and is_request)
+
 
 class CanRevokeInvitation(BasePermission):
     """
@@ -50,7 +58,6 @@ class CanRevokeInvitation(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         user = request.user
-        return (
-            (obj.request and obj.user == user) or
-            (not obj.request and obj.organization.has_admin(user))
+        return (obj.request and obj.user == user) or (
+            not obj.request and obj.organization.has_admin(user)
         )

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -7,7 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
 
 # Squarelet
-from squarelet.organizations.models import Charge, Membership, Organization
+from squarelet.organizations.models import Charge, Membership, Organization, Invitation
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
@@ -144,3 +144,10 @@ class ChargeSerializer(serializers.ModelSerializer):
                 "Must supply a token if save card is true"
             )
         return attrs
+
+
+class InvitationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Invitation
+        fields = "__all__"
+        read_only_fields = ("accepted_at", "rejected_at", "created_at")

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -7,7 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
 
 # Squarelet
-from squarelet.organizations.models import Charge, Membership, Organization, Invitation
+from squarelet.organizations.models import Charge, Invitation, Membership, Organization
 
 
 class OrganizationSerializer(serializers.ModelSerializer):

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -1,17 +1,27 @@
 # Third Party
+# Django
 from django.db.models import Q
+
 import django_filters
-from rest_framework import viewsets, filters
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from django_filters.rest_framework import DjangoFilterBackend
 
 # Squarelet
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import Charge, Organization, Invitation
-from squarelet.organizations.serializers import ChargeSerializer, OrganizationSerializer, InvitationSerializer
-from squarelet.organizations.permissions import CanRevokeInvitation, CanAcceptOrRejectInvitation
+from squarelet.organizations.models import Charge, Invitation, Organization
+from squarelet.organizations.permissions import (
+    CanAcceptOrRejectInvitation,
+    CanRevokeInvitation,
+)
+from squarelet.organizations.serializers import (
+    ChargeSerializer,
+    InvitationSerializer,
+    OrganizationSerializer,
+)
+
 
 class OrganizationFilter(django_filters.FilterSet):
     verified_journalist = django_filters.BooleanFilter()
@@ -19,6 +29,7 @@ class OrganizationFilter(django_filters.FilterSet):
     class Meta:
         model = Organization
         fields = ["verified_journalist"]
+
 
 class OrganizationViewSet(viewsets.ModelViewSet):
     # remove _plan after clients are updated
@@ -30,7 +41,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     lookup_field = "uuid"
     swagger_schema = None
 
-    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter,
+    ]
     filterset_class = OrganizationFilter
     search_fields = ["name"]
     ordering_fields = ["name"]
@@ -44,57 +59,65 @@ class ChargeViewSet(viewsets.ModelViewSet):
     write_scopes = ("write_charge",)
     swagger_schema = None
 
+
 class InvitationViewSet(viewsets.ModelViewSet):
     queryset = Invitation.objects.all()
     serializer_class = InvitationSerializer
     permission_classes = [IsAdminUser]  # restrict to staff users only
     lookup_field = "uuid"
+
     def get_queryset(self):
         user = self.request.user
-        verified_emails = user.emailaddress_set.filter(verified=True).values_list("email", flat=True)
+        verified_emails = user.emailaddress_set.filter(verified=True).values_list(
+            "email", flat=True
+        )
 
         return Invitation.objects.filter(
-            accepted_at__isnull=True,
-            rejected_at__isnull=True
+            accepted_at__isnull=True, rejected_at__isnull=True
         ).filter(
-            Q(user=user) |
-            Q(email__in=verified_emails) |
-            Q(
+            Q(user=user)
+            | Q(email__in=verified_emails)
+            | Q(
                 organization__memberships__user=user,
-                organization__memberships__admin=True
+                organization__memberships__admin=True,
             )
         )
 
-
-    @action(detail=True, methods=["post"], permission_classes=[CanAcceptOrRejectInvitation])
-    def accept(self, request, uuid):
+    @action(
+        detail=True, methods=["post"], permission_classes=[CanAcceptOrRejectInvitation]
+    )
+    def accept(self, request):
         invitation = self.get_object()
         try:
             invitation.accept(user=request.user)
             return Response({"status": "invitation accepted"})
-        except ValueError as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValueError as error:
+            return Response({"detail": str(error)}, status=status.HTTP_400_BAD_REQUEST)
 
-    @action(detail=True, methods=["post"], permission_classes=[CanAcceptOrRejectInvitation])
-    def reject(self, request, uuid):
+    @action(
+        detail=True, methods=["post"], permission_classes=[CanAcceptOrRejectInvitation]
+    )
+    def reject(self, request):
         invitation = self.get_object()
         try:
             invitation.reject()
             return Response({"status": "invitation rejected"})
-        except ValueError as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValueError as error:
+            return Response({"detail": str(error)}, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, methods=["post"], permission_classes=[CanRevokeInvitation])
-    def revoke(self, request, uuid):
-        """ 
-            Used to revoke a request to join an organization by a user
-            or revoke a pending invite sent by an admin
+    def revoke(self, request):
+        """
+        Used to revoke a request to join an organization by a user
+        or revoke a pending invite sent by an admin
         """
         invitation = self.get_object()
         try:
             invitation.reject()
             return Response({"status": "Invitation revoked"})
-        except ValueError as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValueError as error:
+            return Response({"detail": str(error)}, status=status.HTTP_400_BAD_REQUEST)
         else:
-            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN
+            )

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -1,12 +1,24 @@
 # Third Party
-from rest_framework import viewsets
+from django.db.models import Q
+import django_filters
+from rest_framework import viewsets, filters
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+from django_filters.rest_framework import DjangoFilterBackend
 
 # Squarelet
 from squarelet.oidc.permissions import ScopePermission
-from squarelet.organizations.models import Charge, Organization
-from squarelet.organizations.serializers import ChargeSerializer, OrganizationSerializer
+from squarelet.organizations.models import Charge, Organization, Invitation
+from squarelet.organizations.serializers import ChargeSerializer, OrganizationSerializer, InvitationSerializer
+from squarelet.organizations.permissions import CanRevokeInvitation, CanAcceptOrRejectInvitation
 
+class OrganizationFilter(django_filters.FilterSet):
+    verified_journalist = django_filters.BooleanFilter()
+
+    class Meta:
+        model = Organization
+        fields = ["verified_journalist"]
 
 class OrganizationViewSet(viewsets.ModelViewSet):
     # remove _plan after clients are updated
@@ -18,6 +30,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     lookup_field = "uuid"
     swagger_schema = None
 
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_class = OrganizationFilter
+    search_fields = ["name"]
+    ordering_fields = ["name"]
+
 
 class ChargeViewSet(viewsets.ModelViewSet):
     queryset = Charge.objects.all()
@@ -26,3 +43,58 @@ class ChargeViewSet(viewsets.ModelViewSet):
     read_scopes = ("read_charge",)
     write_scopes = ("write_charge",)
     swagger_schema = None
+
+class InvitationViewSet(viewsets.ModelViewSet):
+    queryset = Invitation.objects.all()
+    serializer_class = InvitationSerializer
+    permission_classes = [IsAdminUser]  # restrict to staff users only
+    lookup_field = "uuid"
+    def get_queryset(self):
+        user = self.request.user
+        verified_emails = user.emailaddress_set.filter(verified=True).values_list("email", flat=True)
+
+        return Invitation.objects.filter(
+            accepted_at__isnull=True,
+            rejected_at__isnull=True
+        ).filter(
+            Q(user=user) |
+            Q(email__in=verified_emails) |
+            Q(
+                organization__memberships__user=user,
+                organization__memberships__admin=True
+            )
+        )
+
+
+    @action(detail=True, methods=["post"], permission_classes=[CanAcceptOrRejectInvitation])
+    def accept(self, request, uuid):
+        invitation = self.get_object()
+        try:
+            invitation.accept(user=request.user)
+            return Response({"status": "invitation accepted"})
+        except ValueError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=["post"], permission_classes=[CanAcceptOrRejectInvitation])
+    def reject(self, request, uuid):
+        invitation = self.get_object()
+        try:
+            invitation.reject()
+            return Response({"status": "invitation rejected"})
+        except ValueError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=["post"], permission_classes=[CanRevokeInvitation])
+    def revoke(self, request, uuid):
+        """ 
+            Used to revoke a request to join an organization by a user
+            or revoke a pending invite sent by an admin
+        """
+        invitation = self.get_object()
+        try:
+            invitation.reject()
+            return Response({"status": "Invitation revoked"})
+        except ValueError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Before I spend some time writing tests for this, I want to see if this looks good so far. Under the hood a revoke is just a reject, but I wanted to provide a different response for a revoke to assist in debugging in the future. This PR has changes that would close out everything in https://github.com/MuckRock/squarelet/issues/295
except 
- List invited members. This can be added in by finding user IDs by their associated emails from the invites, but in the case of a user that isn't yet created I wasn't sure how to handle this. 

Here is some further background for my thought process here

Admin should view both invitations they have sent for the orgs they are admins of (request=False) and users who have requested to join their org(request=True). For invitations they have sent out- they can only revoke the invitation. It doesn't make sense to me to call it a "reject" because it isn't something they are responding too, even though they are functionally the same. For invitations that were sent to the admin (request=True), they can accept/reject. As well as any requests to join  a different org they aren't an admin of. 

For the regular user- they can see both invitations they have received (by email, request=False) which they can accept/reject and requests for invites they have sent (request=True), which they can only revoke(withdraw). They cannot accept their own request to join.

List() will automatically filter based only on the invitations that have not yet been accepted or rejected (thus they are open).

The endpoint will only be visible on /api/ for staff users