### PR TITLE
Tests and refactors `UserOnboardingView`

### DIFF
--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -1,4 +1,5 @@
 # Django
+from django.utils import timezone
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http.response import Http404
@@ -14,6 +15,7 @@ import pytest
 
 # Squarelet
 from squarelet.core.tests.mixins import ViewTestMixin
+from squarelet.organizations.models.payment import Plan
 from squarelet.users import views
 
 # pylint: disable=invalid-name
@@ -211,3 +213,1357 @@ class TestReceipts(ViewTestMixin):
         charge_factory(organization=organization)
         response = self.call_view(rf, user)
         assert response.status_code == 200
+
+
+@pytest.mark.django_db()
+class TestUserOnboardingView(ViewTestMixin):
+    """Test the User Onboarding view"""
+
+    view = views.UserOnboardingView
+    url = "/accounts/onboard/"
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock session with onboarding defaults"""
+        return {
+            "onboarding": {
+                "email_check_completed": False,
+                "mfa_step": "not_started",
+                "join_org": False,
+                "subscription": "not_started",
+            }
+        }
+
+    @pytest.fixture
+    def subscription_plans(self, mocker):
+        """Mock subscription plans"""
+        individual_plan = mocker.MagicMock()
+        individual_plan.slug = "professional"
+        individual_plan.name = "Professional"
+        individual_plan.pk = 1
+        
+        group_plan = mocker.MagicMock()
+        group_plan.slug = "organization"
+        group_plan.name = "Organization"
+        group_plan.pk = 2
+        
+        # Mock Plan.objects.get to handle both slug and pk lookups
+        def get_plan(slug=None, pk=None, **kwargs):
+            # Handle pk lookup
+            if pk == '1' or pk == 1:
+                return individual_plan
+            elif pk == '2' or pk == 2:
+                return group_plan
+            # Handle slug lookup
+            elif slug == "professional":
+                return individual_plan
+            elif slug == "organization":
+                return group_plan
+            else:
+                raise views.Plan.DoesNotExist()
+        
+        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=get_plan)
+        return {"individual": individual_plan, "group": group_plan}
+
+    @pytest.fixture
+    def mock_django_session(self, mocker):
+        """Create a mock Django session that behaves like the real thing"""  
+        class MockSession(dict):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.modified = False
+        
+        return MockSession
+
+    # ===== HELPER METHODS =====
+
+    def _mock_user_state(self, mocker, user, **kwargs):
+        """Mock common user state properties with sensible defaults"""
+        defaults = {
+            'has_verified_email': True,
+            'has_organizations': True,
+            'has_active_subscription': False,
+            'is_mfa_enabled': True,
+            'has_invitations': False,
+            'has_unverified_emails': False,
+        }
+        defaults.update(kwargs)
+        
+        # Mock email verification
+        mocker.patch('squarelet.users.views.has_verified_email', return_value=defaults['has_verified_email'])
+        
+        # Mock organizations
+        mock_org_queryset = mocker.MagicMock()
+        mock_org_queryset.exists.return_value = defaults['has_organizations']
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
+        
+        # Mock subscription status
+        if hasattr(user, 'individual_organization'):
+            mocker.patch.object(user.individual_organization, 'has_active_subscription', 
+                               return_value=defaults['has_active_subscription'])
+        
+        # Mock MFA status
+        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=defaults['is_mfa_enabled'])
+        
+        # Mock invitations
+        if defaults['has_invitations']:
+            mock_invitation = mocker.MagicMock()
+            mocker.patch.object(user, 'get_pending_invitations', return_value=[mock_invitation])
+        else:
+            mocker.patch.object(user, 'get_pending_invitations', return_value=[])
+        
+        # Mock potential organizations
+        mock_potential_queryset = mocker.MagicMock()
+        mock_potential_queryset.filter.return_value = []
+        mocker.patch.object(user, 'get_potential_organizations', return_value=mock_potential_queryset)
+        
+        # Mock unverified emails
+        mock_email_queryset = mocker.MagicMock()
+        mock_email_queryset.exists.return_value = defaults['has_unverified_emails']
+        mocker.patch('squarelet.users.views.EmailAddress.objects.filter', return_value=mock_email_queryset)
+        
+        # Set user attributes
+        if not hasattr(user, 'last_mfa_prompt'):
+            user.last_mfa_prompt = None
+
+    def _mock_messages(self, mocker):
+        """Mock Django messages framework to avoid middleware issues"""
+        mocker.patch('squarelet.users.views.messages.info')
+        mocker.patch('squarelet.users.views.messages.success')
+        mocker.patch('squarelet.users.views.messages.error')
+
+    def _mock_mfa_forms(self, mocker, valid=True):
+        """Mock MFA-related forms"""
+        mock_form = mocker.MagicMock()
+        mock_form.is_valid.return_value = valid
+        mock_form.secret = "test_secret"
+        mocker.patch('squarelet.users.views.ActivateTOTPForm', return_value=mock_form)
+        
+        if valid:
+            mocker.patch('squarelet.users.views.activate_totp')
+        
+        # Mock adapter for TOTP
+        mock_adapter = mocker.MagicMock()
+        mock_adapter.build_totp_url.return_value = "otpauth://test"
+        mock_adapter.build_totp_svg.return_value = "<svg>test</svg>"
+        mocker.patch('squarelet.users.views.get_adapter', return_value=mock_adapter)
+        mocker.patch('squarelet.users.views.base64.b64encode', return_value=b'dGVzdA==')
+        
+        return mock_form
+
+    def _mock_subscription_forms(self, mocker, valid=True):
+        """Mock subscription-related forms"""
+        mock_form = mocker.MagicMock()
+        mock_form.is_valid.return_value = valid
+        mock_form.save.return_value = valid
+        
+        mock_individual_form = mocker.MagicMock()
+        mock_group_form = mocker.MagicMock()
+        
+        if valid:
+            mocker.patch('squarelet.users.views.PremiumSubscriptionForm', return_value=mock_form)
+        else:
+            # For invalid forms, we need to handle context rendering
+            mocker.patch('squarelet.users.views.PremiumSubscriptionForm', side_effect=[
+                mock_form,  # First call for validation
+                mock_individual_form,  # Second call for individual form in context
+                mock_group_form  # Third call for group form in context
+            ])
+        
+        return mock_form, mock_individual_form, mock_group_form
+
+    def _create_get_request(self, rf, user, mock_django_session, session_data=None, params=None):
+        """Create a GET request with common setup"""
+        request = rf.get(self.url, params or {})
+        request.user = user
+        request.session = mock_django_session(session_data or {})
+        return request
+
+    def _create_post_request(self, rf, user, mock_django_session, data, session_data=None):
+        """Create a POST request with common setup"""
+        request = rf.post(self.url, data)
+        request.user = user
+        request.session = mock_django_session(session_data or {})
+        return request
+
+    def _get_onboarding_step(self, request, mocker):
+        """Get onboarding step with common mocking"""
+        self._mock_messages(mocker)
+        view = self.view()
+        return view.get_onboarding_step(request)
+
+    def _call_view_get(self, request, mocker, mock_email_send=True):
+        """Call view GET with common mocking"""
+        self._mock_messages(mocker)
+        if mock_email_send:
+            mocker.patch('squarelet.users.views.send_email_confirmation')
+        view_instance = self.view.as_view()
+        return view_instance(request)
+
+    def _call_view_post(self, request, mocker):
+        """Call view POST with common mocking"""
+        self._mock_messages(mocker)
+        view_instance = self.view.as_view()
+        return view_instance(request)
+
+    def _assert_step(self, step, expected_step, context=None, expected_context_keys=None):
+        """Assert onboarding step and context"""
+        assert step == expected_step
+        if expected_context_keys:
+            for key in expected_context_keys:
+                assert key in context
+
+    def _assert_session_updated(self, session, key, expected_value):
+        """Assert session was updated correctly"""
+        if isinstance(key, str):
+            assert session["onboarding"][key] == expected_value
+        else:  # key is a dict for multiple updates
+            for k, v in key.items():
+                assert session["onboarding"][k] == v
+        assert session.modified is True
+
+    def _assert_redirect_to_onboard(self, response):
+        """Assert redirect back to onboarding"""
+        assert response.status_code == 302
+        assert response.url == "/accounts/onboard/"
+
+    def _assert_template(self, response, expected_template):
+        """Assert correct template is used"""
+        assert response.status_code == 200
+        assert response.template_name == [expected_template]
+
+    # ===== STEP LOGIC TESTS =====
+
+    def test_get_onboarding_step_email_unverified(self, rf, user_factory, mocker, mock_django_session):
+        """User with unverified email should get confirm_email step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        self._assert_step(step, "confirm_email", context, ["email"])
+        assert context["email"] == user.email
+
+    def test_get_onboarding_step_email_verified(self, rf, user_factory, mocker, mock_django_session):
+        """User with verified email should skip email step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
+        
+        self._mock_user_state(mocker, user, has_verified_email=True)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # Should skip email step and session should be updated
+        assert request.session["onboarding"]["email_check_completed"] is True
+        assert step is None  # Should complete onboarding
+
+    def test_get_onboarding_step_join_org_with_invitations(self, rf, user_factory, mocker, mock_django_session):
+        """User with pending invitations should get join_org step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "join_org": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        self._assert_step(step, "join_org", context, ["invitations", "potential_orgs", "joinable_orgs_count"])
+        assert len(context["invitations"]) == 1
+        assert context["joinable_orgs_count"] == 1
+
+    def test_get_onboarding_step_join_org_already_has_orgs(self, rf, user_factory, mocker, mock_django_session):
+        """User with existing organizations should skip join_org step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "join_org": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_organizations=True)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step is None  # Should skip join_org and complete onboarding
+
+    def test_get_onboarding_step_subscribe_with_valid_plan(self, rf, user_factory, mocker, mock_django_session):
+        """User with valid plan in session should get subscribe step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        }, {"plan": "professional"})
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        self._assert_step(step, "subscribe", context, ["plans"])
+        assert context["plans"]["selected"].slug == "professional"
+
+    def test_get_onboarding_step_subscribe_already_subscribed(self, rf, user_factory, mocker, mock_django_session):
+        """User already subscribed to professional plan should skip subscribe step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "plan": "professional",
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user, has_active_subscription=True)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # Should mark subscription as completed and clear plan
+        assert request.session["onboarding"]["subscription"] == "completed"
+        assert request.session["plan"] is None
+        assert step is None
+
+    def test_get_onboarding_step_subscribe_invalid_plan(self, rf, user_factory, mocker, mock_django_session):
+        """User with invalid plan should skip subscribe step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "plan": "invalid_plan",
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user)
+        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=views.Plan.DoesNotExist())
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step is None  # Should skip subscribe step
+
+    def test_get_onboarding_step_mfa_opt_in(self, rf, user_factory, mocker, mock_django_session):
+        """User with MFA not started should get mfa_opt_in step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "mfa_opt_in"
+
+    def test_get_onboarding_step_mfa_setup(self, rf, user_factory, mocker, mock_django_session):
+        """User who opted in for MFA should get mfa_setup step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "mfa_setup"
+
+    def test_get_onboarding_step_mfa_confirm(self, rf, user_factory, mocker, mock_django_session):
+        """User who submitted MFA code should get mfa_confirm step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "mfa_step": "code_submitted"}
+        })
+        
+        self._mock_user_state(mocker, user)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "mfa_confirm"
+
+    def test_get_onboarding_step_mfa_already_enabled(self, rf, user_factory, mocker, mock_django_session):
+        """User with MFA already enabled should skip MFA steps"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=True)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # Should mark MFA as completed
+        assert request.session["onboarding"]["mfa_step"] == "completed"
+        assert step is None
+
+    def test_get_onboarding_step_first_login_skips_mfa(self, rf, user_factory, mocker, mock_django_session):
+        """First-time login should skip MFA prompting"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": True,
+            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # Should mark MFA as completed due to first login
+        assert request.session["onboarding"]["mfa_step"] == "completed"
+        assert step is None
+
+    def test_get_onboarding_step_session_initialization(self, rf, user_factory, mocker, mock_django_session):
+        """Should initialize onboarding session if it doesn't exist"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {})  # No onboarding session
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # Should initialize session with defaults
+        assert "onboarding" in request.session
+        onboarding = request.session["onboarding"]
+        assert onboarding["email_check_completed"] is False
+        assert onboarding["mfa_step"] == "not_started"
+        assert onboarding["join_org"] is False
+        assert onboarding["subscription"] == "not_started"
+
+    def test_get_onboarding_step_complete_flow(self, rf, user_factory, mocker, mock_django_session):
+        """User who completed all steps should return None"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {
+                "email_check_completed": True,
+                "mfa_step": "completed",
+                "join_org": True,
+                "subscription": "completed",
+            }
+        })
+        
+        self._mock_user_state(mocker, user)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step is None
+        assert context == {}
+
+    # ===== TEMPLATE TESTS =====
+
+    def test_get_template_names_confirm_email(self, rf, user_factory, mocker, mock_django_session):
+        """Should return confirm_email template for email confirmation step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        view = self.view()
+        view.request = request
+        template_names = view.get_template_names()
+        
+        assert template_names == ["account/onboarding/confirm_email.html"]
+
+    def test_get_template_names_join_org(self, rf, user_factory, mocker, mock_django_session):
+        """Should return join_org template for organization joining step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "join_org": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
+        
+        view = self.view()
+        view.request = request
+        template_names = view.get_template_names()
+        
+        assert template_names == ["account/onboarding/join_org.html"]
+
+    def test_get_template_names_subscribe(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """Should return subscribe template for subscription step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        }, {"plan": "professional"})
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        
+        view = self.view()
+        view.request = request
+        template_names = view.get_template_names()
+        
+        assert template_names == ["account/onboarding/subscribe.html"]
+
+    @pytest.mark.parametrize("mfa_step,expected_template", [
+        ("not_started", "account/onboarding/mfa_opt_in.html"),
+        ("opted_in", "account/onboarding/mfa_setup.html"),
+        ("code_submitted", "account/onboarding/mfa_confirm.html"),
+        ("completed", "account/onboarding/base.html")
+    ])
+    def test_mfa_templates(self, rf, user_factory, mocker, mock_django_session, mfa_step, expected_template):
+        """Should return mfa_opt_in template for MFA opt-in step"""
+        user = user_factory()
+        session_data = {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": mfa_step}
+        }
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        view = self.view()
+        view.request = request
+        template_names = view.get_template_names()
+        
+        assert template_names == [expected_template]
+
+    # ===== CONTEXT DATA TESTS =====
+
+    def test_get_context_data_base_context(self, rf, user_factory, mocker, mock_django_session):
+        """Should include base context data for all steps"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "next_url": "/target/url/",
+            "intent": "muckrock",
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        # Mock service lookup
+        mock_service = mocker.MagicMock()
+        mock_service.slug = "muckrock"
+        mocker.patch('squarelet.users.views.Service.objects.filter').return_value.first.return_value = mock_service
+        
+        view = self.view()
+        view.request = request
+        context = view.get_context_data()
+        
+        assert context["onboarding_step"] == "confirm_email"
+        assert context["next_url"] == "/target/url/"
+        assert context["intent"] == "muckrock"
+        assert context["service"] == mock_service
+        assert context["email"] == user.email
+
+    def test_get_context_data_subscribe_step(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """Should include subscription forms and organizations for subscribe step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        }, {"plan": "professional"})
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        
+        # Mock forms
+        mock_individual_form, mock_group_form, _ = self._mock_subscription_forms(mocker, valid=True)
+        
+        # Mock user organizations queryset
+        mock_group_orgs = mocker.MagicMock()
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_group_orgs)
+        mock_group_orgs.order_by.return_value = mock_group_orgs
+        
+        view = self.view()
+        view.request = request
+        context = view.get_context_data()
+        
+        assert context["onboarding_step"] == "subscribe"
+        assert "forms" in context
+        assert context["individual_org"] == user.individual_organization
+        assert "group_orgs" in context
+
+    def test_get_context_data_mfa_setup_step(self, rf, user_factory, mocker, mock_django_session):
+        """Should include MFA form and TOTP data for MFA setup step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        mock_form = self._mock_mfa_forms(mocker)
+        
+        view = self.view()
+        view.request = request
+        context = view.get_context_data()
+        
+        assert context["onboarding_step"] == "mfa_setup"
+        assert context["form"] == mock_form
+        assert context["totp_svg"] == "<svg>test</svg>"
+        assert context["totp_svg_data_uri"] == "data:image/svg+xml;base64,dGVzdA=="
+        assert context["totp_url"] == "otpauth://test"
+
+    def test_get_context_data_join_org_step(self, rf, user_factory, mocker, mock_django_session):
+        """Should include invitation and potential org data for join_org step"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "join_org": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
+        
+        view = self.view()
+        view.request = request
+        context = view.get_context_data()
+        
+        assert context["onboarding_step"] == "join_org"
+        assert len(context["invitations"]) == 1
+        assert context["potential_orgs"] == []
+        assert context["joinable_orgs_count"] == 1
+
+    def test_get_context_data_no_step_context(self, rf, user_factory, mocker, mock_django_session):
+        """Should not include step-specific context for steps that don't need it"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "mfa_step": "code_submitted"}
+        })
+        
+        self._mock_user_state(mocker, user)
+        
+        view = self.view()
+        view.request = request
+        context = view.get_context_data()
+        
+        assert context["onboarding_step"] == "mfa_confirm"
+        # Should not have forms, TOTP data, or other step-specific context
+        assert "forms" not in context
+        assert "totp_svg" not in context
+        assert "invitations" not in context
+
+    # ===== HTTP METHOD TESTS =====
+
+    def test_get_unauthenticated_user(self, rf):
+        """Unauthenticated user should be redirected to login"""
+        request = rf.get(self.url)
+        request.user = AnonymousUser()
+        request.session = {}
+        
+        view = self.view.as_view()
+        response = view(request)
+        
+        assert response.status_code == 302
+        assert "/accounts/login/" in response.url
+
+    def test_get_confirm_email_sends_email_except_first_login(self, rf, user_factory, mocker, mock_django_session):
+        """Email confirmation step should send email except on first login"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        mock_send = mocker.patch('squarelet.users.views.send_email_confirmation')
+        
+        response = self._call_view_get(request, mocker, mock_email_send=False)
+        
+        assert response.status_code == 200
+        mock_send.assert_called_once_with(request, user, False, user.email)
+
+    def test_get_confirm_email_skips_email_on_first_login(self, rf, user_factory, mocker, mock_django_session):
+        """Email confirmation step should not send email on first login"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": True,
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        mock_send = mocker.patch('squarelet.users.views.send_email_confirmation')
+        
+        response = self._call_view_get(request, mocker, mock_email_send=False)
+        
+        assert response.status_code == 200
+        mock_send.assert_not_called()
+
+    def test_get_completed_onboarding_with_next_url(self, rf, user_factory, mocker, mock_django_session):
+        """Completed onboarding with next_url should redirect to next_url"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "next_url": "/target/page/",
+            "onboarding": {
+                "email_check_completed": True,
+                "mfa_step": "completed",
+                "join_org": True,
+                "subscription": "completed",
+            }
+        })
+        
+        self._mock_user_state(mocker, user)
+        
+        response = self._call_view_get(request, mocker)
+        
+        assert response.status_code == 302
+        assert response.url == "/target/page/"
+
+    def test_get_completed_onboarding_without_next_url(self, rf, user_factory, mocker, mock_django_session):
+        """Completed onboarding without next_url should redirect to user detail"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {
+                "email_check_completed": True,
+                "mfa_step": "completed",
+                "join_org": True,
+                "subscription": "completed",
+            }
+        })
+        
+        self._mock_user_state(mocker, user)
+        
+        response = self._call_view_get(request, mocker)
+        
+        assert response.status_code == 302
+        assert response.url == f"/users/{user.username}/"
+
+    def test_get_renders_correct_template_for_each_step(self, rf, user_factory, mocker, mock_django_session):
+        """Each onboarding step should render the correct template"""
+        user = user_factory()
+        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        response = self._call_view_get(request, mocker)
+        
+        assert response.status_code == 200
+        assert response.template_name == ["account/onboarding/confirm_email.html"]
+
+    # ===== POST METHOD TESTS =====
+
+    def test_post_confirm_email_step(self, rf, user_factory, mocker, mock_django_session):
+        """POST to confirm_email step should update session"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "confirm_email"}, {
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "email_check_completed", True)
+
+    def test_post_mfa_opt_in_yes(self, rf, user_factory, mocker, mock_django_session):
+        """POST to mfa_opt_in step with 'yes' should update session"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_opt_in", "enable_mfa": "yes"}, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "mfa_step", "opted_in")
+
+    def test_post_mfa_opt_in_no(self, rf, user_factory, mocker, mock_django_session):
+        """POST to mfa_opt_in step with 'no' should complete MFA and update user"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_opt_in", "choice": "no"}, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        # Mock timezone and user save
+        mock_timezone_now = mocker.patch('squarelet.users.views.timezone.now')
+        mock_timezone_now.return_value = "2023-01-01"
+        mock_user_save = mocker.patch.object(user, 'save')
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "mfa_step", "completed")
+        assert user.last_mfa_prompt == "2023-01-01"
+        mock_user_save.assert_called_once()
+
+    def test_post_mfa_setup_valid_code(self, rf, user_factory, mocker, mock_django_session):
+        """POST to mfa_setup step with valid code should activate TOTP"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "123456"}, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        self._mock_mfa_forms(mocker, valid=True)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "mfa_step", "code_submitted")
+
+    def test_post_mfa_setup_invalid_code(self, rf, user_factory, mocker, mock_django_session):
+        """POST to mfa_setup step with invalid code should show errors"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "invalid"}, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        self._mock_mfa_forms(mocker, valid=False)
+        
+        response = self._call_view_post(request, mocker)
+        
+        # Should render template with form errors, not redirect
+        self._assert_template(response, "account/onboarding/mfa_setup.html")
+
+    def test_post_mfa_setup_skip(self, rf, user_factory, mocker, mock_django_session):
+        """POST to mfa_setup step with skip should complete MFA"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "mfa_setup": "skip"}, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        
+        # Mock timezone and user save
+        mock_timezone_now = mocker.patch('squarelet.users.views.timezone.now')
+        mock_timezone_now.return_value = "2023-01-01"
+        mock_user_save = mocker.patch.object(user, 'save')
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "mfa_step", "completed")
+        assert user.last_mfa_prompt == "2023-01-01"
+        mock_user_save.assert_called_once()
+
+    def test_post_mfa_confirm_step(self, rf, user_factory, mocker, mock_django_session):
+        """POST to mfa_confirm step should complete MFA"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_confirm"}, {
+            "onboarding": {"email_check_completed": True, "mfa_step": "code_submitted"}
+        })
+        
+        self._mock_user_state(mocker, user)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "mfa_step", "completed")
+
+    def test_post_subscribe_valid_individual_form(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """POST to subscribe step with valid individual form should process subscription"""
+        user = user_factory()
+        form_data = {
+            "step": "subscribe",
+            "plan": "1",
+            "organization": str(user.individual_organization.pk),
+            "stripe_token": "tok_test123"
+        }
+        request = self._create_post_request(rf, user, mock_django_session, form_data, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"},
+            "plan": "professional"
+        })
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        self._mock_subscription_forms(mocker, valid=True)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "subscription", "completed")
+
+    def test_post_subscribe_invalid_form(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """POST to subscribe step with invalid form should show errors"""
+        user = user_factory()
+        form_data = {
+            "step": "subscribe",
+            "plan": "1",
+            "organization": str(user.individual_organization.pk),
+            "stripe_token": "invalid_token"
+        }
+        request = self._create_post_request(rf, user, mock_django_session, form_data, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"},
+            "plan": "professional"
+        })
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        self._mock_subscription_forms(mocker, valid=False)
+        
+        # Mock user organizations queryset
+        mock_group_orgs = mocker.MagicMock()
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_group_orgs)
+        mock_group_orgs.order_by.return_value = mock_group_orgs
+        
+        response = self._call_view_post(request, mocker)
+        
+        # Should render template with form errors, not redirect
+        self._assert_template(response, "account/onboarding/subscribe.html")
+
+    def test_post_subscribe_skip(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """POST to subscribe step with skip should complete subscription"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "subscribe", "submit-type": "skip"}, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"},
+            "plan": "professional"
+        })
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "subscription", "completed")
+
+    def test_post_join_org_skip(self, rf, user_factory, mocker, mock_django_session):
+        """POST to join_org step with skip should complete join_org"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "join_org", "join_org": "skip"}, {
+            "onboarding": {"email_check_completed": True, "join_org": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "join_org", True)
+
+    def test_post_invalid_step(self, rf, user_factory, mocker, mock_django_session):
+        """POST with invalid step should handle gracefully"""
+        user = user_factory()
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "invalid_step"}, {
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        
+        response = self._call_view_post(request, mocker)
+        
+        # Should redirect back to onboarding (handles invalid step gracefully)
+        self._assert_redirect_to_onboard(response)
+
+    # ===== INTEGRATION TESTS =====
+
+    def test_complete_onboarding_flow_new_user_no_plan(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """Complete onboarding flow for new user without subscription plan"""
+        user = user_factory()
+        
+        # Step 1: Start with empty session (new user)
+        session_data = {}
+        
+        self._mock_user_state(mocker, user, has_verified_email=False, has_organizations=False, 
+                             has_invitations=False, is_mfa_enabled=False)
+        
+        # Step 1: Email confirmation required
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "confirm_email"
+        assert context["email"] == user.email
+        assert request.session["onboarding"]["email_check_completed"] is False
+        
+        # Step 2: Confirm email via POST
+        session_data = request.session
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "confirm_email"}, session_data)
+        
+        # Mock email now verified
+        self._mock_user_state(mocker, user, has_verified_email=False, has_organizations=False, 
+                             has_invitations=False, is_mfa_enabled=False)
+        
+        response = self._call_view_post(request, mocker)
+        assert response.status_code == 302
+        assert request.session["onboarding"]["email_check_completed"] is True
+        
+        # Step 3: Check final state - should be complete
+        session_data = request.session
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        response = self._call_view_get(request, mocker)
+        assert response.url == f"/users/{user.username}/"
+        assert response.status_code == 302
+
+    def test_complete_onboarding_flow_with_professional_plan(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """Complete onboarding flow for user signing up for professional plan"""
+        user = user_factory()
+        
+        # Start with plan in session
+        session_data = {"plan": "professional"}
+        
+        self._mock_user_state(mocker, user, has_verified_email=True, has_active_subscription=False, is_mfa_enabled=False)
+        
+        # Step 1: Should go straight to subscription (email already verified)
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "subscribe"
+        assert context["plans"]["selected"].slug == "professional"
+        assert request.session["onboarding"]["email_check_completed"] is True
+        
+        # Step 2: Complete subscription via POST
+        session_data = request.session
+        form_data = {
+            "step": "subscribe",
+            "plan": "1",
+            "organization": str(user.individual_organization.pk),
+            "stripe_token": "tok_test123"
+        }
+        request = self._create_post_request(rf, user, mock_django_session, form_data, session_data)
+        
+        self._mock_subscription_forms(mocker, valid=True)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "subscription", "completed")
+
+    def test_complete_onboarding_flow_with_organization_invitations(self, rf, user_factory, mocker, mock_django_session):
+        """Complete onboarding flow for user with pending organization invitations"""
+        user = user_factory()
+        
+        # Mock user with verified email, no personal orgs, but has invitations
+        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True, is_mfa_enabled=True)
+        
+        # Step 1: Should go to join_org step
+        request = self._create_get_request(rf, user, mock_django_session, {})
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "join_org"
+        assert len(context["invitations"]) == 1
+        assert context["joinable_orgs_count"] == 1
+        assert request.session["onboarding"]["join_org"] is False
+        
+        # Step 2: Skip organization joining
+        session_data = request.session
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "join_org", "join_org": "skip"}, session_data)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "join_org", True)
+
+        # Step 3: Onboarding complete (MFA already enabled)
+        session_data = request.session
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        
+        response = self._call_view_get(request, mocker)
+        
+        assert response.status_code == 302
+        assert response.url == f"/users/{user.username}/"
+
+    def test_onboarding_flow_interrupted_and_resumed(self, rf, user_factory, mocker, mock_django_session):
+        """User should resume onboarding from where they left off after interruption"""
+        user = user_factory()
+        
+        # Simulate user who started onboarding but didn't complete it
+        # They confirmed email and opted into MFA but didn't complete setup
+        session_data = {
+            "onboarding": {
+                "email_check_completed": True,
+                "mfa_step": "opted_in",  # Stuck at this step
+                "join_org": False,
+                "subscription": "not_started"
+            }
+        }
+        
+        # Mock user state
+        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mock_org_queryset = mocker.MagicMock()
+        mock_org_queryset.exists.return_value = True
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
+        mocker.patch.object(user.individual_organization, 'has_active_subscription', return_value=False)
+        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=False)
+        user.last_mfa_prompt = None
+        
+        # Mock no unverified emails
+        mock_email_queryset = mocker.MagicMock()
+        mock_email_queryset.exists.return_value = False
+        mocker.patch('squarelet.users.views.EmailAddress.objects.filter', return_value=mock_email_queryset)
+        
+        # User returns - should resume at MFA setup step
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        assert step == "mfa_setup"
+        assert request.session["onboarding"]["email_check_completed"] is True  # Preserved
+        assert request.session["onboarding"]["mfa_step"] == "opted_in"  # Preserved
+        
+        # Complete MFA setup to continue flow
+        session_data = request.session
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "123456"}, session_data)
+        
+        mock_form = self._mock_mfa_forms(mocker, valid=True)
+        
+        response = self._call_view_post(request, mocker)
+        
+        self._assert_redirect_to_onboard(response)
+        self._assert_session_updated(request.session, "mfa_step", "code_submitted")
+        
+        # Continue with rest of flow...
+        # [Additional steps would follow the same pattern]
+
+    def test_onboarding_flow_with_next_url_redirect(self, rf, user_factory, mocker, mock_django_session):
+        """Completed onboarding should redirect to next_url from session"""
+        user = user_factory()
+        
+        # Session with target URL
+        session_data = {
+            "next_url": "/target/dashboard/",
+            "intent": "muckrock",
+            "onboarding": {
+                "email_check_completed": True,
+                "mfa_step": "completed",
+                "join_org": True,
+                "subscription": "completed"
+            }
+        }
+        
+        # Mock all steps complete
+        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mock_org_queryset = mocker.MagicMock()
+        mock_org_queryset.exists.return_value = True
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
+        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=True)
+        
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        
+        response = self._call_view_get(request, mocker)
+        
+        # Should redirect to next_url and remove it from session
+        assert response.status_code == 302
+        assert response.url == "/target/dashboard/"
+        assert "next_url" not in request.session
+
+    # ===== EDGE CASE TESTS =====
+
+    def test_malformed_post_data_handling(self, rf, user_factory, mocker, mock_django_session):
+        """Malformed POST data should not crash the application"""
+        user = user_factory()
+        
+        malformed_requests = [
+            {},  # Missing step parameter
+            {"step": "None"},  # Invalid step values
+            {"step": ""},
+            {"step": 12345},
+            {"step": ["invalid", "list"]},
+        ]
+        
+        for malformed_data in malformed_requests:
+            request = self._create_post_request(rf, user, mock_django_session, malformed_data, {
+                "onboarding": {"email_check_completed": True}
+            })
+            
+            # Should handle gracefully and not crash
+            try:
+                response = self._call_view_post(request, mocker)
+                assert response.status_code in [200, 302]  # Either render or redirect
+            except (TypeError, ValueError, AttributeError) as e:
+                pytest.fail(f"Should handle malformed POST data gracefully. Error: {e}, Data: {malformed_data}")
+
+    def test_unauthorized_access_redirects_to_login(self, rf):
+        """Unauthenticated users should be redirected to login"""
+        from django.contrib.auth.models import AnonymousUser
+        
+        # GET request from unauthenticated user
+        request = rf.get(self.url)
+        request.user = AnonymousUser()
+        
+        view_instance = self.view.as_view()
+        response = view_instance(request)
+        
+        assert response.status_code == 302
+        assert response.url == '/accounts/login/'
+
+    def test_email_confirmation_send_on_first_visit(self, rf, user_factory, mocker, mock_django_session):
+        """Email confirmation should be sent automatically on first visit (not first login)"""
+        user = user_factory()
+        
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": False,
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        mock_send_confirmation = mocker.patch('squarelet.users.views.send_email_confirmation')
+        
+        response = self._call_view_get(request, mocker, mock_email_send=False)
+        
+        # Should send email confirmation automatically
+        mock_send_confirmation.assert_called_once_with(request, user, False, user.email)
+        assert response.status_code == 200  # Render confirm_email template
+
+    def test_email_confirmation_not_sent_on_first_login(self, rf, user_factory, mocker, mock_django_session):
+        """Email confirmation should NOT be sent on first login (already sent during signup)"""
+        user = user_factory()
+        
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "first_login": True,
+            "onboarding": {"email_check_completed": False}
+        })
+        
+        self._mock_user_state(mocker, user, has_verified_email=False)
+        mock_send_confirmation = mocker.patch('squarelet.users.views.send_email_confirmation')
+        
+        response = self._call_view_get(request, mocker, mock_email_send=False)
+        
+        # Should NOT send email confirmation (already sent during signup)
+        mock_send_confirmation.assert_not_called()
+        assert response.status_code == 200  # Still render confirm_email template
+
+    def test_mfa_setup_form_validation_errors(self, rf, user_factory, mocker, mock_django_session):
+        """MFA setup with invalid tokens should be handled properly"""
+        user = user_factory()
+        
+        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "invalid"})
+        request.user = user
+        request.session = mock_django_session({
+            "onboarding": {"mfa_step": "opted_in"}
+        })
+        
+        self._mock_user_state(mocker, user, is_mfa_enabled=False)
+        self._mock_mfa_forms(mocker, valid=False)
+        
+        response = self._call_view_post(request, mocker)
+        
+        # Should re-render form with errors, not redirect
+        self._assert_template(response, "account/onboarding/mfa_setup.html")
+
+    # ===== SESSION STATE TESTING =====
+
+    def test_session_initialization_creates_defaults(self, rf, user_factory, mocker, mock_django_session):
+        """Empty session should be initialized with proper defaults"""
+        user = user_factory()
+        request = rf.get(self.url)
+        request.user = user
+        request.session = mock_django_session({})  # Completely empty session
+        
+        # Mock dependencies to trigger session initialization
+        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        
+        view = self.view()
+        step, context = view.get_onboarding_step(request)
+        
+        # Verify session was initialized with correct defaults
+        assert "onboarding" in request.session
+        onboarding = request.session["onboarding"]
+        assert onboarding["email_check_completed"] is True
+        assert onboarding["mfa_step"] == "completed"
+        assert onboarding["join_org"] is False
+        assert onboarding["subscription"] == "not_started"
+        assert request.session.modified is True
+
+    def test_session_initialization_uses_setdefault(self, rf, user_factory, mocker, mock_django_session):
+        """Session initialization should use setdefault to preserve existing values"""
+        user = user_factory()
+        request = rf.get(self.url)
+        request.user = user
+        request.session = mock_django_session({
+            "onboarding": {
+                "email_check_completed": True,  # This should be preserved
+                "mfa_step": "opted_in",          # This should be preserved
+                # Missing join_org and subscription - should get defaults
+            }
+        })
+        
+        # Mock dependencies
+        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mock_org_queryset = mocker.MagicMock()
+        mock_org_queryset.exists.return_value = True
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
+        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=True)
+        
+        view = self.view()
+        step, context = view.get_onboarding_step(request)
+        
+        # Verify setdefault behavior - existing values preserved, missing values get defaults
+        onboarding = request.session["onboarding"]
+        assert onboarding["email_check_completed"] is True    # Preserved
+        assert onboarding["mfa_step"] == "completed"          
+        assert onboarding["join_org"] is False                # Default added
+        assert onboarding["subscription"] == "not_started"    # Default added
+
+    def test_session_email_verification_auto_update(self, rf, user_factory, mocker, mock_django_session):
+        """Session should auto-update email_check_completed when email is verified"""
+        user = user_factory()
+        request = rf.get(self.url)
+        request.user = user
+        request.session = mock_django_session({
+            "onboarding": {
+                "email_check_completed": False  # Start as false
+            }
+        })
+        
+        # Mock has_verified_email to return True (email is actually verified)
+        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mock_org_queryset = mocker.MagicMock()
+        mock_org_queryset.exists.return_value = True
+        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
+        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=True)
+        
+        view = self.view()
+        step, context = view.get_onboarding_step(request)
+        
+        # Should auto-update session when email is verified
+        assert request.session["onboarding"]["email_check_completed"] is True
+        assert request.session.modified is True
+
+    def test_session_plan_persistence_from_get_parameter(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+        """Plan from GET parameter should be used and stored in session"""
+        user = user_factory()
+        
+        # Request with plan parameter
+        request = self._create_get_request(rf, user, mock_django_session, {
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        }, {"plan": "professional"})
+        
+        self._mock_user_state(mocker, user, has_active_subscription=False)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # The view should use the plan from GET parameter
+        assert step == "subscribe"
+        assert context["plans"]["selected"].slug == "professional"
+
+    def test_database_errors_plan_doesnotexist_handling(self, rf, user_factory, mocker, mock_django_session, capsys):
+        """Plan.DoesNotExist errors should be handled gracefully"""
+        user = user_factory()
+        
+        # Session with invalid plan
+        session_data = {
+            "plan": "nonexistent_plan",
+            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+        }
+        
+        self._mock_user_state(mocker, user)
+        
+        # Mock Plan.DoesNotExist for any plan lookup
+        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=Plan.DoesNotExist())
+        
+        request = self._create_get_request(rf, user, mock_django_session, session_data)
+        
+        step, context = self._get_onboarding_step(request, mocker)
+        
+        # Should handle DoesNotExist gracefully and skip subscription step
+        assert step is None  # Onboarding complete, subscription skipped
+        
+        # Should print debug message
+        captured = capsys.readouterr()
+        assert "Invalid plan slug: nonexistent_plan" in captured.out
+
+    def test_plan_database_error_during_subscription_post(self, rf, user_factory, mocker, mock_django_session):
+        """Database errors during subscription POST should be handled"""
+        user = user_factory()
+        
+        form_data = {
+            "step": "subscribe",
+            "plan": "999",  # Non-existent plan ID
+            "organization": str(user.individual_organization.pk),
+            "stripe_token": "tok_test123"
+        }
+        request = self._create_post_request(rf, user, mock_django_session, form_data, {
+            "onboarding": {"subscription": "not_started"}
+        })
+        
+        # Mock Plan.DoesNotExist on pk lookup
+        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=Plan.DoesNotExist())
+
+        mocker.patch('squarelet.users.views.messages.error')
+        
+        view_instance = self.view.as_view()
+        
+        # Should handle gracefully - either catch exception or let it bubble up appropriately
+        try:
+            response = view_instance(request)
+            # If successful, should respond gracefully
+            assert response.status_code == 200
+        except Plan.DoesNotExist:
+            # Current behavior - documents that error handling could be improved
+            pytest.fail("Should handle Plan.DoesNotExist gracefully in POST")
+

--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -1,5 +1,4 @@
 # Django
-from django.utils import timezone
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http.response import Http404
@@ -18,7 +17,7 @@ from squarelet.core.tests.mixins import ViewTestMixin
 from squarelet.organizations.models.payment import Plan
 from squarelet.users import views
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, disable=too-many-lines
 
 
 @pytest.mark.django_db()
@@ -219,6 +218,8 @@ class TestReceipts(ViewTestMixin):
 class TestUserOnboardingView(ViewTestMixin):
     """Test the User Onboarding view"""
 
+    # pylint: disable=too-many-public-methods, disable=unused-argument
+
     view = views.UserOnboardingView
     url = "/accounts/onboard/"
 
@@ -241,18 +242,18 @@ class TestUserOnboardingView(ViewTestMixin):
         individual_plan.slug = "professional"
         individual_plan.name = "Professional"
         individual_plan.pk = 1
-        
+
         group_plan = mocker.MagicMock()
         group_plan.slug = "organization"
         group_plan.name = "Organization"
         group_plan.pk = 2
-        
+
         # Mock Plan.objects.get to handle both slug and pk lookups
         def get_plan(slug=None, pk=None, **kwargs):
             # Handle pk lookup
-            if pk == '1' or pk == 1:
+            if pk in ("1", 1):
                 return individual_plan
-            elif pk == '2' or pk == 2:
+            elif pk in ("2", 2):
                 return group_plan
             # Handle slug lookup
             elif slug == "professional":
@@ -261,18 +262,19 @@ class TestUserOnboardingView(ViewTestMixin):
                 return group_plan
             else:
                 raise views.Plan.DoesNotExist()
-        
-        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=get_plan)
+
+        mocker.patch("squarelet.users.views.Plan.objects.get", side_effect=get_plan)
         return {"individual": individual_plan, "group": group_plan}
 
     @pytest.fixture
-    def mock_django_session(self, mocker):
-        """Create a mock Django session that behaves like the real thing"""  
+    def mock_django_session(self):
+        """Create a mock Django session that behaves like the real thing"""
+
         class MockSession(dict):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.modified = False
-        
+
         return MockSession
 
     # ===== HELPER METHODS =====
@@ -280,76 +282,96 @@ class TestUserOnboardingView(ViewTestMixin):
     def _mock_user_state(self, mocker, user, **kwargs):
         """Mock common user state properties with sensible defaults"""
         defaults = {
-            'has_verified_email': True,
-            'has_organizations': True,
-            'has_active_subscription': False,
-            'is_mfa_enabled': True,
-            'has_invitations': False,
-            'has_unverified_emails': False,
+            "has_verified_email": True,
+            "has_organizations": True,
+            "has_active_subscription": False,
+            "is_mfa_enabled": True,
+            "has_invitations": False,
+            "has_unverified_emails": False,
         }
         defaults.update(kwargs)
-        
+
         # Mock email verification
-        mocker.patch('squarelet.users.views.has_verified_email', return_value=defaults['has_verified_email'])
-        
+        mocker.patch(
+            "squarelet.users.views.has_verified_email",
+            return_value=defaults["has_verified_email"],
+        )
+
         # Mock organizations
         mock_org_queryset = mocker.MagicMock()
-        mock_org_queryset.exists.return_value = defaults['has_organizations']
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
-        
+        mock_org_queryset.exists.return_value = defaults["has_organizations"]
+        mocker.patch.object(
+            user.organizations, "filter", return_value=mock_org_queryset
+        )
+
         # Mock subscription status
-        if hasattr(user, 'individual_organization'):
-            mocker.patch.object(user.individual_organization, 'has_active_subscription', 
-                               return_value=defaults['has_active_subscription'])
-        
+        if hasattr(user, "individual_organization"):
+            mocker.patch.object(
+                user.individual_organization,
+                "has_active_subscription",
+                return_value=defaults["has_active_subscription"],
+            )
+
         # Mock MFA status
-        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=defaults['is_mfa_enabled'])
-        
+        mocker.patch(
+            "squarelet.users.views.is_mfa_enabled",
+            return_value=defaults["is_mfa_enabled"],
+        )
+
         # Mock invitations
-        if defaults['has_invitations']:
+        if defaults["has_invitations"]:
             mock_invitation = mocker.MagicMock()
-            mocker.patch.object(user, 'get_pending_invitations', return_value=[mock_invitation])
+            mocker.patch.object(
+                user, "get_pending_invitations", return_value=[mock_invitation]
+            )
         else:
-            mocker.patch.object(user, 'get_pending_invitations', return_value=[])
-        
+            mocker.patch.object(user, "get_pending_invitations", return_value=[])
+
         # Mock potential organizations
         mock_potential_queryset = mocker.MagicMock()
         mock_potential_queryset.filter.return_value = []
-        mocker.patch.object(user, 'get_potential_organizations', return_value=mock_potential_queryset)
-        
+        mocker.patch.object(
+            user, "get_potential_organizations", return_value=mock_potential_queryset
+        )
+
         # Mock unverified emails
         mock_email_queryset = mocker.MagicMock()
-        mock_email_queryset.exists.return_value = defaults['has_unverified_emails']
-        mocker.patch('squarelet.users.views.EmailAddress.objects.filter', return_value=mock_email_queryset)
-        
+        mock_email_queryset.exists.return_value = defaults["has_unverified_emails"]
+        mocker.patch(
+            "squarelet.users.views.EmailAddress.objects.filter",
+            return_value=mock_email_queryset,
+        )
+
         # Set user attributes
-        if not hasattr(user, 'last_mfa_prompt'):
+        if not hasattr(user, "last_mfa_prompt"):
             user.last_mfa_prompt = None
 
     def _mock_messages(self, mocker):
         """Mock Django messages framework to avoid middleware issues"""
-        mocker.patch('squarelet.users.views.messages.info')
-        mocker.patch('squarelet.users.views.messages.success')
-        mocker.patch('squarelet.users.views.messages.error')
+        mocker.patch("squarelet.users.views.messages.info")
+        mocker.patch("squarelet.users.views.messages.success")
+        mocker.patch("squarelet.users.views.messages.error")
 
     def _mock_mfa_forms(self, mocker, valid=True):
         """Mock MFA-related forms"""
         mock_form = mocker.MagicMock()
         mock_form.is_valid.return_value = valid
         mock_form.secret = "test_secret"
-        mocker.patch('allauth.mfa.totp.internal.auth.get_totp_secret', return_value="test_secret")
-        mocker.patch('squarelet.users.views.ActivateTOTPForm', return_value=mock_form)
-        
+        mocker.patch(
+            "allauth.mfa.totp.internal.auth.get_totp_secret", return_value="test_secret"
+        )
+        mocker.patch("squarelet.users.views.ActivateTOTPForm", return_value=mock_form)
+
         if valid:
-            mocker.patch('squarelet.users.views.activate_totp')
-        
+            mocker.patch("squarelet.users.views.activate_totp")
+
         # Mock adapter for TOTP
         mock_adapter = mocker.MagicMock()
         mock_adapter.build_totp_url.return_value = "otpauth://test"
         mock_adapter.build_totp_svg.return_value = "<svg>test</svg>"
-        mocker.patch('squarelet.users.views.get_adapter', return_value=mock_adapter)
-        mocker.patch('squarelet.users.views.base64.b64encode', return_value=b'dGVzdA==')
-        
+        mocker.patch("squarelet.users.views.get_adapter", return_value=mock_adapter)
+        mocker.patch("squarelet.users.views.base64.b64encode", return_value=b"dGVzdA==")
+
         return mock_form
 
     def _mock_subscription_forms(self, mocker, valid=True):
@@ -357,19 +379,25 @@ class TestUserOnboardingView(ViewTestMixin):
         mock_form = mocker.MagicMock()
         mock_form.is_valid.return_value = valid
         mock_form.save.return_value = valid
-        
-        mocker.patch('squarelet.users.views.PremiumSubscriptionForm', return_value=mock_form)
-        
+
+        mocker.patch(
+            "squarelet.users.views.PremiumSubscriptionForm", return_value=mock_form
+        )
+
         return mock_form
 
-    def _create_get_request(self, rf, user, mock_django_session, session_data=None, params=None):
+    def _create_get_request(
+        self, rf, user, mock_django_session, session_data=None, params=None
+    ):
         """Create a GET request with common setup"""
         request = rf.get(self.url, params or {})
         request.user = user
         request.session = mock_django_session(session_data or {})
         return request
 
-    def _create_post_request(self, rf, user, mock_django_session, data, session_data=None):
+    def _create_post_request(
+        self, rf, user, mock_django_session, data, session_data=None
+    ):
         """Create a POST request with common setup"""
         request = rf.post(self.url, data)
         request.user = user
@@ -386,7 +414,7 @@ class TestUserOnboardingView(ViewTestMixin):
         """Call view GET with common mocking"""
         self._mock_messages(mocker)
         if mock_email_send:
-            mocker.patch('squarelet.users.views.send_email_confirmation')
+            mocker.patch("squarelet.users.views.send_email_confirmation")
         view_instance = self.view.as_view()
         return view_instance(request)
 
@@ -396,7 +424,9 @@ class TestUserOnboardingView(ViewTestMixin):
         view_instance = self.view.as_view()
         return view_instance(request)
 
-    def _assert_step(self, step, expected_step, context=None, expected_context_keys=None):
+    def _assert_step(
+        self, step, expected_step, context=None, expected_context_keys=None
+    ):
         """Assert onboarding step and context"""
         assert step == expected_step
         if expected_context_keys:
@@ -424,188 +454,299 @@ class TestUserOnboardingView(ViewTestMixin):
 
     # ===== STEP LOGIC TESTS =====
 
-    def test_get_onboarding_step_email_unverified(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_email_unverified(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with unverified email should get confirm_email step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
+
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         self._assert_step(step, "confirm_email", context, ["email"])
         assert context["email"] == user.email
 
-    def test_get_onboarding_step_email_verified(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_email_verified(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with verified email should skip email step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=True)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         # Should skip email step and session should be updated
         assert request.session["onboarding"]["email_check_completed"] is True
         assert step is None  # Should complete onboarding
 
-    def test_get_onboarding_step_join_org_with_invitations(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_join_org_with_invitations(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with pending invitations should get join_org step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "join_org": False}
-        })
-        
-        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": True, "join_org": False}},
+        )
+
+        self._mock_user_state(
+            mocker, user, has_organizations=False, has_invitations=True
+        )
+
         step, context = self._get_onboarding_step(request, mocker)
-        
-        self._assert_step(step, "join_org", context, ["invitations", "potential_orgs", "joinable_orgs_count"])
+
+        self._assert_step(
+            step,
+            "join_org",
+            context,
+            ["invitations", "potential_orgs", "joinable_orgs_count"],
+        )
         assert len(context["invitations"]) == 1
         assert context["joinable_orgs_count"] == 1
 
-    def test_get_onboarding_step_join_org_already_has_orgs(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_join_org_already_has_orgs(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with existing organizations should skip join_org step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "join_org": False}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": True, "join_org": False}},
+        )
+
         self._mock_user_state(mocker, user, has_organizations=True)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         assert step is None  # Should skip join_org and complete onboarding
 
-    def test_get_onboarding_step_subscribe_with_valid_plan(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_subscribe_with_valid_plan(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """User with valid plan in session should get subscribe step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
-        }, {"plan": "professional"})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                }
+            },
+            {"plan": "professional"},
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
-        
+
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         self._assert_step(step, "subscribe", context, ["plans"])
         assert context["plans"]["selected"].slug == "professional"
 
-    def test_get_onboarding_step_subscribe_already_subscribed(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_subscribe_already_subscribed(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """User already subscribed to professional plan should skip subscribe step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "plan": "professional",
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "plan": "professional",
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=True)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         # Should mark subscription as completed and clear plan
         assert request.session["onboarding"]["subscription"] == "completed"
         assert request.session["plan"] is None
         assert step is None
 
-    def test_get_onboarding_step_subscribe_invalid_plan(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_subscribe_invalid_plan(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with invalid plan should skip subscribe step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "plan": "invalid_plan",
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "plan": "invalid_plan",
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=views.Plan.DoesNotExist())
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+        mocker.patch(
+            "squarelet.users.views.Plan.objects.get",
+            side_effect=views.Plan.DoesNotExist(),
+        )
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         assert step is None  # Should skip subscribe step
 
-    def test_get_onboarding_step_mfa_opt_in(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_mfa_opt_in(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with MFA not started should get mfa_opt_in step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "first_login": False,
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "not_started",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         assert step == "mfa_opt_in"
 
-    def test_get_onboarding_step_mfa_setup(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_mfa_setup(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User who opted in for MFA should get mfa_setup step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "first_login": False,
+                "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"},
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
 
         self._mock_mfa_forms(mocker, valid=True)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         assert step == "mfa_setup"
 
-    def test_get_onboarding_step_mfa_confirm(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_mfa_confirm(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User who submitted MFA code should get mfa_confirm step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "mfa_step": "code_submitted"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "code_submitted",
+                }
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         assert step == "mfa_confirm"
 
-    def test_get_onboarding_step_mfa_already_enabled(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_mfa_already_enabled(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User with MFA already enabled should skip MFA steps"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": True, "mfa_step": "not_started"}},
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=True)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         # Should mark MFA as completed
         assert request.session["onboarding"]["mfa_step"] == "completed"
         assert step is None
 
-    def test_get_onboarding_step_first_login_skips_mfa(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_first_login_skips_mfa(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """First-time login should skip MFA prompting"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": True,
-            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "first_login": True,
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "not_started",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         # Should mark MFA as completed due to first login
         assert request.session["onboarding"]["mfa_step"] == "completed"
         assert step is None
 
-    def test_get_onboarding_step_session_initialization(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_session_initialization(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should initialize onboarding session if it doesn't exist"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {})  # No onboarding session
-        
+        request = self._create_get_request(
+            rf, user, mock_django_session, {}
+        )  # No onboarding session
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        self._get_onboarding_step(request, mocker)
+
         # Should initialize session with defaults
         assert "onboarding" in request.session
         onboarding = request.session["onboarding"]
@@ -614,198 +755,279 @@ class TestUserOnboardingView(ViewTestMixin):
         assert onboarding["join_org"] is False
         assert onboarding["subscription"] == "not_started"
 
-    def test_get_onboarding_step_complete_flow(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_onboarding_step_complete_flow(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User who completed all steps should return None"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {
-                "email_check_completed": True,
-                "mfa_step": "completed",
-                "join_org": True,
-                "subscription": "completed",
-            }
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "completed",
+                    "join_org": True,
+                    "subscription": "completed",
+                }
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        
+
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         assert step is None
-        assert context == {}
+        assert not context
 
     # ===== TEMPLATE TESTS =====
 
-    def test_get_template_names_confirm_email(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_template_names_confirm_email(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should return confirm_email template for email confirmation step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
+
         view = self.view()
         view.request = request
         template_names = view.get_template_names()
-        
+
         assert template_names == ["account/onboarding/confirm_email.html"]
 
-    def test_get_template_names_join_org(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_template_names_join_org(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should return join_org template for organization joining step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "join_org": False}
-        })
-        
-        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": True, "join_org": False}},
+        )
+
+        self._mock_user_state(
+            mocker, user, has_organizations=False, has_invitations=True
+        )
+
         view = self.view()
         view.request = request
         template_names = view.get_template_names()
-        
+
         assert template_names == ["account/onboarding/join_org.html"]
 
-    def test_get_template_names_subscribe(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_get_template_names_subscribe(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """Should return subscribe template for subscription step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
-        }, {"plan": "professional"})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                }
+            },
+            {"plan": "professional"},
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
-        
+
         view = self.view()
         view.request = request
         template_names = view.get_template_names()
-        
+
         assert template_names == ["account/onboarding/subscribe.html"]
 
-    @pytest.mark.parametrize("mfa_step,expected_template", [
-        ("not_started", "account/onboarding/mfa_opt_in.html"),
-        ("opted_in", "account/onboarding/mfa_setup.html"),
-        ("code_submitted", "account/onboarding/mfa_confirm.html"),
-        ("completed", "account/onboarding/base.html")
-    ])
-    def test_mfa_templates(self, rf, user_factory, mocker, mock_django_session, mfa_step, expected_template):
+    @pytest.mark.parametrize(
+        "mfa_step,expected_template",
+        [
+            ("not_started", "account/onboarding/mfa_opt_in.html"),
+            ("opted_in", "account/onboarding/mfa_setup.html"),
+            ("code_submitted", "account/onboarding/mfa_confirm.html"),
+            ("completed", "account/onboarding/base.html"),
+        ],
+    )
+    def test_mfa_templates(
+        self, rf, user_factory, mocker, mock_django_session, mfa_step, expected_template
+    ):
         """Should return mfa_opt_in template for MFA opt-in step"""
         user = user_factory()
         session_data = {
             "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": mfa_step}
+            "onboarding": {"email_check_completed": True, "mfa_step": mfa_step},
         }
         request = self._create_get_request(rf, user, mock_django_session, session_data)
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
         self._mock_mfa_forms(mocker, valid=True)
-        
+
         view = self.view()
         view.request = request
         template_names = view.get_template_names()
-        
+
         assert template_names == [expected_template]
 
     # ===== CONTEXT DATA TESTS =====
 
-    def test_get_context_data_base_context(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_context_data_base_context(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should include base context data for all steps"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "next_url": "/target/url/",
-            "intent": "muckrock",
-            "onboarding": {"email_check_completed": False}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "next_url": "/target/url/",
+                "intent": "muckrock",
+                "onboarding": {"email_check_completed": False},
+            },
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
+
         # Mock service lookup
         mock_service = mocker.MagicMock()
         mock_service.slug = "muckrock"
-        mocker.patch('squarelet.users.views.Service.objects.filter').return_value.first.return_value = mock_service
-        
+        mocker.patch(
+            "squarelet.users.views.Service.objects.filter"
+        ).return_value.first.return_value = mock_service
+
         view = self.view()
         view.request = request
         context = view.get_context_data()
-        
+
         assert context["onboarding_step"] == "confirm_email"
         assert context["next_url"] == "/target/url/"
         assert context["intent"] == "muckrock"
         assert context["service"] == mock_service
         assert context["email"] == user.email
 
-    def test_get_context_data_subscribe_step(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_get_context_data_subscribe_step(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """Should include subscription forms and organizations for subscribe step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
-        }, {"plan": "professional"})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                }
+            },
+            {"plan": "professional"},
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
-        
+
         self._mock_subscription_forms(mocker, valid=True)
-        
+
         # Mock user organizations queryset
         mock_group_orgs = mocker.MagicMock()
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_group_orgs)
+        mocker.patch.object(user.organizations, "filter", return_value=mock_group_orgs)
         mock_group_orgs.order_by.return_value = mock_group_orgs
-        
+
         view = self.view()
         view.request = request
         context = view.get_context_data()
-        
+
         assert context["onboarding_step"] == "subscribe"
         assert "forms" in context
         assert context["individual_org"] == user.individual_organization
         assert "group_orgs" in context
 
-    def test_get_context_data_mfa_setup_step(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_context_data_mfa_setup_step(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should include MFA form and TOTP data for MFA setup step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "first_login": False,
+                "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"},
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
         mock_form = self._mock_mfa_forms(mocker)
-        
+
         view = self.view()
         view.request = request
         context = view.get_context_data()
-        
+
         assert context["onboarding_step"] == "mfa_setup"
         assert context["form"] == mock_form
         assert context["totp_svg"] == "<svg>test</svg>"
         assert context["totp_svg_data_uri"] == "data:image/svg+xml;base64,dGVzdA=="
         assert context["totp_url"] == "otpauth://test"
 
-    def test_get_context_data_join_org_step(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_context_data_join_org_step(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should include invitation and potential org data for join_org step"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "join_org": False}
-        })
-        
-        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": True, "join_org": False}},
+        )
+
+        self._mock_user_state(
+            mocker, user, has_organizations=False, has_invitations=True
+        )
+
         view = self.view()
         view.request = request
         context = view.get_context_data()
-        
+
         assert context["onboarding_step"] == "join_org"
         assert len(context["invitations"]) == 1
         assert context["potential_orgs"] == []
         assert context["joinable_orgs_count"] == 1
 
-    def test_get_context_data_no_step_context(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_context_data_no_step_context(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Should not include step-specific context for steps that don't need it"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "mfa_step": "code_submitted"}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "code_submitted",
+                }
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        
+
         view = self.view()
         view.request = request
         context = view.get_context_data()
-        
+
         assert context["onboarding_step"] == "mfa_confirm"
         # Should not have forms, TOTP data, or other step-specific context
         assert "forms" not in context
@@ -819,199 +1041,274 @@ class TestUserOnboardingView(ViewTestMixin):
         request = rf.get(self.url)
         request.user = AnonymousUser()
         request.session = {}
-        
+
         view = self.view.as_view()
         response = view(request)
-        
+
         assert response.status_code == 302
         assert "/accounts/login/" in response.url
 
-    def test_get_confirm_email_sends_email_except_first_login(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_confirm_email_sends_email_except_first_login(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Email confirmation step should send email except on first login"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": False}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"first_login": False, "onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        mock_send = mocker.patch('squarelet.users.views.send_email_confirmation')
-        
+        mock_send = mocker.patch("squarelet.users.views.send_email_confirmation")
+
         response = self._call_view_get(request, mocker, mock_email_send=False)
-        
+
         assert response.status_code == 200
         mock_send.assert_called_once_with(request, user, False, user.email)
 
-    def test_get_confirm_email_skips_email_on_first_login(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_confirm_email_skips_email_on_first_login(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Email confirmation step should not send email on first login"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": True,
-            "onboarding": {"email_check_completed": False}
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"first_login": True, "onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        mock_send = mocker.patch('squarelet.users.views.send_email_confirmation')
-        
+        mock_send = mocker.patch("squarelet.users.views.send_email_confirmation")
+
         response = self._call_view_get(request, mocker, mock_email_send=False)
-        
+
         assert response.status_code == 200
         mock_send.assert_not_called()
 
-    def test_get_completed_onboarding_with_next_url(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_completed_onboarding_with_next_url(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Completed onboarding with next_url should redirect to next_url"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "next_url": "/target/page/",
-            "onboarding": {
-                "email_check_completed": True,
-                "mfa_step": "completed",
-                "join_org": True,
-                "subscription": "completed",
-            }
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "next_url": "/target/page/",
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "completed",
+                    "join_org": True,
+                    "subscription": "completed",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        
+
         response = self._call_view_get(request, mocker)
-        
+
         assert response.status_code == 302
         assert response.url == "/target/page/"
 
-    def test_get_completed_onboarding_without_next_url(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_completed_onboarding_without_next_url(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Completed onboarding without next_url should redirect to user detail"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {
-                "email_check_completed": True,
-                "mfa_step": "completed",
-                "join_org": True,
-                "subscription": "completed",
-            }
-        })
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "completed",
+                    "join_org": True,
+                    "subscription": "completed",
+                }
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        
+
         response = self._call_view_get(request, mocker)
-        
+
         assert response.status_code == 302
         assert response.url == f"/users/{user.username}/"
 
-    def test_get_renders_correct_template_for_each_step(self, rf, user_factory, mocker, mock_django_session):
+    def test_get_renders_correct_template_for_each_step(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Each onboarding step should render the correct template"""
         user = user_factory()
-        request = self._create_get_request(rf, user, mock_django_session, {"onboarding": {"email_check_completed": False}})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
+
         response = self._call_view_get(request, mocker)
-        
+
         assert response.status_code == 200
         assert response.template_name == ["account/onboarding/confirm_email.html"]
 
     # ===== POST METHOD TESTS =====
 
-    def test_post_confirm_email_step(self, rf, user_factory, mocker, mock_django_session):
+    def test_post_confirm_email_step(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """POST to confirm_email step should update session"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "confirm_email"}, {
-            "onboarding": {"email_check_completed": False}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "confirm_email"},
+            {"onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "email_check_completed", True)
 
     def test_post_mfa_opt_in_yes(self, rf, user_factory, mocker, mock_django_session):
         """POST to mfa_opt_in step with 'yes' should update session"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_opt_in", "enable_mfa": "yes"}, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_opt_in", "enable_mfa": "yes"},
+            {
+                "first_login": False,
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "not_started",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "mfa_step", "opted_in")
 
     def test_post_mfa_opt_in_no(self, rf, user_factory, mocker, mock_django_session):
         """POST to mfa_opt_in step with 'no' should complete MFA and update user"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_opt_in", "choice": "no"}, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "not_started"}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_opt_in", "choice": "no"},
+            {
+                "first_login": False,
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "not_started",
+                },
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
-        
+
         # Mock timezone and user save
-        mock_timezone_now = mocker.patch('squarelet.users.views.timezone.now')
+        mock_timezone_now = mocker.patch("squarelet.users.views.timezone.now")
         mock_timezone_now.return_value = "2023-01-01"
-        mock_user_save = mocker.patch.object(user, 'save')
-        
+        mock_user_save = mocker.patch.object(user, "save")
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "mfa_step", "completed")
         assert user.last_mfa_prompt == "2023-01-01"
         mock_user_save.assert_called_once()
 
-    def test_post_mfa_setup_valid_code(self, rf, user_factory, mocker, mock_django_session):
+    def test_post_mfa_setup_valid_code(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """POST to mfa_setup step with valid code should activate TOTP"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "123456"}, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_setup", "token": "123456"},
+            {
+                "first_login": False,
+                "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"},
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
         self._mock_mfa_forms(mocker, valid=True)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "mfa_step", "code_submitted")
 
-    def test_post_mfa_setup_invalid_code(self, rf, user_factory, mocker, mock_django_session):
+    def test_post_mfa_setup_invalid_code(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """POST to mfa_setup step with invalid code should show errors"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "invalid"}, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_setup", "token": "invalid"},
+            {
+                "first_login": False,
+                "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"},
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
         self._mock_mfa_forms(mocker, valid=False)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         # Should render template with form errors, not redirect
         self._assert_template(response, "account/onboarding/mfa_setup.html")
 
     def test_post_mfa_setup_skip(self, rf, user_factory, mocker, mock_django_session):
         """POST to mfa_setup step with skip should complete MFA"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "mfa_setup": "skip"}, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_setup", "mfa_setup": "skip"},
+            {
+                "first_login": False,
+                "onboarding": {"email_check_completed": True, "mfa_step": "opted_in"},
+            },
+        )
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
         self._mock_mfa_forms(mocker, valid=True)
-        
+
         # Mock timezone and user save
-        mock_timezone_now = mocker.patch('squarelet.users.views.timezone.now')
+        mock_timezone_now = mocker.patch("squarelet.users.views.timezone.now")
         mock_timezone_now.return_value = "2023-01-01"
-        mock_user_save = mocker.patch.object(user, 'save')
-        
+        mock_user_save = mocker.patch.object(user, "save")
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "mfa_step", "completed")
         assert user.last_mfa_prompt == "2023-01-01"
@@ -1020,141 +1317,208 @@ class TestUserOnboardingView(ViewTestMixin):
     def test_post_mfa_confirm_step(self, rf, user_factory, mocker, mock_django_session):
         """POST to mfa_confirm step should complete MFA"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_confirm"}, {
-            "onboarding": {"email_check_completed": True, "mfa_step": "code_submitted"}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_confirm"},
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "mfa_step": "code_submitted",
+                }
+            },
+        )
+
         self._mock_user_state(mocker, user)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "mfa_step", "completed")
 
-    def test_post_subscribe_valid_individual_form(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
-        """POST to subscribe step with valid individual form should process subscription"""
+    def test_post_subscribe_valid_individual_form(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
+        """POST to subscribe step with valid
+        individual form should process subscription"""
         user = user_factory()
         form_data = {
             "step": "subscribe",
             "plan": "1",
             "organization": str(user.individual_organization.pk),
-            "stripe_token": "tok_test123"
+            "stripe_token": "tok_test123",
         }
-        request = self._create_post_request(rf, user, mock_django_session, form_data, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"},
-            "plan": "professional"
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            form_data,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                },
+                "plan": "professional",
+            },
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
         self._mock_subscription_forms(mocker, valid=True)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "subscription", "completed")
 
-    def test_post_subscribe_invalid_form(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_post_subscribe_invalid_form(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """POST to subscribe step with invalid form should show errors"""
         user = user_factory()
         form_data = {
             "step": "subscribe",
             "plan": "1",
             "organization": str(user.individual_organization.pk),
-            "stripe_token": "invalid_token"
+            "stripe_token": "invalid_token",
         }
-        request = self._create_post_request(rf, user, mock_django_session, form_data, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"},
-            "plan": "professional"
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            form_data,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                },
+                "plan": "professional",
+            },
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
         self._mock_subscription_forms(mocker, valid=False)
-        
+
         # Mock user organizations queryset
         mock_group_orgs = mocker.MagicMock()
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_group_orgs)
+        mocker.patch.object(user.organizations, "filter", return_value=mock_group_orgs)
         mock_group_orgs.order_by.return_value = mock_group_orgs
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         # Should render template with form errors, not redirect
         self._assert_template(response, "account/onboarding/subscribe.html")
 
-    def test_post_subscribe_skip(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_post_subscribe_skip(self, rf, user_factory, mocker, mock_django_session):
         """POST to subscribe step with skip should complete subscription"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "subscribe", "submit-type": "skip"}, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"},
-            "plan": "professional"
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "subscribe", "submit-type": "skip"},
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                },
+                "plan": "professional",
+            },
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "subscription", "completed")
 
     def test_post_join_org_skip(self, rf, user_factory, mocker, mock_django_session):
         """POST to join_org step with skip should complete join_org"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "join_org", "join_org": "skip"}, {
-            "onboarding": {"email_check_completed": True, "join_org": False}
-        })
-        
-        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True)
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "join_org", "join_org": "skip"},
+            {"onboarding": {"email_check_completed": True, "join_org": False}},
+        )
+
+        self._mock_user_state(
+            mocker, user, has_organizations=False, has_invitations=True
+        )
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "join_org", True)
 
     def test_post_invalid_step(self, rf, user_factory, mocker, mock_django_session):
         """POST with invalid step should handle gracefully"""
         user = user_factory()
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "invalid_step"}, {
-            "onboarding": {"email_check_completed": False}
-        })
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "invalid_step"},
+            {"onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         # Should redirect back to onboarding (handles invalid step gracefully)
         self._assert_redirect_to_onboard(response)
 
     # ===== INTEGRATION TESTS =====
 
-    def test_complete_onboarding_flow_new_user_no_plan(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_complete_onboarding_flow_new_user_no_plan(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Complete onboarding flow for new user without subscription plan"""
         user = user_factory()
-        
+
         # Step 1: Start with empty session (new user)
         session_data = {}
-        
-        self._mock_user_state(mocker, user, has_verified_email=False, has_organizations=False, 
-                             has_invitations=False, is_mfa_enabled=False)
-        
+
+        self._mock_user_state(
+            mocker,
+            user,
+            has_verified_email=False,
+            has_organizations=False,
+            has_invitations=False,
+            is_mfa_enabled=False,
+        )
+
         # Step 1: Email confirmation required
         request = self._create_get_request(rf, user, mock_django_session, session_data)
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         assert step == "confirm_email"
         assert context["email"] == user.email
         assert request.session["onboarding"]["email_check_completed"] is False
-        
+
         # Step 2: Confirm email via POST
         session_data = request.session
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "confirm_email"}, session_data)
-        
+        request = self._create_post_request(
+            rf, user, mock_django_session, {"step": "confirm_email"}, session_data
+        )
+
         # Mock email now verified
-        self._mock_user_state(mocker, user, has_verified_email=False, has_organizations=False, 
-                             has_invitations=False, is_mfa_enabled=False)
-        
+        self._mock_user_state(
+            mocker,
+            user,
+            has_verified_email=False,
+            has_organizations=False,
+            has_invitations=False,
+            is_mfa_enabled=False,
+        )
+
         response = self._call_view_post(request, mocker)
         assert response.status_code == 302
         assert request.session["onboarding"]["email_check_completed"] is True
-        
+
         # Step 3: Check final state - should be complete
         session_data = request.session
         request = self._create_get_request(rf, user, mock_django_session, session_data)
@@ -1162,79 +1526,105 @@ class TestUserOnboardingView(ViewTestMixin):
         assert response.url == f"/users/{user.username}/"
         assert response.status_code == 302
 
-    def test_complete_onboarding_flow_with_professional_plan(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_complete_onboarding_flow_with_professional_plan(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """Complete onboarding flow for user signing up for professional plan"""
         user = user_factory()
-        
+
         # Start with plan in session
         session_data = {"plan": "professional"}
-        
-        self._mock_user_state(mocker, user, has_verified_email=True, has_active_subscription=False, is_mfa_enabled=False)
-        
+
+        self._mock_user_state(
+            mocker,
+            user,
+            has_verified_email=True,
+            has_active_subscription=False,
+            is_mfa_enabled=False,
+        )
+
         # Step 1: Should go straight to subscription (email already verified)
         request = self._create_get_request(rf, user, mock_django_session, session_data)
-        
+
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         assert step == "subscribe"
         assert context["plans"]["selected"].slug == "professional"
         assert request.session["onboarding"]["email_check_completed"] is True
-        
+
         # Step 2: Complete subscription via POST
         session_data = request.session
         form_data = {
             "step": "subscribe",
             "plan": "1",
             "organization": str(user.individual_organization.pk),
-            "stripe_token": "tok_test123"
+            "stripe_token": "tok_test123",
         }
-        request = self._create_post_request(rf, user, mock_django_session, form_data, session_data)
-        
+        request = self._create_post_request(
+            rf, user, mock_django_session, form_data, session_data
+        )
+
         self._mock_subscription_forms(mocker, valid=True)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "subscription", "completed")
 
-    def test_complete_onboarding_flow_with_organization_invitations(self, rf, user_factory, mocker, mock_django_session):
+    def test_complete_onboarding_flow_with_organization_invitations(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Complete onboarding flow for user with pending organization invitations"""
         user = user_factory()
-        
+
         # Mock user with verified email, no personal orgs, but has invitations
-        self._mock_user_state(mocker, user, has_organizations=False, has_invitations=True, is_mfa_enabled=True)
-        
+        self._mock_user_state(
+            mocker,
+            user,
+            has_organizations=False,
+            has_invitations=True,
+            is_mfa_enabled=True,
+        )
+
         # Step 1: Should go to join_org step
         request = self._create_get_request(rf, user, mock_django_session, {})
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         assert step == "join_org"
         assert len(context["invitations"]) == 1
         assert context["joinable_orgs_count"] == 1
         assert request.session["onboarding"]["join_org"] is False
-        
+
         # Step 2: Skip organization joining
         session_data = request.session
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "join_org", "join_org": "skip"}, session_data)
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "join_org", "join_org": "skip"},
+            session_data,
+        )
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "join_org", True)
 
         # Step 3: Onboarding complete (MFA already enabled)
         session_data = request.session
         request = self._create_get_request(rf, user, mock_django_session, session_data)
-        
+
         response = self._call_view_get(request, mocker)
-        
+
         assert response.status_code == 302
         assert response.url == f"/users/{user.username}/"
 
-    def test_onboarding_flow_interrupted_and_resumed(self, rf, user_factory, mocker, mock_django_session):
+    def test_onboarding_flow_interrupted_and_resumed(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """User should resume onboarding from where they left off after interruption"""
         user = user_factory()
-        
+
         # Simulate user who started onboarding but didn't complete it
         # They confirmed email and opted into MFA but didn't complete setup
         session_data = {
@@ -1242,52 +1632,69 @@ class TestUserOnboardingView(ViewTestMixin):
                 "email_check_completed": True,
                 "mfa_step": "opted_in",  # Stuck at this step
                 "join_org": False,
-                "subscription": "not_started"
+                "subscription": "not_started",
             }
         }
-        
+
         # Mock user state
-        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mocker.patch("squarelet.users.views.has_verified_email", return_value=True)
         mock_org_queryset = mocker.MagicMock()
         mock_org_queryset.exists.return_value = True
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
-        mocker.patch.object(user.individual_organization, 'has_active_subscription', return_value=False)
-        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=False)
+        mocker.patch.object(
+            user.organizations, "filter", return_value=mock_org_queryset
+        )
+        mocker.patch.object(
+            user.individual_organization, "has_active_subscription", return_value=False
+        )
+        mocker.patch("squarelet.users.views.is_mfa_enabled", return_value=False)
         user.last_mfa_prompt = None
 
         self._mock_mfa_forms(mocker, valid=True)
-        
+
         # Mock no unverified emails
         mock_email_queryset = mocker.MagicMock()
         mock_email_queryset.exists.return_value = False
-        mocker.patch('squarelet.users.views.EmailAddress.objects.filter', return_value=mock_email_queryset)
-        
+        mocker.patch(
+            "squarelet.users.views.EmailAddress.objects.filter",
+            return_value=mock_email_queryset,
+        )
+
         # User returns - should resume at MFA setup step
         request = self._create_get_request(rf, user, mock_django_session, session_data)
-        step, context = self._get_onboarding_step(request, mocker)
-        
+        step, _ = self._get_onboarding_step(request, mocker)
+
         assert step == "mfa_setup"
-        assert request.session["onboarding"]["email_check_completed"] is True  # Preserved
+        assert (
+            request.session["onboarding"]["email_check_completed"] is True
+        )  # Preserved
         assert request.session["onboarding"]["mfa_step"] == "opted_in"  # Preserved
-        
+
         # Complete MFA setup to continue flow
         session_data = request.session
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "123456"}, session_data)
-        
-        mock_form = self._mock_mfa_forms(mocker, valid=True)
-        
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            {"step": "mfa_setup", "token": "123456"},
+            session_data,
+        )
+
+        self._mock_mfa_forms(mocker, valid=True)
+
         response = self._call_view_post(request, mocker)
-        
+
         self._assert_redirect_to_onboard(response)
         self._assert_session_updated(request.session, "mfa_step", "code_submitted")
-        
+
         # Continue with rest of flow...
         # [Additional steps would follow the same pattern]
 
-    def test_onboarding_flow_with_next_url_redirect(self, rf, user_factory, mocker, mock_django_session):
+    def test_onboarding_flow_with_next_url_redirect(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Completed onboarding should redirect to next_url from session"""
         user = user_factory()
-        
+
         # Session with target URL
         session_data = {
             "next_url": "/target/dashboard/",
@@ -1296,21 +1703,23 @@ class TestUserOnboardingView(ViewTestMixin):
                 "email_check_completed": True,
                 "mfa_step": "completed",
                 "join_org": True,
-                "subscription": "completed"
-            }
+                "subscription": "completed",
+            },
         }
-        
+
         # Mock all steps complete
-        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mocker.patch("squarelet.users.views.has_verified_email", return_value=True)
         mock_org_queryset = mocker.MagicMock()
         mock_org_queryset.exists.return_value = True
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
-        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=True)
-        
+        mocker.patch.object(
+            user.organizations, "filter", return_value=mock_org_queryset
+        )
+        mocker.patch("squarelet.users.views.is_mfa_enabled", return_value=True)
+
         request = self._create_get_request(rf, user, mock_django_session, session_data)
-        
+
         response = self._call_view_get(request, mocker)
-        
+
         # Should redirect to next_url and remove it from session
         assert response.status_code == 302
         assert response.url == "/target/dashboard/"
@@ -1318,10 +1727,12 @@ class TestUserOnboardingView(ViewTestMixin):
 
     # ===== EDGE CASE TESTS =====
 
-    def test_malformed_post_data_handling(self, rf, user_factory, mocker, mock_django_session):
+    def test_malformed_post_data_handling(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Malformed POST data should not crash the application"""
         user = user_factory()
-        
+
         malformed_requests = [
             {},  # Missing step parameter
             {"step": "None"},  # Invalid step values
@@ -1329,102 +1740,126 @@ class TestUserOnboardingView(ViewTestMixin):
             {"step": 12345},
             {"step": ["invalid", "list"]},
         ]
-        
+
         for malformed_data in malformed_requests:
-            request = self._create_post_request(rf, user, mock_django_session, malformed_data, {
-                "onboarding": {"email_check_completed": True}
-            })
-            
+            request = self._create_post_request(
+                rf,
+                user,
+                mock_django_session,
+                malformed_data,
+                {"onboarding": {"email_check_completed": True}},
+            )
+
             # Should handle gracefully and not crash
             try:
                 response = self._call_view_post(request, mocker)
                 assert response.status_code in [200, 302]  # Either render or redirect
             except (TypeError, ValueError, AttributeError) as e:
-                pytest.fail(f"Should handle malformed POST data gracefully. Error: {e}, Data: {malformed_data}")
+                pytest.fail(
+                    f"Should handle malformed POST data gracefully. "
+                    f"Error: {e}, Data: {malformed_data}"
+                )
 
     def test_unauthorized_access_redirects_to_login(self, rf):
         """Unauthenticated users should be redirected to login"""
-        from django.contrib.auth.models import AnonymousUser
-        
+
         # GET request from unauthenticated user
         request = rf.get(self.url)
         request.user = AnonymousUser()
-        
+
         view_instance = self.view.as_view()
         response = view_instance(request)
-        
-        assert response.status_code == 302
-        assert response.url == '/accounts/login/'
 
-    def test_email_confirmation_send_on_first_visit(self, rf, user_factory, mocker, mock_django_session):
-        """Email confirmation should be sent automatically on first visit (not first login)"""
+        assert response.status_code == 302
+        assert response.url == "/accounts/login/"
+
+    def test_email_confirmation_send_on_first_visit(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
+        """Email confirmation should be sent automatically
+        on first visit (not first login)"""
         user = user_factory()
-        
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": False,
-            "onboarding": {"email_check_completed": False}
-        })
-        
+
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"first_login": False, "onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        mock_send_confirmation = mocker.patch('squarelet.users.views.send_email_confirmation')
-        
+        mock_send_confirmation = mocker.patch(
+            "squarelet.users.views.send_email_confirmation"
+        )
+
         response = self._call_view_get(request, mocker, mock_email_send=False)
-        
+
         # Should send email confirmation automatically
         mock_send_confirmation.assert_called_once_with(request, user, False, user.email)
         assert response.status_code == 200  # Render confirm_email template
 
-    def test_email_confirmation_not_sent_on_first_login(self, rf, user_factory, mocker, mock_django_session):
-        """Email confirmation should NOT be sent on first login (already sent during signup)"""
+    def test_email_confirmation_not_sent_on_first_login(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
+        """Email confirmation should NOT be sent on first login
+        (already sent during signup)"""
         user = user_factory()
-        
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "first_login": True,
-            "onboarding": {"email_check_completed": False}
-        })
-        
+
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {"first_login": True, "onboarding": {"email_check_completed": False}},
+        )
+
         self._mock_user_state(mocker, user, has_verified_email=False)
-        mock_send_confirmation = mocker.patch('squarelet.users.views.send_email_confirmation')
-        
+        mock_send_confirmation = mocker.patch(
+            "squarelet.users.views.send_email_confirmation"
+        )
+
         response = self._call_view_get(request, mocker, mock_email_send=False)
-        
+
         # Should NOT send email confirmation (already sent during signup)
         mock_send_confirmation.assert_not_called()
         assert response.status_code == 200  # Still render confirm_email template
 
-    def test_mfa_setup_form_validation_errors(self, rf, user_factory, mocker, mock_django_session):
+    def test_mfa_setup_form_validation_errors(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """MFA setup with invalid tokens should be handled properly"""
         user = user_factory()
-        
-        request = self._create_post_request(rf, user, mock_django_session, {"step": "mfa_setup", "token": "invalid"})
+
+        request = self._create_post_request(
+            rf, user, mock_django_session, {"step": "mfa_setup", "token": "invalid"}
+        )
         request.user = user
-        request.session = mock_django_session({
-            "onboarding": {"mfa_step": "opted_in"}
-        })
-        
+        request.session = mock_django_session({"onboarding": {"mfa_step": "opted_in"}})
+
         self._mock_user_state(mocker, user, is_mfa_enabled=False)
         self._mock_mfa_forms(mocker, valid=False)
-        
+
         response = self._call_view_post(request, mocker)
-        
+
         # Should re-render form with errors, not redirect
         self._assert_template(response, "account/onboarding/mfa_setup.html")
 
     # ===== SESSION STATE TESTING =====
 
-    def test_session_initialization_creates_defaults(self, rf, user_factory, mocker, mock_django_session):
+    def test_session_initialization_creates_defaults(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Empty session should be initialized with proper defaults"""
         user = user_factory()
         request = rf.get(self.url)
         request.user = user
         request.session = mock_django_session({})  # Completely empty session
-        
+
         # Mock dependencies to trigger session initialization
-        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
-        
+        mocker.patch("squarelet.users.views.has_verified_email", return_value=True)
+
         view = self.view()
-        step, context = view.get_onboarding_step(request)
-        
+        view.get_onboarding_step(request)
+
         # Verify session was initialized with correct defaults
         assert "onboarding" in request.session
         onboarding = request.session["onboarding"]
@@ -1434,129 +1869,162 @@ class TestUserOnboardingView(ViewTestMixin):
         assert onboarding["subscription"] == "not_started"
         assert request.session.modified is True
 
-    def test_session_initialization_uses_setdefault(self, rf, user_factory, mocker, mock_django_session):
+    def test_session_initialization_uses_setdefault(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Session initialization should use setdefault to preserve existing values"""
         user = user_factory()
         request = rf.get(self.url)
         request.user = user
-        request.session = mock_django_session({
-            "onboarding": {
-                "email_check_completed": True,  # This should be preserved
-                "mfa_step": "opted_in",          # This should be preserved
-                # Missing join_org and subscription - should get defaults
+        request.session = mock_django_session(
+            {
+                "onboarding": {
+                    "email_check_completed": True,  # This should be preserved
+                    "mfa_step": "opted_in",  # This should be preserved
+                    # Missing join_org and subscription - should get defaults
+                }
             }
-        })
-        
+        )
+
         # Mock dependencies
-        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mocker.patch("squarelet.users.views.has_verified_email", return_value=True)
         mock_org_queryset = mocker.MagicMock()
         mock_org_queryset.exists.return_value = True
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
-        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=True)
+        mocker.patch.object(
+            user.organizations, "filter", return_value=mock_org_queryset
+        )
+        mocker.patch("squarelet.users.views.is_mfa_enabled", return_value=True)
         self._mock_mfa_forms(mocker, valid=True)
-        
-        view = self.view()
-        step, context = view.get_onboarding_step(request)
-        
-        # Verify setdefault behavior - existing values preserved, missing values get defaults
-        onboarding = request.session["onboarding"]
-        assert onboarding["email_check_completed"] is True    # Preserved
-        assert onboarding["mfa_step"] == "opted_in"           # Preserved
-        assert onboarding["join_org"] is False                # Default added
-        assert onboarding["subscription"] == "not_started"    # Default added
 
-    def test_session_email_verification_auto_update(self, rf, user_factory, mocker, mock_django_session):
+        view = self.view()
+        view.get_onboarding_step(request)
+
+        # Verify setdefault behavior - existing values preserved,
+        # missing values get defaults
+        onboarding = request.session["onboarding"]
+        assert onboarding["email_check_completed"] is True  # Preserved
+        assert onboarding["mfa_step"] == "opted_in"  # Preserved
+        assert onboarding["join_org"] is False  # Default added
+        assert onboarding["subscription"] == "not_started"  # Default added
+
+    def test_session_email_verification_auto_update(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Session should auto-update email_check_completed when email is verified"""
         user = user_factory()
         request = rf.get(self.url)
         request.user = user
-        request.session = mock_django_session({
-            "onboarding": {
-                "email_check_completed": False  # Start as false
-            }
-        })
-        
+        request.session = mock_django_session(
+            {"onboarding": {"email_check_completed": False}}  # Start as false
+        )
+
         # Mock has_verified_email to return True (email is actually verified)
-        mocker.patch('squarelet.users.views.has_verified_email', return_value=True)
+        mocker.patch("squarelet.users.views.has_verified_email", return_value=True)
         mock_org_queryset = mocker.MagicMock()
         mock_org_queryset.exists.return_value = True
-        mocker.patch.object(user.organizations, 'filter', return_value=mock_org_queryset)
-        mocker.patch('squarelet.users.views.is_mfa_enabled', return_value=True)
-        
+        mocker.patch.object(
+            user.organizations, "filter", return_value=mock_org_queryset
+        )
+        mocker.patch("squarelet.users.views.is_mfa_enabled", return_value=True)
+
         view = self.view()
-        step, context = view.get_onboarding_step(request)
-        
+        view.get_onboarding_step(request)
+
         # Should auto-update session when email is verified
         assert request.session["onboarding"]["email_check_completed"] is True
         assert request.session.modified is True
 
-    def test_session_plan_persistence_from_get_parameter(self, rf, user_factory, mocker, subscription_plans, mock_django_session):
+    def test_session_plan_persistence_from_get_parameter(
+        self, rf, user_factory, subscription_plans, mocker, mock_django_session
+    ):
         """Plan from GET parameter should be used and stored in session"""
         user = user_factory()
-        
+
         # Request with plan parameter
-        request = self._create_get_request(rf, user, mock_django_session, {
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
-        }, {"plan": "professional"})
-        
+        request = self._create_get_request(
+            rf,
+            user,
+            mock_django_session,
+            {
+                "onboarding": {
+                    "email_check_completed": True,
+                    "subscription": "not_started",
+                }
+            },
+            {"plan": "professional"},
+        )
+
         self._mock_user_state(mocker, user, has_active_subscription=False)
-        
+
         step, context = self._get_onboarding_step(request, mocker)
-        
+
         # The view should use the plan from GET parameter
         assert step == "subscribe"
         assert context["plans"]["selected"].slug == "professional"
 
-    def test_database_errors_plan_doesnotexist_handling(self, rf, user_factory, mocker, mock_django_session, capsys):
+    def test_database_errors_plan_doesnotexist_handling(
+        self, rf, user_factory, mocker, mock_django_session, capsys
+    ):
         """Plan.DoesNotExist errors should be handled gracefully"""
         user = user_factory()
-        
+
         # Session with invalid plan
         session_data = {
             "plan": "nonexistent_plan",
-            "onboarding": {"email_check_completed": True, "subscription": "not_started"}
+            "onboarding": {
+                "email_check_completed": True,
+                "subscription": "not_started",
+            },
         }
-        
+
         self._mock_user_state(mocker, user)
-        
+
         # Mock Plan.DoesNotExist for any plan lookup
-        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=Plan.DoesNotExist())
-        
+        mocker.patch(
+            "squarelet.users.views.Plan.objects.get", side_effect=Plan.DoesNotExist()
+        )
+
         request = self._create_get_request(rf, user, mock_django_session, session_data)
-        
-        step, context = self._get_onboarding_step(request, mocker)
-        
+
+        step, _ = self._get_onboarding_step(request, mocker)
+
         # Should handle DoesNotExist gracefully and skip subscription step
         assert step is None  # Onboarding complete, subscription skipped
-        
+
         # Should print debug message
         captured = capsys.readouterr()
         assert "Invalid plan slug: nonexistent_plan" in captured.out
 
-    def test_plan_database_error_during_subscription_post(self, rf, user_factory, mocker, mock_django_session):
+    def test_plan_database_error_during_subscription_post(
+        self, rf, user_factory, mocker, mock_django_session
+    ):
         """Database errors during subscription POST should be handled"""
         user = user_factory()
-        
+
         form_data = {
             "step": "subscribe",
             "plan": "999",  # Non-existent plan ID
             "organization": str(user.individual_organization.pk),
-            "stripe_token": "tok_test123"
+            "stripe_token": "tok_test123",
         }
-        request = self._create_post_request(rf, user, mock_django_session, form_data, {
-            "onboarding": {"subscription": "not_started"}
-        })
-        
-        # Mock Plan.DoesNotExist on pk lookup
-        mocker.patch('squarelet.users.views.Plan.objects.get', side_effect=Plan.DoesNotExist())
+        request = self._create_post_request(
+            rf,
+            user,
+            mock_django_session,
+            form_data,
+            {"onboarding": {"subscription": "not_started"}},
+        )
 
-        mocker.patch('squarelet.users.views.messages.error')
-        
+        # Mock Plan.DoesNotExist on pk lookup
+        mocker.patch(
+            "squarelet.users.views.Plan.objects.get", side_effect=Plan.DoesNotExist()
+        )
+
+        mocker.patch("squarelet.users.views.messages.error")
+
         view_instance = self.view.as_view()
-        
+
         # Should rerender the current view with form errors
         response = view_instance(request)
         # If successful, should respond gracefully
         assert response.status_code == 302
-        
-

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -1,4 +1,5 @@
 # Django
+from click import group
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -45,6 +46,7 @@ from allauth.mfa.totp.internal.flows import activate_totp
 from allauth.mfa.utils import is_mfa_enabled
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout
+from requests import session
 
 # Squarelet
 from squarelet.core.forms import ImagePreviewWidget
@@ -155,89 +157,288 @@ class UserListView(LoginRequiredMixin, ListView):
     model = User
 
 
-class UserOnboardingView(TemplateView):
-    """Show onboarding steps for new or existing users after they log in"""
+class OnboardingStep:
+    """Base class for onboarding steps"""
 
-    template_name = "account/onboarding/base.html"  # Base template with includes
+    name = None
+    template_name = None
 
-    def get_onboarding_step(self, request):
-        # pylint: disable=too-many-locals, too-many-return-statements
-        """
-        Check user account status and return the appropriate onboarding step
-        Returns: (step_name, context_data)
-        """
+    def should_execute(self, request):
+        """Check if this step should be executed"""
+        raise NotImplementedError
+
+    def get_context_data(self, request):
+        """Return context data for the step"""
+        return {}
+
+    def handle_post(self, request):
+        """Handle POST requests for the step"""
+        return None
+    
+    def get_template_name(self):
+        """Return the template name for the step"""
+        return self.template_name or f"account/onboarding/{self.name}.html"
+
+
+class EmailConfirmationStep(OnboardingStep):
+    """Step for confirming the user's email address"""
+
+    name = "confirm_email"
+
+    def should_execute(self, request):
+        """Show this step if the user has not confirmed their email"""
         user = request.user
         session = request.session
-        # check_for = session.get("checkFor", [])
+        onboarding = session.get("onboarding", {})
 
-        # Initialize onboarding session if it doesn't exist
-        if "onboarding" not in session or not isinstance(session["onboarding"], dict):
-            session["onboarding"] = {}
-
-        for key, value in ONBOARDING_SESSION_DEFAULTS:
-            session["onboarding"].setdefault(key, value)
-
-        # Onboarding progress state is tracked in the session
-        onboarding = session["onboarding"]
         if has_verified_email(user):
             onboarding["email_check_completed"] = True
             session.modified = True
-        elif not onboarding["email_check_completed"]:
-            return "confirm_email", {
-                "email": user.email,
-            }
+            return False
+        
+        return not onboarding.get("email_check_completed", False)
 
-        # TODO: Verification check
+    def get_context_data(self, request):
+        return { "email": request.user.email }
 
-        # Organization check
-        has_orgs = user.organizations.filter(individual=False).exists()
+    def handle_post(self, request):
+        """Mark email confirmation as completed"""
+        if request.POST.get("step") == self.name:
+            request.session["onboarding"]["email_check_completed"] = True
+            request.session.modified = True
+        return True
+
+
+class OrganizationJoinStep(OnboardingStep):
+    """Prompt users to join an organization"""
+    
+    name = "join_org"
+
+    def _get_joinable_orgs(self, user):
+        """Get organizations the user can join"""
         invitations = list(user.get_pending_invitations())
         potential_orgs = list(
             user.get_potential_organizations().filter(allow_auto_join=True)
         )
-        joinable_orgs_count = len(invitations + potential_orgs)
-        if not has_orgs and not onboarding["join_org"] and joinable_orgs_count > 0:
-            return "join_org", {
-                "invitations": invitations,
-                "potential_orgs": potential_orgs,
-                "joinable_orgs_count": len(invitations + potential_orgs),
-            }
+        return invitations, potential_orgs
 
-        # Subscription check
-        # If the user is signing up for a plan, the "plan" session variable
-        # will be set to the plan slug. If not, it will be None.
-        # We want to load both the individual and organization plans,
-        # and then pass through the "active" plan based on the user's choice.
-        # In order to enter the step, we need to check:
-        # 1. if the plan is valid
-        # 2. if the plan is professional, that the user is not already subscribed
-        # 3. that the subscription step state is `not_started`
-        plan = session.get("plan", None) or request.GET.get("plan", None)
+    def should_execute(self, request):
+        """Show if user has no organizations and can join one"""
+        user = request.user
+        session = request.session
+        onboarding = session.get("onboarding", {})
+
+        has_orgs = user.organizations.filter(individual=False).exists()
+        if has_orgs or onboarding.get("join_org", False):
+            return False
+        
+        invitations, potential_orgs = self._get_joinable_orgs(user)
+        return len(invitations + potential_orgs) > 0
+
+    def get_context_data(self, request):
+        user = request.user
+        invitations, potential_orgs = self._get_joinable_orgs(user)
+        return {
+            "invitations": invitations,
+            "potential_orgs": potential_orgs,
+            "joinable_orgs_count": len(invitations + potential_orgs),
+        }
+    
+    def handle_post(self, request):
+        """Handle organization joining form submission"""
+        if request.POST.get("step") != self.name:
+            return None
+            
+        # Handle skip action
+        if request.POST.get("join_org") == "skip":
+            request.session["onboarding"]["join_org"] = True
+            request.session.modified = True
+            return True
+            
+        # TODO: Add handling for actual organization joining
+        # This would involve processing invitation acceptances or
+        # automatic organization joining based on the form data
+        
+        return None
+
+
+class SubscriptionStep(OnboardingStep):
+    """Handle subscription onboarding step"""
+    # If the user is signing up for a plan, the "plan" session variable
+    # will be set to the plan slug. If not, it will be None.
+    # We want to load both the individual and organization plans,
+    # and then pass through the "active" plan based on the user's choice.
+    # In order to enter the step, we need to check:
+    # 1. if the plan is valid
+    # 2. if the plan is professional, that the user is not already subscribed
+    # 3. that the subscription step state is `not_started`
+
+    name = "subscribe"
+
+    def _get_subscription_plans(self, request):
+        """Get subscription data for the step"""
+        user = request.user
+        session = request.session
+        plan_slug = session.get("plan", None) or request.GET.get("plan", None)
+
+        plans = {
+            "individual": None,
+            "group": None,
+            "selected": None,
+        }
+
+        if not plan_slug:
+            return plans
+
+        try:
+            plans["individual"] = Plan.objects.get(slug="professional")
+            plans["group"] = Plan.objects.get(slug="organization")
+            plans["selected"] = Plan.objects.get(slug=plan_slug)
+            return plans
+        except Plan.DoesNotExist:
+            print("Invalid plan slug:", plan_slug)
+            return plans
+    
+    def should_execute(self, request):
+        """Show this step if the user has no active subscription"""
+        user = request.user
+        session = request.session
+        onboarding = session.get("onboarding", {})
+
+        # The state of the step should be "not_started"
+        if onboarding.get("subscription") != "not_started":
+            return False
+        # The plans should all exist
+        plans = self._get_subscription_plans(request)
+        found_plans = all(plans.values())
+        if not found_plans:
+            return False
+        # If the selected plan is "professional",
+        # check if the user has an active subscription
         if (
-            plan == "professional"
+            plans["selected"].slug == "professional"
             and user.individual_organization.has_active_subscription()
-            and onboarding["subscription"] == "not_started"
         ):
-            # User is already subscribed to the professional plan
             onboarding["subscription"] = "completed"
             session["plan"] = None
             session.modified = True
-        if plan and onboarding["subscription"] == "not_started":
-            try:
-                individual_plan = Plan.objects.get(slug="professional")
-                group_plan = Plan.objects.get(slug="organization")
-                selected_plan = Plan.objects.get(slug=plan)
-                return "subscribe", {
-                    "plans": {
-                        "individual": individual_plan,
-                        "group": group_plan,
-                        "selected": selected_plan,
-                    }
-                }
-            except Plan.DoesNotExist:
-                print("Invalid plan slug:", plan)
-        # MFA check
-        # Check if this is user's first login
+            return False
+        # We have ruled out the negative cases,
+        # so we can show the subscription step
+        return True
+    
+    def get_context_data(self, request):
+        """Return context data for the subscription step"""
+        user = request.user
+        plans = self._get_subscription_plans(request)
+        if not all(plans.values()):
+            return {}
+
+        # Check for a form with errors from a failed POST
+        error_form = getattr(request.session, '_subscription_form_errors', None)
+        if error_form:
+            if error_form.plan == plans["individual"]:
+                individual_form = error_form
+                group_form = PremiumSubscriptionForm(
+                    plan=plans["group"], user=request.user
+                )
+            else:
+                individual_form = PremiumSubscriptionForm(
+                    plan=plans["individual"], user=request.user
+                )
+                group_form = error_form
+        else:
+            # Create fresh forms
+            individual_form = PremiumSubscriptionForm(
+                plan=plans["individual"], user=request.user
+            )
+            group_form = PremiumSubscriptionForm(
+                plan=plans["group"], user=request.user
+            )
+
+        # Get organizations for the user
+        individual_org = user.individual_organization
+        group_orgs = user.organizations.filter(
+            individual=False,
+            memberships__user=user,
+            memberships__admin=True,
+        ).order_by("name")
+
+        return {
+            "plans": plans,
+            "forms": {
+                "individual": individual_form,
+                "group": group_form,
+            },
+            "individual_org": individual_org,
+            "group_orgs": group_orgs,
+        }
+
+    def handle_post(self, request):
+        """Handle subscription form submission"""
+        # The form will have the plan, the organization, and the Stripe token
+        # First, check for a step mismatch:
+        if request.POST.get("step") != self.name:
+            return False
+        
+        # Then, check if the user skipped this step:
+        if request.POST.get("submit-type") == "skip":
+            request.session["onboarding"]["subscription"] = "completed"
+            request.session.modified = True
+            messages.info(request, "Subscription skipped.")
+            return True
+        
+        # Finally, initialize the form with the submitted data, validate it, and
+        # save it if valid. If invalid, rerender the page with the form errors.
+        plan_id = request.POST.get("plan")
+        org_id = request.POST.get("organization")
+        
+        try: 
+            plan_id = int(plan_id)
+            plan = Plan.objects.get(pk=plan_id)
+        except (ValueError, TypeError, Plan.DoesNotExist) as e:
+            messages.error(request, "Invalid plan selected.")
+            return False # Let the view re-render with the error
+
+        form = PremiumSubscriptionForm(request.POST, plan=plan, user=request.user)
+        if form.is_valid() and form.save(request.user):
+            # Create a subscription for the selected organization
+            messages.success(request, "Subscription created successfully.")
+            request.session["onboarding"]["subscription"] = "completed"
+            request.session.modified = True
+            return True
+        else:
+            # Store the form with errors for re-rendering
+            setattr(request.session, '_subscription_form_errors', form)
+            messages.error(
+                request, "Error creating subscription. Please try again."
+            )
+            return False
+
+
+class MFAOptInStep(OnboardingStep):
+    """Step for opting into MFA"""
+
+    name = "mfa_opt_in"
+
+    def should_execute(self, request):
+        """Show this step if the user has not opted into MFA"""
+        user = request.user
+        session = request.session
+        onboarding = session.get("onboarding", {})
+        mfa_step = onboarding.get("mfa_step", "not_started")
+
+        # If the user has already opted in or completed MFA, skip this step
+        if mfa_step != "not_started":
+            return False
+        
+        # If the user has MFA enabled, skip this step
+        if is_mfa_enabled(user):
+            onboarding["mfa_step"] = "completed"
+            session.modified = True
+            return False
+
+        # Skip if not the right time to prompt
         is_first_login = request.session.get("first_login", False)
         is_snoozed = (
             user.last_mfa_prompt
@@ -246,27 +447,203 @@ class UserOnboardingView(TemplateView):
         )
         # 2FA setup will fail if the user has any unverified emails,
         # even if they are not the primary email
-        has_unverified_email = not has_verified_email(user) or (
+        has_any_unverified_email = not has_verified_email(user) or (
             EmailAddress.objects.filter(user=user, verified=False).exists()
         )
-        mfa_step = onboarding.get("mfa_step", None)
-        # Check for the "code_submitted" step first, since
-        # is_mfa_enabled will be true when the step is active
-        if mfa_step == "code_submitted":
-            return "mfa_confirm", {}
-        # Otherwise, if the user has MFA enabled, or if it's
-        # not the right time to prompt, mark step as checked
-        elif (
-            is_mfa_enabled(user) or is_first_login or is_snoozed or has_unverified_email
-        ):
+
+        if is_first_login or is_snoozed or has_any_unverified_email:
             onboarding["mfa_step"] = "completed"
             session.modified = True
-        # Finally, if the user doesn't have MFA enabled,
-        # ask if they want to opt-in, or show them setup
-        elif mfa_step == "not_started":
-            return "mfa_opt_in", {}
-        elif mfa_step == "opted_in":
-            return "mfa_setup", {}
+            return False
+        
+        return True
+    
+    def handle_post(self, request):
+        """Handle the user's choice to enable or skip MFA"""
+        if request.POST.get("step") != self.name:
+            return False
+        choice = request.POST.get("enable_mfa")
+        if choice == "yes":
+            # User opted-in for MFA, move to next step
+            request.session["onboarding"]["mfa_step"] = "opted_in"
+            request.session.modified = True
+            return True
+        else:
+            # User skipped MFA, mark as completed
+            messages.info(request, "Two-factor authentication skipped.")
+            request.session["onboarding"]["mfa_step"] = "completed"
+            request.session.modified = True
+
+            # Update last_mfa_prompt to now
+            request.user.last_mfa_prompt = timezone.now()
+            request.user.save(update_fields=["last_mfa_prompt"])
+            return True
+
+
+class MFASetupStep(OnboardingStep):
+    """Show QR code and collect TOTP code"""
+    
+    name = "mfa_setup"
+
+    def should_execute(self, request):
+        """Show MFA setup if user has opted in"""
+        session = request.session
+        onboarding = session.get("onboarding", {})
+        mfa_step = onboarding.get("mfa_step", "not_started")
+        return mfa_step == "opted_in"
+    
+    def get_context_data(self, request):
+        """Return MFA setup form and QR code"""
+        # First check if we have a form with errors from a previous POST
+        error_form = getattr(request.session, '_mfa_setup_form_errors', None)
+        if error_form:
+            # If we have an error form, use it
+            form = error_form
+        else:
+            # Otherwise, create a new form
+            form = ActivateTOTPForm(user=request.user)
+        
+        # Generate the TOTP URL and SVG
+        adapter = get_adapter()
+        totp_url = adapter.build_totp_url(request.user, form.secret)
+        totp_svg = adapter.build_totp_svg(totp_url)
+        base64_data = base64.b64encode(totp_svg.encode("utf8")).decode("utf-8")
+        totp_data_uri = f"data:image/svg+xml;base64,{base64_data}"
+
+        return {
+            "form": form,
+            "totp_svg": totp_svg,
+            "totp_svg_data_uri": totp_data_uri,
+            "totp_url": totp_url,
+        }
+    
+    def handle_post(self, request):
+        """Handle MFA setup form submission"""
+        if request.POST.get("step") != self.name:
+            return None
+        
+        # Check if the user skipped the MFA setup step
+        if request.POST.get("mfa_setup") == "skip":
+            # User skipped MFA, mark as completed
+            request.session["onboarding"]["mfa_step"] = "completed"
+            request.session.modified = True
+            # Update last_mfa_prompt to now
+            request.user.last_mfa_prompt = timezone.now()
+            request.user.save(update_fields=["last_mfa_prompt"])
+            messages.info(request, "Two-factor authentication skipped.")
+            return True
+        # Process MFA setup - validate the code
+        form = ActivateTOTPForm(user=request.user, data=request.POST)
+        if form.is_valid():
+            # Code validated successfully
+            activate_totp(request, form)
+            request.session["onboarding"]["mfa_step"] = "code_submitted"
+            request.session.modified = True
+            messages.success(request, "Two-factor authentication enabled.")
+            return True
+        else:
+            # Rerender form with errors
+            setattr(request.session, '_mfa_setup_form_errors', form)
+            messages.error(request, "Invalid verification code. Please try again.")
+            return False
+
+
+class MFAConfirmStep(OnboardingStep):
+    """Confirmation step after MFA setup"""
+
+    name = "mfa_confirm"
+
+    def should_execute(self, request):
+        """Show this step if the user has submitted the MFA code"""
+        session = request.session
+        onboarding = session.get("onboarding", {})
+        mfa_step = onboarding.get("mfa_step", "not_started")
+        return mfa_step == "code_submitted"
+    
+    def handle_post(self, request):
+        """Mark MFA as completed"""
+        if request.POST.get("step") == self.name:
+            # User has seen the confirmation screen, mark MFA as completed
+            request.session["onboarding"]["mfa_step"] = "completed"
+            request.session.modified = True
+            return True
+        return None
+
+
+class OnboardingStepRegistry:
+    """Registry for managing onboarding steps"""
+    
+    def __init__(self):
+        self.steps = [
+            EmailConfirmationStep(),
+            OrganizationJoinStep(),
+            SubscriptionStep(),
+            MFAOptInStep(),
+            MFASetupStep(),
+            MFAConfirmStep(),
+            # More steps will be added here as we migrate them
+            # TODO: Verification check
+        ]
+    
+    def get_current_step(self, request):
+        """Find the first step that should be executed"""
+        for step in self.steps:
+            if step.should_execute(request):
+                return step.name, step.get_context_data(request)
+        return None, {}
+    
+    def get_step_by_name(self, name):
+        """Get a specific step by name"""
+        for step in self.steps:
+            if step.name == name:
+                return step
+        return None
+    
+    def handle_post(self, request, step_name):
+        """Handle POST request for a specific step"""
+        step = self.get_step_by_name(step_name)
+        if step:
+            return step.handle_post(request)
+        return None
+
+    def get_template_names(self, request, step_name):
+        """Get the template names for a specific step"""
+        step = self.get_step_by_name(step_name)
+        if step:
+            return [step.get_template_name()]
+        return []
+
+class UserOnboardingView(TemplateView):
+    """Show onboarding steps for new or existing users after they log in"""
+
+    template_name = "account/onboarding/base.html"  # Base template with includes
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.step_registry = OnboardingStepRegistry()
+
+    def _initialize_onboarding_session(self, request):
+        """Initialize the onboarding session with default values"""
+        session = request.session
+        if "onboarding" not in session or not isinstance(session["onboarding"], dict):
+            session["onboarding"] = {}
+        for key, value in ONBOARDING_SESSION_DEFAULTS:
+            session["onboarding"].setdefault(key, value)
+
+    def get_onboarding_step(self, request):
+        # pylint: disable=too-many-locals, too-many-return-statements
+        """
+        Check user account status and return the appropriate onboarding step
+        Returns: (step_name, context_data)
+        """
+        self._initialize_onboarding_session(request)
+
+        # Check registry steps
+        # check_for = session.get("checkFor", [])
+        step_name, context = self.step_registry.get_current_step(request)
+        if step_name:
+            # If a step is found, return it immediately
+            return step_name, context
 
         # If all checks pass, user has completed onboarding
         return None, {}
@@ -276,7 +653,7 @@ class UserOnboardingView(TemplateView):
         step, _ = self.get_onboarding_step(self.request)
 
         if step:
-            return [f"account/onboarding/{step}.html"]
+            return self.step_registry.get_template_names(self.request, step)
 
         return [self.template_name]
 
@@ -292,53 +669,6 @@ class UserOnboardingView(TemplateView):
         context["next_url"] = self.request.session.get("next_url", "/")
         context["intent"] = self.request.session.get("intent", None)
         context["service"] = Service.objects.filter(slug=context["intent"]).first()
-
-        # For Subscription, initialize the form and get the user's organizations
-        if step == "subscribe":
-            plans = step_context.get("plans")
-            if plans:
-                individual_form = PremiumSubscriptionForm(
-                    plan=plans["individual"], user=self.request.user
-                )
-                group_form = PremiumSubscriptionForm(
-                    plan=plans["group"], user=self.request.user
-                )
-            context.update(
-                {
-                    "forms": {
-                        "individual": individual_form,
-                        "group": group_form,
-                    },
-                    "individual_org": self.request.user.individual_organization,
-                    "group_orgs": (
-                        self.request.user.organizations.filter(
-                            individual=False,
-                            memberships__user=self.request.user,
-                            memberships__admin=True,
-                        ).order_by("name")
-                    ),
-                }
-            )
-
-        # For MFA setup, initialize the form and generate the SVG
-        if step == "mfa_setup":
-            activate_totp_form = ActivateTOTPForm(user=self.request.user)
-            context["form"] = activate_totp_form
-            adapter = get_adapter()
-            totp_url = adapter.build_totp_url(
-                self.request.user,
-                context["form"].secret,
-            )
-            totp_svg = adapter.build_totp_svg(totp_url)
-            base64_data = base64.b64encode(totp_svg.encode("utf8")).decode("utf-8")
-            totp_data_uri = f"data:image/svg+xml;base64,{base64_data}"
-            context.update(
-                {
-                    "totp_svg": totp_svg,
-                    "totp_svg_data_uri": totp_data_uri,
-                    "totp_url": totp_url,
-                }
-            )
 
         return context
 
@@ -365,112 +695,26 @@ class UserOnboardingView(TemplateView):
         # Otherwise, show the appropriate onboarding step
         return super().get(request, *args, **kwargs)
 
-    # TODO: Refactor the UserOnboardingView to reduce branches and statements,
-    # perhaps using a dictionary to map steps to their respective handlers.
-    # pylint: disable=too-many-branches, too-many-statements
     def post(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
             return redirect("account_login")
+        
+        self._initialize_onboarding_session(request)
 
         # Handle any form submissions for the current onboarding step
         step = request.POST.get("step")
-        if step == "confirm_email":
-            # User has confirmed their email, mark as completed
-            request.session["onboarding"]["email_check_completed"] = True
-            request.session.modified = True
+        current_step_name, _ = self.get_onboarding_step(request)
 
-        elif step == "mfa_opt_in":
-            choice = request.POST.get("enable_mfa")
-            if choice == "yes":
-                # User opted-in for MFA, move to next step
-                request.session["onboarding"]["mfa_step"] = "opted_in"
-            else:
-                # User skipped MFA, mark as completed
-                messages.info(request, "Two-factor authentication skipped.")
-                request.session["onboarding"]["mfa_step"] = "completed"
-
-                # Update last_mfa_prompt to now
-                request.user.last_mfa_prompt = timezone.now()
-                request.user.save(update_fields=["last_mfa_prompt"])
-            request.session.modified = True
-
-        elif step == "mfa_setup":
-            # Check if the user skipped the MFA setup step
-            if request.POST.get("mfa_setup") == "skip":
-                # User skipped MFA, mark as completed
-                request.session["onboarding"]["mfa_step"] = "completed"
-                request.session.modified = True
-                # Update last_mfa_prompt to now
-                request.user.last_mfa_prompt = timezone.now()
-                request.user.save(update_fields=["last_mfa_prompt"])
-                messages.info(request, "Two-factor authentication skipped.")
-                return redirect("account_onboarding")
-            # Process MFA setup - validate the code
-            form = ActivateTOTPForm(user=request.user, data=request.POST)
-            if form.is_valid():
-                # Code validated successfully
-                activate_totp(self.request, form)
-                request.session["onboarding"]["mfa_step"] = "code_submitted"
-                request.session.modified = True
-                messages.success(request, "Two-factor authentication enabled.")
-            else:
-                # Rerender form with errors
-                context = self.get_context_data(**kwargs)
-                context["form"] = form
-                messages.error(request, "Invalid verification code. Please try again.")
-                return self.render_to_response(context)
-
-        elif step == "mfa_confirm":
-            # User has seen the confirmation screen, mark MFA as completed
-            request.session["onboarding"]["mfa_step"] = "completed"
-            request.session.modified = True
-
-        elif step == "subscribe":
-            # Handle subscription form submission
-            # the form will have the plan, the organization, and the Stripe token
-            # ---
-            # First, check if the user skipped this step
-            if request.POST.get("submit-type") == "skip":
-                request.session["onboarding"]["subscription"] = "completed"
-                request.session.modified = True
-                messages.info(request, "Subscription skipped.")
-                return redirect("account_onboarding")
-            # Otherwise, initialize the form with the submitted data,
-            # validate it, and save it if valid. If invalid, rerender
-            # the page with the form errors.
-            plan_id = request.POST.get("plan")
-            org_id = request.POST.get("organization")
-            try: 
-                plan_id = int(plan_id)
-                plan = Plan.objects.get(pk=plan_id)
-            except (ValueError, TypeError, Plan.DoesNotExist) as e:
-                messages.error(request, "Invalid plan selected.")
-                context = self.get_context_data(**kwargs)
-                return self.render_to_response(context)
-            form = PremiumSubscriptionForm(request.POST, plan=plan, user=request.user)
-            if form.is_valid() and form.save(request.user):
-                # Create a subscription for the selected organization
-                messages.success(request, "Subscription created successfully.")
-                request.session["onboarding"]["subscription"] = "completed"
-                request.session.modified = True
-            else:
-                context = self.get_context_data(**kwargs)
-                if org_id == request.user.individual_organization.pk:
-                    context["forms"]["individual"] = form
-                else:
-                    context["forms"]["group"] = form
-                messages.error(
-                    request, "Error creating subscription. Please try again."
-                )
-                return self.render_to_response(context)
-
-        elif step == "join_org" and request.POST.get("join_org") == "skip":
-            request.session["onboarding"]["join_org"] = True
-            request.session.modified = True
-
-        # Redirect back to the same view to check the next step
+        # Try registry steps first
+        success = self.step_registry.handle_post(request, step)
+        if success == False and step == current_step_name:
+            # If registry step returned False, it means there was a validation error
+            # and we need to re-render the current step with errors
+            context = self.get_context_data(**kwargs)
+            return self.render_to_response(context)
+        
+        # Otherwise, reload the pipeline to get the next step
         return redirect("account_onboarding")
-
 
 class LoginView(AllAuthLoginView):
     def get(self, request, *args, **kwargs):

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -171,7 +171,7 @@ class UserOnboardingView(TemplateView):
         # check_for = session.get("checkFor", [])
 
         # Initialize onboarding session if it doesn't exist
-        if "onboarding" not in session:
+        if "onboarding" not in session or not isinstance(session["onboarding"], dict):
             session["onboarding"] = {}
 
         for key, value in ONBOARDING_SESSION_DEFAULTS:
@@ -440,7 +440,13 @@ class UserOnboardingView(TemplateView):
             # the page with the form errors.
             plan_id = request.POST.get("plan")
             org_id = request.POST.get("organization")
-            plan = Plan.objects.get(pk=plan_id)
+            try: 
+                plan_id = int(plan_id)
+                plan = Plan.objects.get(pk=plan_id)
+            except (ValueError, TypeError, Plan.DoesNotExist) as e:
+                messages.error(request, "Invalid plan selected.")
+                context = self.get_context_data(**kwargs)
+                return self.render_to_response(context)
             form = PremiumSubscriptionForm(request.POST, plan=plan, user=request.user)
             if form.is_valid() and form.save(request.user):
                 # Create a subscription for the selected organization


### PR DESCRIPTION
Closes #323 

This refactors the monolithic onboarding view class into a composable pipeline of isolated onboarding steps. Each step defines its template and context, whether it should be shown, and its handler for POST requests.

Before refactoring, I added comprehensive unit and integration tests for the `UserOnboardingView` class. I ensured that all major functionality was tested with expected behavior before making any changes.

## Manual testing

We should ensure that all onboarding behavior remains consistent (this can be avoided in the future if we introduce E2E tests!):

- [ ]  Confirming an email
- [ ]  Enabling 2FA
- [ ]  Accepting an invitation to an org
- [ ]  Subscribing to a premium plan (individual + organization)
