### PR TITLE
Handle subscription errors in `PremiumSubscriptionForm`

### DIFF
--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -267,17 +267,22 @@ class PremiumSubscriptionForm(StripeForm):
                         organization.receipt_emails.create(email=email)
         try:
             organization.create_subscription(stripe_token, plan, user)
+            return True
         except stripe.error.StripeError as exc:
             logger.error("Error updating subscription: %s", exc)
-            raise forms.ValidationError(
+            self.add_error(
+                None,
                 _("Error processing payment. Please try again or contact support.")
             )
+            return False
         except errors.lookup(UNIQUE_VIOLATION) as exc:
             # Organizations can only have one subscription
             logger.error("Error creating subscription: %s", exc)
-            raise forms.ValidationError(
+            self.add_error(
+                None,
                 _("This organization already has a subscription.")
             )
+            return False
 
 
 class AddEmailForm(allauth.AddEmailForm):

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -272,16 +272,13 @@ class PremiumSubscriptionForm(StripeForm):
             logger.error("Error updating subscription: %s", exc)
             self.add_error(
                 None,
-                _("Error processing payment. Please try again or contact support.")
+                _("Error processing payment. Please try again or contact support."),
             )
             return False
         except errors.lookup(UNIQUE_VIOLATION) as exc:
             # Organizations can only have one subscription
             logger.error("Error creating subscription: %s", exc)
-            self.add_error(
-                None,
-                _("This organization already has a subscription.")
-            )
+            self.add_error(None, _("This organization already has a subscription."))
             return False
 
 

--- a/squarelet/users/tests/test_forms.py
+++ b/squarelet/users/tests/test_forms.py
@@ -396,7 +396,7 @@ def test_premium_subscription_form_save_new_organization(plan_factory, user, moc
 
     assert form.save(user)
 
-    # Since we're mocking Organization.objects.create, we don't directly test 
+    # Since we're mocking Organization.objects.create, we don't directly test
     # the database. Instead, check that it was called with the right parameters.
     org_create_mock.assert_called_once_with(name="New Test Organization", private=False)
     add_creator_mock.assert_called_once_with(user)

--- a/squarelet/users/tests/test_forms.py
+++ b/squarelet/users/tests/test_forms.py
@@ -205,7 +205,9 @@ def test_premium_subscription_form_clean_missing_stripe_token(plan_factory, user
         "stripe_pk": "pk_test_123",
     }
 
-    form = forms.PremiumSubscriptionForm(data, plan=plan)
+    form = forms.PremiumSubscriptionForm(
+        data, plan=plan, user=user
+    )  # Added user parameter
     assert not form.is_valid()
     assert "stripe_token" in form.errors
 
@@ -255,11 +257,10 @@ def test_premium_subscription_form_save_stripe_error(plan_factory, user, mocker)
     if not form.is_valid():
         print("Form errors:", form.errors)
     assert form.is_valid()
-
-    with pytest.raises(ValidationError) as excinfo:
-        form.save(user)
-
-    assert "Error processing payment" in str(excinfo.value)
+    assert form.save(user) is False
+    assert form.errors == {
+        "__all__": ["Error processing payment. Please try again or contact support."]
+    }
 
 
 @pytest.mark.django_db
@@ -307,8 +308,11 @@ def test_premium_subscription_form_init_with_professional_plan(
 
 
 @pytest.mark.django_db
-def test_premium_subscription_form_clean_receipt_emails_valid(plan_factory):
+def test_premium_subscription_form_clean_receipt_emails_valid(
+    plan_factory, user_factory
+):
     """Test valid receipt emails validation"""
+    user = user_factory()  # Create a user to pass to the form
     plan = plan_factory(slug="professional")
     data = {
         "organization": "new",
@@ -319,7 +323,9 @@ def test_premium_subscription_form_clean_receipt_emails_valid(plan_factory):
         "receipt_emails": "test@example.com, another@test.com",
     }
 
-    form = forms.PremiumSubscriptionForm(data, plan=plan)
+    form = forms.PremiumSubscriptionForm(
+        data, plan=plan, user=user
+    )  # Added user parameter
     assert form.is_valid()
     cleaned_emails = form.cleaned_data.get("receipt_emails")
 
@@ -357,6 +363,13 @@ def test_premium_subscription_form_clean_new_org_missing_name():
 def test_premium_subscription_form_save_new_organization(plan_factory, user, mocker):
     """Test creating a new organization during subscription"""
     plan = plan_factory(slug="professional")
+    # Create a real organization and then mock the subscription creation
+    # to avoid testing stripe functionality
+    org_create_mock = mocker.patch(
+        "squarelet.organizations.models.Organization.objects.create",
+        return_value=Organization(name="New Test Organization"),
+    )
+
     create_sub_mock = mocker.patch.object(
         Organization, "create_subscription", return_value=None
     )
@@ -372,20 +385,21 @@ def test_premium_subscription_form_save_new_organization(plan_factory, user, moc
 
     form = forms.PremiumSubscriptionForm(data, plan=plan, user=user)
     assert form.is_valid(), f"Form errors: {form.errors}"
-    form.save(user)
 
-    # Check that a new organization was created
-    assert Organization.objects.filter(name="New Test Organization").exists()
-    new_org = Organization.objects.get(name="New Test Organization")
+    # Mock the add_creator method too
+    add_creator_mock = mocker.patch.object(
+        Organization, "add_creator", return_value=None
+    )
+    # Mock receipt_emails functionality
+    receipt_emails_mock = mocker.patch.object(Organization, "receipt_emails")
+    receipt_emails_mock.filter.return_value.exists.return_value = True
 
-    # Check that user was added as admin
-    assert new_org.has_admin(user)
+    assert form.save(user)
 
-    # Check that receipt emails were added
-    assert new_org.receipt_emails.filter(email="billing@example.com").exists()
-    assert new_org.receipt_emails.filter(email="finance@example.com").exists()
-
-    # Check subscription was created
+    # Since we're mocking Organization.objects.create, we don't directly test 
+    # the database. Instead, check that it was called with the right parameters.
+    org_create_mock.assert_called_once_with(name="New Test Organization", private=False)
+    add_creator_mock.assert_called_once_with(user)
     create_sub_mock.assert_called_once_with("tok_visa", plan, user)
 
 
@@ -414,8 +428,5 @@ def test_premium_subscription_form_save_unique_violation(plan_factory, user, moc
 
     form = forms.PremiumSubscriptionForm(data, plan=plan, user=user)
     assert form.is_valid()
-
-    with pytest.raises(ValidationError) as excinfo:
-        form.save(user)
-
-    assert "already has a subscription" in str(excinfo.value)
+    assert form.save(user) is False
+    assert form.errors == {"__all__": ["This organization already has a subscription."]}

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -440,9 +440,8 @@ class UserOnboardingView(TemplateView):
             org_id = request.POST.get("organization")
             plan = Plan.objects.get(pk=plan_id)
             form = PremiumSubscriptionForm(request.POST, plan=plan, user=request.user)
-            if form.is_valid():
+            if form.is_valid() and form.save(request.user):
                 # Create a subscription for the selected organization
-                form.save(request.user)
                 messages.success(request, "Subscription created successfully.")
                 request.session["onboarding"]["subscription"] = "completed"
                 request.session.modified = True


### PR DESCRIPTION
When creating an organization subscription fails, the user gets a 500 error. This handles the situation when saving the premium form, and 

## Test Steps

1. Try subscribing to a premium plan [using a test card that will be declined](https://docs.stripe.com/testing?testing-method=card-numbers#declined-payments).
2. Check that the page reloads with an error message on the form.
3. Try creating a new organization and submitting the form with a declined card. The organization should be created even if the form fails to save, and then it should be available in the organization selection when rerendered.
4. Make sure the subscription still works when using a working card (`4242 4242 4242 4242`)