### PR TITLE
2fa fixes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -355,6 +355,7 @@ ACCOUNT_AUTHENTICATION_METHOD = "username_email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = "optional"
 ACCOUNT_ADAPTER = "squarelet.users.adapters.AccountAdapter"
+ACCOUNT_PREVENT_ENUMERATION = False
 SOCIALACCOUNT_ADAPTER = "squarelet.users.adapters.SocialAccountAdapter"
 SOCIALACCOUNT_STORE_TOKENS = True
 ACCOUNT_FORMS = {

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -31,6 +31,12 @@ class AccountAdapter(DefaultAccountAdapter):
     Custom account adapter for allauth
     """
 
+    def can_delete_email(self, email_address):
+        """Do not allow somone to delete their primary email address"""
+        if email_address.primary:
+            return False
+        return super().can_delete_email(email_address)
+
     def is_open_for_signup(self, request):
         return getattr(settings, "ACCOUNT_ALLOW_REGISTRATION", True)
 

--- a/squarelet/users/apps.py
+++ b/squarelet/users/apps.py
@@ -35,4 +35,9 @@ class UsersConfig(AppConfig):
         from allauth.account import signals as account_signals
         from allauth.mfa import signals as mfa_signals
 
+        # pylint-disable: protected-access
+        # We are disconnecting the built in signal for MFA here, as it prevents
+        # adding an email address if you have MFA turned on.  We have determined
+        # this to be undesirable.
+        # See https://github.com/MuckRock/squarelet/issues/290
         account_signals._add_email.disconnect(mfa_signals.on_add_email)

--- a/squarelet/users/apps.py
+++ b/squarelet/users/apps.py
@@ -31,3 +31,8 @@ class UsersConfig(AppConfig):
         except ProgrammingError:
             # skip if RSA Key is not found for some reason
             pass
+
+        from allauth.account import signals as account_signals
+        from allauth.mfa import signals as mfa_signals
+
+        account_signals._add_email.disconnect(mfa_signals.on_add_email)

--- a/squarelet/users/apps.py
+++ b/squarelet/users/apps.py
@@ -35,9 +35,9 @@ class UsersConfig(AppConfig):
         from allauth.account import signals as account_signals
         from allauth.mfa import signals as mfa_signals
 
-        # pylint-disable: protected-access
         # We are disconnecting the built in signal for MFA here, as it prevents
         # adding an email address if you have MFA turned on.  We have determined
         # this to be undesirable.
         # See https://github.com/MuckRock/squarelet/issues/290
+        # pylint: disable=protected-access
         account_signals._add_email.disconnect(mfa_signals.on_add_email)


### PR DESCRIPTION
Fixes around 2FA and emails

1.   This allows adding emails with 2FA enabled - whether 2FA is enabled or not doesn't affect email hijacking
2.    I tested trying to sign up for an account with 4 different email addresses - all combinations of verified/unverified and primary/secondary - all fail for signing up
3.    I tested adding a secondary email address for the 4 email addresses above - all are allowed to be added (looking at the code this is because we have account enumeration set to false to protect guessing emails, but this does not work well without mandatory verification)
4.    Trying to verify an already verified email fails, trying to verify an email that is not verified in another account succeeds
5.    For some reason, the default logic allows you to delete your primary email if it is your only email address - this seems problematic in general, and seems to be what leads to the issue Sanjin found
6.    Secondary emails can be used to log in

5. I think disallowing deleting of your primary email address is a good idea2/3/4 - I think there are 2 possibilities:
Just disallow 3 - account enumeration already doesn't work (as seen by #.2) - so just disallow adding emails as secondary if someone else has claimed it.  This makes it easier to lock someone out of their email address, but if this is infrequent enough, we can deal with those cases manually.  This also does not address any outstanding emails which are attached to multiple accounts.Require all emails be verified when added.  I think this would resolve the issue, but the problem is we have outstanding accounts with unverified emails, which we risk locking people out of.  We could release with the above fix, then try to give people a heads up that we will be requiring verified emails soon so to double check that their emails are up to date and verified.