### PR TITLE
Add TOS check, tighten similarity check

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -139,7 +139,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "UserAttributeSimilarityValidator",
         "OPTIONS": {
             "user_attributes": ["username", "name", "email"],
-            "max_similarity": 0.5,
+            "max_similarity": 0.6,
         },
     },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -134,6 +134,14 @@ PASSWORD_HASHERS = [
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
 AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation."
+        "UserAttributeSimilarityValidator",
+        "OPTIONS": {
+            "user_attributes": ["username", "name", "email"],
+            "max_similarity": 0.5,
+        },
+    },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -134,11 +134,6 @@ PASSWORD_HASHERS = [
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation."
-        "UserAttributeSimilarityValidator",
-        "OPTIONS": {"user_attributes": ["username", "name", "email"]},
-    },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -136,6 +136,17 @@
             {{ form.password1.help_text }}
           </div>
         </label>
+        <label class="field">
+          <span class="label">
+          {{ form.tos }}
+          {{ form.tos.label }}
+          {% if form.tos.field.required %}<span class="required">Required</span>{% endif %}
+          </span>
+          {{ form.tos.errors }}
+          <div class="help text">
+          {{ form.tos.help_text }}
+          </div>
+        </label>
       </main>
 
       <footer>

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -139,7 +139,7 @@
         <label class="field">
           <span class="label">
           {{ form.tos }}
-          {{ form.tos.label }}
+          <span>I accept MuckRock&rsquo;s <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/tos/">Terms of Service</a> and <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/privacy-policy/">Privacy Policy</a>.</span>
           {% if form.tos.field.required %}<span class="required">Required</span>{% endif %}
           </span>
           {{ form.tos.errors }}

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -144,7 +144,7 @@
           </span>
           {{ form.tos.errors }}
           <div class="help text">
-          {{ form.tos.help_text }}
+            <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/tos/">{{ form.tos.help_text }}</a>
           </div>
         </label>
       </main>

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -143,9 +143,6 @@
           {% if form.tos.field.required %}<span class="required">Required</span>{% endif %}
           </span>
           {{ form.tos.errors }}
-          <div class="help text">
-            <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/tos/">{{ form.tos.help_text }}</a>
-          </div>
         </label>
       </main>
 

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -40,6 +40,13 @@ class SignupForm(allauth.SignupForm):
     )
     organization_name = forms.CharField(max_length=255, required=False)
 
+    tos = forms.BooleanField(
+        required=True,
+        widget=forms.CheckboxInput(),
+        label="Terms of service",
+        help_text="You must agree to MuckRock's terms of service",
+    )
+
     def __init__(self, *args, **kwargs):
         # set free to blank in case people have old links
         if "data" in kwargs and kwargs["data"].get("plan") == "free":
@@ -54,6 +61,7 @@ class SignupForm(allauth.SignupForm):
             Field("username"),
             Field("email", type="email"),
             Field("password1", type="password", css_class="_cls-passwordInput"),
+            Field("tos", type="checkbox"),
         )
         self.fields["username"].widget.attrs.pop("autofocus", None)
         self.helper.form_tag = False

--- a/squarelet/users/tests/test_forms.py
+++ b/squarelet/users/tests/test_forms.py
@@ -22,6 +22,7 @@ def test_clean_good(plan_factory):
         "password1": "squarelet",
         "stripe_pk": "key",
         "plan": plan.slug,
+        "tos": True,
     }
     form = forms.SignupForm(data)
     assert form.is_valid()
@@ -37,6 +38,7 @@ def test_clean_bad_no_pay(professional_plan_factory, mocker):
         "email": "doe@example.com",
         "password1": "squarelet",
         "plan": "professional",
+        "tos": True,
     }
     form = forms.SignupForm(data)
     assert form.is_valid()
@@ -52,6 +54,7 @@ def test_clean_bad_no_org_name(organization_plan_factory, mocker):
         "email": "doe@example.com",
         "password1": "squarelet",
         "plan": "organization",
+        "tos": True,
     }
     form = forms.SignupForm(data)
     assert form.is_valid()
@@ -67,6 +70,7 @@ def test_save(rf, plan_factory):
         "password1": "squarelet",
         "stripe_pk": "key",
         "plan": plan.slug,
+        "tos": True,
     }
     request = rf.post("/accounts/signup/", data)
     request.session = MagicMock()
@@ -94,6 +98,7 @@ def test_save_org(rf, plan_factory, organization_plan_factory, mocker):
         "stripe_token": "token",
         "plan": "organization",
         "organization_name": "my organization",
+        "tos": True,
     }
     request = rf.post("/accounts/signup/", data)
     request.session = {}  # MagicMock()


### PR DESCRIPTION
Closes #309 

This is actually removing one of our password validators, so we should decide if this is what we want. Alternately, we can make it check against the full name field.

The TOS field is only on the signup form. We don't store anything, but anyone who creates an account will have to check the box that they agree to it.