### PR TITLE
Social login flag

### DIFF
--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,4 +6,4 @@ set -o nounset
 
 
 python manage.py migrate
-python manage.py runserver_plus 0.0.0.0:80
+python manage.py runserver_plus --nopin 0.0.0.0:80

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -363,6 +363,12 @@ ACCOUNT_ADAPTER = "squarelet.users.adapters.AccountAdapter"
 ACCOUNT_PREVENT_ENUMERATION = False
 SOCIALACCOUNT_ADAPTER = "squarelet.users.adapters.SocialAccountAdapter"
 SOCIALACCOUNT_STORE_TOKENS = True
+SOCIALACCOUNT_AUTO_SIGNUP = False
+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
+SOCIALACCOUNT_EMAIL_REQUIRED = True
+SOCIALACCOUNT_QUERY_EMAIL = True
+
 ACCOUNT_FORMS = {
     "signup": "squarelet.users.forms.SignupForm",
     "login": "squarelet.users.forms.LoginForm",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -121,7 +121,7 @@ django-email-bandit==1.5
     # via -r requirements/base.in
 django-environ==0.4.4
     # via -r requirements/base.in
-django-extensions==3.2.3
+django-extensions==4.1
     # via -r requirements/base.in
 django-filter==21.1
     # via -r requirements/base.in
@@ -264,9 +264,7 @@ python-levenshtein==0.25.1
 python-slugify==1.2.5
     # via -r requirements/base.in
 pytz==2024.2
-    # via
-    #   -r requirements/base.in
-    #   djangorestframework
+    # via -r requirements/base.in
 qrcode==8.0
     # via django-allauth
 rapidfuzz==3.9.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -77,9 +77,7 @@ bz2file==0.98
     #   -r requirements/base.txt
     #   smart-open
 cachecontrol[filecache]==0.14.2
-    # via
-    #   cachecontrol
-    #   pip-audit
+    # via pip-audit
 celery==5.4.0
     # via -r requirements/base.txt
 certifi==2024.7.4
@@ -196,7 +194,7 @@ django-email-bandit==1.5
     # via -r requirements/base.txt
 django-environ==0.4.4
     # via -r requirements/base.txt
-django-extensions==3.2.3
+django-extensions==4.1
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
@@ -529,7 +527,6 @@ pytz==2024.2
     # via
     #   -r requirements/base.txt
     #   babel
-    #   djangorestframework
 qrcode==8.0
     # via
     #   -r requirements/base.txt
@@ -681,7 +678,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==3.1.3
+werkzeug==3.0.2
     # via -r requirements/local.in
 wheel==0.45.1
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -179,7 +179,7 @@ django-email-bandit==1.5
     # via -r requirements/base.txt
 django-environ==0.4.4
     # via -r requirements/base.txt
-django-extensions==3.2.3
+django-extensions==4.1
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
@@ -393,9 +393,7 @@ python-levenshtein==0.25.1
 python-slugify==1.2.5
     # via -r requirements/base.txt
 pytz==2024.2
-    # via
-    #   -r requirements/base.txt
-    #   djangorestframework
+    # via -r requirements/base.txt
 qrcode==8.0
     # via
     #   -r requirements/base.txt

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -27,7 +27,7 @@
   header {
     text-align: center;
   }
-  header h2 {
+  header h2, p {
     max-width: 18rem;
   }
   .help.link {
@@ -83,75 +83,98 @@
 {% endblock %}
 
 {% block login_step %}
-  <div class="wrapper" id="form">
-    <form class="signup-form m-0" id="signup_form" method="POST">
-      <header>
-        {% sign_up_message %}
-      </header>
-      <main class="fields">
-        {% csrf_token %}
-        {{form.non_field_errors}}
-        {{form.plan}}
-        <label class="field">
-          <span class="label">
-            {{form.email.label}}
-            {% if form.email.field.required %}<span class="required">Required</span>{% endif %}
-          </span>
-          {{form.email}}
-          {{form.email.errors}}
-          <div class="help text">
-            {{ form.email.help_text }}
+  {% if confirm_sociallogin %}
+    <div class="wrapper" id="form">
+      <div class="signup-form m-0">
+        <header>
+          <div>
+            <h2>Please confirm</h2>
+            <p>
+              We don't see an existing account with that email address. If you
+              already have an account with MuckRock or DocumentCloud, please
+              log in and add {{ sociallogin_email }} to your account. If you are new
+              to our services, create an account now.
+            </p>
+            <a class="help link" href="{% url "account_login" %}">
+              Sign in to an existing account
+            </a>
+            <br>
+            <a class="help link" href="?confirm=1">Create a new account</a>
           </div>
-        </label>
-        <label class="field">
-          <span class="label">
-            {{form.name.label}}
-            {% if form.name.field.required %}<span class="required">Required</span>{% endif %}
-          </span>
-          {{form.name}}
-          {{form.name.errors}}
-          <div class="help text">
-            {{ form.name.help_text }}
-          </div>
-        </label>
-        <label class="field">
-          <span class="label">
-            {{form.username.label}}
-            {% if form.username.field.required %}<span class="required">Required</span>{% endif %}
-          </span>
-          {{form.username}}
-          {{form.username.errors}}
-          <div class="help text">
-            {{ form.username.help_text }}
-          </div>
-        </label>
-        <label class="field">
-          <span class="label">
-            {{form.password1.label}}
-            {% if form.password1.field.required %}<span class="required">Required</span>{% endif %}
-          </span>
-          {{form.password1}}
-          {{form.password1.errors}}
-          <div class="help text">
-            {{ form.password1.help_text }}
-          </div>
-        </label>
-        <label class="field">
-          <span class="label">
-          {{ form.tos }}
-          <span>I accept MuckRock&rsquo;s <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/tos/">Terms of Service</a> and <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/privacy-policy/">Privacy Policy</a>.</span>
-          {% if form.tos.field.required %}<span class="required">Required</span>{% endif %}
-          </span>
-          {{ form.tos.errors }}
-        </label>
-      </main>
+        </header>
+      </div>
+    </div>
+  {% else %}
+    <div class="wrapper" id="form">
+      <form class="signup-form m-0" id="signup_form" method="POST">
+        <header>
+          {% sign_up_message %}
+        </header>
+        <main class="fields">
+          {% csrf_token %}
+          {{form.non_field_errors}}
+          {{form.plan}}
+          <label class="field">
+            <span class="label">
+              {{form.email.label}}
+              {% if form.email.field.required %}<span class="required">Required</span>{% endif %}
+            </span>
+            {{form.email}}
+            {{form.email.errors}}
+            <div class="help text">
+              {{ form.email.help_text }}
+            </div>
+          </label>
+          <label class="field">
+            <span class="label">
+              {{form.name.label}}
+              {% if form.name.field.required %}<span class="required">Required</span>{% endif %}
+            </span>
+            {{form.name}}
+            {{form.name.errors}}
+            <div class="help text">
+              {{ form.name.help_text }}
+            </div>
+          </label>
+          <label class="field">
+            <span class="label">
+              {{form.username.label}}
+              {% if form.username.field.required %}<span class="required">Required</span>{% endif %}
+            </span>
+            {{form.username}}
+            {{form.username.errors}}
+            <div class="help text">
+              {{ form.username.help_text }}
+            </div>
+          </label>
+          <label class="field">
+            <span class="label">
+              {{form.password1.label}}
+              {% if form.password1.field.required %}<span class="required">Required</span>{% endif %}
+            </span>
+            {{form.password1}}
+            {{form.password1.errors}}
+            <div class="help text">
+              {{ form.password1.help_text }}
+            </div>
+          </label>
+          <label class="field">
+            <span class="label">
+            {{ form.tos }}
+            <span>I accept MuckRock&rsquo;s <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/tos/">Terms of Service</a> and <a target="_blank" rel="noopener noreferer" href="https://www.muckrock.com/privacy-policy/">Privacy Policy</a>.</span>
+            {% if form.tos.field.required %}<span class="required">Required</span>{% endif %}
+            </span>
+            {{ form.tos.errors }}
+          </label>
+        </main>
 
-      <footer>
-        <button class="button primary">{% trans 'Sign up' %}</button>
-        <a class="button primary ghost" href="{% url 'account_login' %}{% pass_query %}">
-          {% blocktrans %}Already have an account? Sign in{% endblocktrans %}
-        </a>
-      </footer>
-    </form>
-  </div>
+        <footer>
+          <button class="button primary">{% trans 'Sign up' %}</button>
+          <a class="button primary ghost" href="{% url 'account_login' %}{% pass_query %}">
+            {% blocktrans %}Already have an account? Sign in{% endblocktrans %}
+          </a>
+        </footer>
+      </form>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/squarelet/templates/account/signup.html
+++ b/squarelet/templates/account/signup.html
@@ -24,6 +24,10 @@
     margin-top: 0;
     max-width: 24rem;
   }
+  .social-account {
+    margin: 2rem;
+    max-width: 32rem;
+  }
   header {
     text-align: center;
   }
@@ -85,23 +89,21 @@
 {% block login_step %}
   {% if confirm_sociallogin %}
     <div class="wrapper" id="form">
-      <div class="signup-form m-0">
-        <header>
-          <div>
-            <h2>Please confirm</h2>
-            <p>
-              We don't see an existing account with that email address. If you
-              already have an account with MuckRock or DocumentCloud, please
-              log in and add {{ sociallogin_email }} to your account. If you are new
-              to our services, create an account now.
-            </p>
-            <a class="help link" href="{% url "account_login" %}">
-              Sign in to an existing account
-            </a>
-            <br>
-            <a class="help link" href="?confirm=1">Create a new account</a>
-          </div>
-        </header>
+      <div class="social-account">
+        <h2>Account not found</h2>
+        <p>
+          We don't see an existing account for the email address
+          {{ sociallogin_email|default:"you used" }}.
+        </p>
+        <p>
+          If you already have an account with MuckRock or DocumentCloud,
+          please sign in and add this email address to your account:
+        </p>
+        <a class="button primary" href="{% url "account_login" %}">
+          Sign in to an existing account
+        </a>
+        <p>If you are new to our services, you can create an account now:</p>
+        <a class="ghost button primary" href="?confirm=1">Create a new account</a>
       </div>
     </div>
   {% else %}

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -1,7 +1,6 @@
 # Django
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import login
 from django.contrib.sites.shortcuts import get_current_site
 from django.http.response import HttpResponseRedirect
 from django.template.loader import render_to_string
@@ -11,10 +10,8 @@ from django.utils.translation import gettext_lazy as _
 
 # Third Party
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.account.models import EmailAddress
 from allauth.account.signals import user_logged_in
 from allauth.account.utils import get_login_redirect_url
-from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.mfa.adapter import DefaultMFAAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from furl import furl
@@ -22,8 +19,6 @@ from furl import furl
 # Squarelet
 from squarelet.core.mail import Email
 from squarelet.organizations.models import Invitation
-from squarelet.users.models import User
-from squarelet.users.serializers import UserWriteSerializer
 
 
 class AccountAdapter(DefaultAccountAdapter):

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -106,7 +106,7 @@ class SignupForm(allauth.SignupForm):
         return data
 
     @transaction.atomic()
-    def save(self, request):
+    def save(self, request, setup_email=True):
 
         user_data = {
             "source": request.GET.get("intent", "squarelet").lower().strip()[:255]
@@ -120,7 +120,8 @@ class SignupForm(allauth.SignupForm):
         if plan and plan.requires_payment():
             request.session["plan"] = plan.slug
 
-        setup_user_email(request, user, [])
+        if setup_email:
+            setup_user_email(request, user, [])
 
         return user
 

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -276,12 +276,19 @@ class SignupView(AllAuthSignupView):
         kwargs["request"] = self.request
         return kwargs
 
+    def get(self, request, *args, **kwargs):
+        if self.request.session.get("socialaccount_sociallogin_clear"):
+            flows.signup.clear_pending_signup(self.request)
+            self.request.session.pop("socialaccount_sociallogin_clear")
+        return super().get(request, *args, **kwargs)
+
     def get_initial(self):
         initial = super().get_initial()
         sociallogin = flows.signup.get_pending_signup(self.request)
         if sociallogin:
             # pre-fill the form with the data the social provider returns
             initial = get_social_adapter().get_signup_form_initial_data(sociallogin)
+            self.request.session["socialaccount_sociallogin_clear"] = True
         return initial
 
     def form_valid(self, form):


### PR DESCRIPTION
Instead of automatically creating an account on social login, this confirms with the user if they want to log in to an existing account or create a new one.

@allanlasser - This probably needs some design tweaks

I used the copy supplied by @amandabee , but it can be further edited if needed

To test, attempt to use the social login with an email address that is not associated with an account.

https://squarelet-pi-social-log-dmdlac.herokuapp.com/accounts/login/