### PR TITLE
Adds FAQ links to sign-in and onboarding pages

### DIFF
--- a/squarelet/templates/account/onboarding/confirm_email.html
+++ b/squarelet/templates/account/onboarding/confirm_email.html
@@ -69,5 +69,5 @@
     <input type="hidden" name="step" value="confirm_email" />
     <button class="button primary" type="submit">Continue{% if service %} to {{service.name}}{% endif %}</button>
   </div>
-    <a class="small inline button primary ghost" href="">{% trans "Why do I need to verify my email?" %}</a>
+    <a class="small inline button primary ghost" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1caf889269638080b222ebe360ffa1d9">{% trans "Why do I need to confirm my email?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/confirm_email.html
+++ b/squarelet/templates/account/onboarding/confirm_email.html
@@ -69,5 +69,5 @@
     <input type="hidden" name="step" value="confirm_email" />
     <button class="button primary" type="submit">Continue{% if service %} to {{service.name}}{% endif %}</button>
   </div>
-    <a class="small inline button primary ghost" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1caf889269638080b222ebe360ffa1d9">{% trans "Why do I need to confirm my email?" %}</a>
+    <a class="small inline button primary ghost" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1caf889269638080b222ebe360ffa1d9">{% trans "Why do I need to confirm my email?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/mfa_opt_in.html
+++ b/squarelet/templates/account/onboarding/mfa_opt_in.html
@@ -60,5 +60,5 @@
     <button class="button primary" type="submit" name="enable_mfa" value="yes">{% trans "Enable Two-Factor Authentication" %}</button>
     <button class="button primary ghost" type="submit" name="enable_mfa" value="skip">{% trans "Skip" %}</button>
   </form>
-  <a class="help link" target="_blank" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
+  <a class="help link" target="_blank" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/mfa_opt_in.html
+++ b/squarelet/templates/account/onboarding/mfa_opt_in.html
@@ -60,5 +60,5 @@
     <button class="button primary" type="submit" name="enable_mfa" value="yes">{% trans "Enable Two-Factor Authentication" %}</button>
     <button class="button primary ghost" type="submit" name="enable_mfa" value="skip">{% trans "Skip" %}</button>
   </form>
-  <a class="help link" target="_blank" href="">{% trans "What is two-factor authentication?" %}</a>
+  <a class="help link" target="_blank" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/mfa_setup.html
+++ b/squarelet/templates/account/onboarding/mfa_setup.html
@@ -96,5 +96,5 @@
     <button class="button primary" type="submit" name="mfa_setup" value="code">{% trans "Submit" %}</button>
     <button class="button primary ghost" type="submit" name="mfa_setup" value="skip">{% trans "Skip" %}</button>
   </form>
-  <a class="help link" target="_blank" href="">{% trans "What is two-factor authentication?" %}</a>
+  <a class="help link" target="_blank" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/mfa_setup.html
+++ b/squarelet/templates/account/onboarding/mfa_setup.html
@@ -96,5 +96,5 @@
     <button class="button primary" type="submit" name="mfa_setup" value="code">{% trans "Submit" %}</button>
     <button class="button primary ghost" type="submit" name="mfa_setup" value="skip">{% trans "Skip" %}</button>
   </form>
-  <a class="help link" target="_blank" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
+  <a class="help link" target="_blank" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
 {% endblock %}

--- a/squarelet/templates/templatetags/sign_up_message.html
+++ b/squarelet/templates/templatetags/sign_up_message.html
@@ -10,5 +10,5 @@
 
 <div>
   <h2>{{ header }}</h2>
-  <a class="help link" href="">What is a MuckRock account?</a>
+  <a class="help link" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380a1b918e94ec25d62b2">What is a MuckRock account?</a>
 </div>

--- a/squarelet/templates/templatetags/sign_up_message.html
+++ b/squarelet/templates/templatetags/sign_up_message.html
@@ -10,5 +10,5 @@
 
 <div>
   <h2>{{ header }}</h2>
-  <a class="help link" href="https://www.notion.so/muckrock/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380a1b918e94ec25d62b2">What is a MuckRock account?</a>
+  <a class="help link" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380a1b918e94ec25d62b2">What is a MuckRock account?</a>
 </div>


### PR DESCRIPTION
Fixes #315 

Since the URLs use our `help.muckrock.com` domain, they will 404 until the FAQ is published. To test that they resolve correctly, replace `help.muckrock.com` with `www.notion.so/muckrock` while signed into Notion.