### PR TITLE
Adds filters to `/api/organization`

### DIFF
--- a/squarelet/organizations/filters.py
+++ b/squarelet/organizations/filters.py
@@ -1,0 +1,10 @@
+from django_filters import rest_framework as filters
+from .models import Organization
+
+class OrganizationFilter(filters.FilterSet):
+    verified = filters.BooleanFilter(field_name="verified_journalist")
+    individual = filters.BooleanFilter(field_name="individual")
+
+    class Meta:
+        model = Organization
+        fields = ["verified", "individual"]

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import IsAdminUser
 from squarelet.oidc.permissions import ScopePermission
 from squarelet.organizations.models import Charge, Organization
 from squarelet.organizations.serializers import ChargeSerializer, OrganizationSerializer
+from squarelet.organizations.filters import OrganizationFilter
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):
@@ -17,6 +18,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     write_scopes = ("write_organization",)
     lookup_field = "uuid"
     swagger_schema = None
+    filterset_class = OrganizationFilter
 
 
 class ChargeViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
As a client, I want to be able to filter the list of organizations to distinguish between private/public orgs, and verified/unverified orgs. This adds simple filters to the list endpoint to narrow down the returned orgs.