### PR TITLE
Adds social accounts to the Connected Accounts section of user page

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -67,3 +67,5 @@ DJANGO_VITE = {
         "manifest_path": str(ROOT_DIR.path("frontend/dist/manifest.json")),
     }
 }
+
+ENABLE_SOCIAL_LOGINS = env.bool("ENABLE_SOCIAL_LOGINS", default=True)

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,7 +16,13 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from squarelet.core.views import HomeView, SelectPlanView
 from squarelet.oidc.views import token_view
 from squarelet.organizations.viewsets import ChargeViewSet, OrganizationViewSet
-from squarelet.users.views import LoginView, SignupView, UserOnboardingView
+from squarelet.users.views import (
+    UserEmailView,
+    UserConnectionsView,
+    LoginView,
+    SignupView,
+    UserOnboardingView
+)
 from squarelet.users.viewsets import (
     RefreshTokenViewSet,
     UrlAuthTokenViewSet,
@@ -51,7 +57,9 @@ urlpatterns = [
         "organizations/",
         include("squarelet.organizations.urls", namespace="organizations"),
     ),
-    # override the accounts login with our version
+    # override the allauth views with our version
+    re_path("accounts/$", UserConnectionsView.as_view(), name="account_connections"),
+    re_path("accounts/email/$", UserEmailView.as_view(), name="account_email"),
     re_path("accounts/login/$", LoginView.as_view(), name="account_login"),
     re_path(
         "accounts/onboard/$", UserOnboardingView.as_view(), name="account_onboarding"

--- a/frontend/css/gps.css
+++ b/frontend/css/gps.css
@@ -344,6 +344,12 @@ h3 {
   cursor: initial;
 }
 
+.btn:disabled:hover,
+.btn.disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
+
 .btn.ghost:disabled {
   color: var(--gray-4, #5c717c);
   fill: var(--gray-4, #5c717c);

--- a/frontend/css/gps.css
+++ b/frontend/css/gps.css
@@ -128,16 +128,40 @@ h3 {
   width: fit-content;
 }
 
-.badge.verified {
+.badge.purple {
+  color: var(--purple-5, #0e4450);
+  border: 1px solid var(--purple-2, #9de3d3);
+  background: var(--purple-1, #ebf9f6);
+}
+
+.badge.blue {
+  color: var(--blue-5, #0e4450);
+  border: 1px solid var(--blue-2, #9de3d3);
+  background: var(--blue-1, #ebf9f6);
+}
+
+.badge.green {
+  color: var(--green-5, #0e4450);
   border: 1px solid var(--green-2, #9de3d3);
   background: var(--green-1, #ebf9f6);
+}
 
-  color: var(--green-5, #0e4450);
-  font-family: "Source Sans Pro";
-  font-size: var(--font-xs, 0.75rem);
-  font-style: normal;
-  font-weight: 600;
-  line-height: normal;
+.badge.yellow {
+  color: var(--yellow-5, #0e4450);
+  border: 1px solid var(--yellow-2, #9de3d3);
+  background: var(--yellow-1, #ebf9f6);
+}
+
+.badge.orange {
+  color: var(--orange-5, #0e4450);
+  border: 1px solid var(--orange-2, #9de3d3);
+  background: var(--orange-1, #ebf9f6);
+}
+
+.badge.red {
+  color: var(--red-5, #0e4450);
+  border: 1px solid var(--red-2, #9de3d3);
+  background: var(--red-1, #ebf9f6);
 }
 
 .btn {
@@ -165,7 +189,7 @@ h3 {
   white-space: nowrap;
 
   /* Colors */
-  fill: currentColor; // This will inherit the text color for SVG icons
+  fill: currentColor; /* This will inherit the text color for SVG icons */
   border: 1px solid var(--gray-4, #5c717c);
   background: var(--gray-3, #99a8b3);
   color: var(--gray-1, #f5f6f7);

--- a/frontend/css/user_detail.css
+++ b/frontend/css/user_detail.css
@@ -398,6 +398,46 @@ a.nav-item {
   gap: 0.5rem;
 }
 
+.social.account .account-detail {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.social.account .account-detail .icon {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.social.account .account-detail-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  flex: 1 0 auto;
+}
+
+.social.account .account-status {
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+.social.account .provider-label {
+  margin: 0;
+  font-size: var(--font-md, 1rem);
+  font-weight: var(--font-semibold, 600);
+  color: var(--gray-5, #233944);
+}
+
+.social.account .provider-account {
+  margin: 0;
+  font-size: var(--font-sm, 0.875rem);
+  color: var(--gray-5, #233944);
+}
+
 .connect-account-dropdown.card {
   padding: 0;
   overflow: hidden;
@@ -418,6 +458,7 @@ a.nav-item {
 .connect-account-form .help-text {
   margin: 0;
   text-align: center;
+  text-wrap: pretty;
   font-size: var(--font-sm, 1rem);
   color: var(--gray-5, #233944);
 }
@@ -567,7 +608,7 @@ a.nav-item {
   opacity: 0;
   transition: visibility 0s, opacity 0.2s ease-in-out;
   z-index: 1000;
-  display: flex;
+  display: none;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
@@ -576,6 +617,7 @@ a.nav-item {
   width: 20rem;
 }
 .dropdown-container.dropdown-open .dropdown {
+  display: flex;
   visibility: visible;
   opacity: 1;
 }

--- a/frontend/css/user_detail.css
+++ b/frontend/css/user_detail.css
@@ -398,6 +398,55 @@ a.nav-item {
   gap: 0.5rem;
 }
 
+.connect-account-dropdown.card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.connect-account-form {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.connect-account-form button {
+  width: 100%;
+}
+
+.connect-account-form .help-text {
+  margin: 0;
+  text-align: center;
+  font-size: var(--font-sm, 1rem);
+  color: var(--gray-5, #233944);
+}
+
+.email-input {
+  /* Layout */
+  box-sizing: border-box;
+  display: flex;
+  padding: 0.375rem 0.75rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 0 0;
+  /* Style */
+  appearance: none;
+  border-radius: 0.5rem;
+  border: 1px solid var(--gray-3, #99A8B3);
+  background: var(--white, #FFF);
+  box-shadow: 0 2px 0 0 #D8DEE2 inset;
+  /* Typography */
+  font-family: var(--font-sans, "Source Sans Pro");
+  font-size: var(--font-md, 1rem);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  text-align: left;
+  width: 100%;
+}
+
 /* Security */
 
 .content .security {
@@ -503,4 +552,84 @@ a.nav-item {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
+}
+
+/* Dropdown */
+
+.dropdown-container {
+  position: relative;
+}
+.dropdown-container .dropdown {
+  position: absolute;
+  top: 0;
+  right: 0;
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s, opacity 0.2s ease-in-out;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  max-width: 90vw;
+  width: 20rem;
+}
+.dropdown-container.dropdown-open .dropdown {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Tabs */
+.tab-controller {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  align-self: stretch;
+  border-bottom: 1px solid var(--gray-2, #d8dee2);
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tab-controller .tab {
+  flex: 1 0 auto;
+  padding: 1rem 2rem 0.5rem;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  transition: background 0.325s linear, border-color 0.125s ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  color: var(--gray-4, #5C717C);
+  font-family: var(--font-sans, "Source Sans Pro");
+  font-size: var(--font-md, 1rem);
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  cursor: pointer;
+  
+}
+
+.tab-controller .tab:hover {
+  color: var(--gray-5, #233944);
+  background: var(--blue-1, #EEF3F9);
+}
+
+.tab-controller .tab-active {
+  border-color: var(--blue-3, #4294F0);
+  color: var(--blue-5, #053775);
+}
+
+.tab-container .tab {
+  display: none;
+  visibility: none;
+  opacity: 0;
+}
+
+.tab-container .tab-active {
+  display: block;
+  visibility: visible;
+  opacity: 1;
 }

--- a/squarelet/templates/account/team_list_item.html
+++ b/squarelet/templates/account/team_list_item.html
@@ -17,7 +17,7 @@
         </h4>
         <div class="status">
             {% if organization.verified_journalist %}
-            <div class="badge verified">
+            <div class="badge green">
                 <img src="{% static "icons/verified.svg" %}">
                 {% trans "Verified" %}
             </div>

--- a/squarelet/templates/users/user_detail.html
+++ b/squarelet/templates/users/user_detail.html
@@ -365,10 +365,10 @@
               </header>
               <div class="tab-container">
                 <div class="tab tab-active" data-tab="email" data-tab-active="true">
-                  <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
+                  <form class="connect-account-form" method="POST" action="{% url 'account_email' %}">
                     {% csrf_token %}
-                    <input class="email-input" type="email" name="email" placeholder="Enter your email" class="email-field" />
-                    <button type=submit" class="primary btn">Add Email</button>
+                    <input class="email-input" type="email" name="email" placeholder="Enter your email" required />
+                    <button class="primary btn" type=submit" name="action_add">Add Email</button>
                     <p class="help-text">
                       {% blocktrans %}
                       When you connect an email address, you can use it as a sign-in method, receive notifications to it, and use it to auto-join organizations that share your domain.

--- a/squarelet/templates/users/user_detail.html
+++ b/squarelet/templates/users/user_detail.html
@@ -13,12 +13,98 @@
 <link rel="stylesheet" href="{% static "css/invites.css" %}" />
 
 
-{# include any style tags in parent tempaltes #}
+{# include any style tags in parent templates #}
 {{ block.super }}
 
 {# page-specific styles #}
 <link rel="stylesheet" href="{% static "css/user_detail.css" %}" />
 {% endblock css %}
+
+{% block javascript %}
+{# include scripts in parent templates #}
+{{ block.super }}
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    function closeDropdown(container) {
+      container.classList.remove('dropdown-open');
+      container.setAttribute('data-dropdown-open', 'false');
+    }
+
+    var containers = document.querySelectorAll('.dropdown-container');
+    containers.forEach(function(container) {
+      var anchor = container.querySelector('.dropdown-anchor');
+      if (anchor) {
+        anchor.addEventListener('click', function(e) {
+          e.preventDefault();
+          var open = container.classList.contains('dropdown-open');
+          if (open) {
+            closeDropdown(container);
+          } else {
+            // Close all other dropdowns first
+            containers.forEach(function(other) {
+              if (other !== container) {
+                closeDropdown(other);
+              }
+            });
+            container.classList.add('dropdown-open');
+            container.setAttribute('data-dropdown-open', 'true');
+          }
+        });
+        // Ensure closed by default
+        closeDropdown(container);
+      }
+    });
+
+    // Close dropdown if clicking outside
+    document.addEventListener('click', function(e) {
+      containers.forEach(function(container) {
+        if (!container.contains(e.target)) {
+          closeDropdown(container);
+        }
+      });
+    });
+  });
+
+  // Tab controller/Tab container logic
+  document.querySelectorAll('.tab-controller').forEach(function(controller) {
+    var container = controller.closest('.dropdown').querySelector('.tab-container');
+    if (!container) return;
+
+    function activateTab(tabName) {
+      // Update controller tabs
+      controller.querySelectorAll('.tab').forEach(function(tab) {
+        var isActive = tab.getAttribute('data-tab') === tabName;
+        tab.setAttribute('data-tab-active', isActive);
+        tab.classList.toggle('tab-active', isActive);
+      });
+      // Update container tabs
+      container.querySelectorAll('.tab').forEach(function(tab) {
+        var isActive = tab.getAttribute('data-tab') === tabName;
+        tab.setAttribute('data-tab-active', isActive);
+        tab.classList.toggle('tab-active', isActive);
+      });
+    }
+
+    // Click handler for controller tabs
+    controller.querySelectorAll('.tab').forEach(function(tab) {
+      tab.addEventListener('click', function(e) {
+        e.preventDefault();
+        var tabName = tab.getAttribute('data-tab');
+        activateTab(tabName);
+      });
+    });
+
+    // Initialize to first active tab
+    var initial = controller.querySelector('.tab[data-tab-active="true"]');
+    if (initial) {
+      activateTab(initial.getAttribute('data-tab'));
+    }
+  });
+
+  
+</script>
+{% endblock %}
+
 
 {% block content %}
 <article id="user_detail">
@@ -255,10 +341,63 @@
     <section id="accounts">
       <header>
         <h2>{% trans "Your Connected Accounts" %}</h2>
-        <a class="btn primary ghost" href="{% url "account_email" %}">
-          {% include "core/icons/plus-circle.svg" %}
-          {% trans "Connect an account" %}
-        </a>
+        <div class="dropdown-container" data-dropdown-open="false" >
+          <a class="btn primary ghost dropdown-anchor" href="{% url "account_email" %}">
+            {% include "core/icons/plus-circle.svg" %}
+            {% trans "Connect an account" %}
+          </a>
+          <div class="dropdown">
+            <div class="connect-account-dropdown card">
+              <header>
+                <ul class="tab-controller">
+                  <li class="tab tab-active" data-tab="email" data-tab-active="true">
+                    Email
+                  </li>
+                  <li class="tab" data-tab="google" data-tab-active="false">
+                    Google
+                  </li>
+                  <li class="tab" data-tab="github" data-tab-active="false">
+                    GitHub
+                  </li>
+                </ul>
+              </header>
+              <div class="tab-container">
+                <div class="tab tab-active" data-tab="email" data-tab-active="true">
+                  <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
+                    {% csrf_token %}
+                    <input class="email-input" type="email" placeholder="Enter your email" class="email-field" />
+                    <button type=submit" class="primary btn">Add Email</button>
+                    <p class="help-text">
+                      {% blocktrans %}
+                      When you connect an email address, you can use it as a sign-in method, receive notifications to it, and use it to auto-join organizations that share your domain.
+                      {% endblocktrans %}
+                    </p>
+                  </form>
+                </div>
+                <div class="tab" data-tab="google" data-tab-active="false">
+                  <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
+                    <button type=submit" class="primary btn">Connect with Google</button>
+                    <p class="help-text">
+                      {% blocktrans %}
+                      When you connect a Google account, you can use your account as a sign-in method.
+                      {% endblocktrans %}                      
+                    </p>
+                  </form>
+                </div>
+                <div class="tab" data-tab="github" data-tab-active="false">
+                  <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
+                    <button type=submit" class="primary btn">Connect with GitHub</button>
+                    <p class="help-text">
+                      {% blocktrans %}
+                      When you connect a GitHub account, you can use your account as a sign-in method.
+                      {% endblocktrans %}                      
+                    </p>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </header>
       <main class="accounts">
         {% for email in emails %}

--- a/squarelet/templates/users/user_detail.html
+++ b/squarelet/templates/users/user_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load account socialaccount %}
 {% load airtable %}
 {% load avatar %}
 {% load i18n %}
@@ -342,10 +343,12 @@
       <header>
         <h2>{% trans "Your Connected Accounts" %}</h2>
         <div class="dropdown-container" data-dropdown-open="false" >
-          <a class="btn primary ghost dropdown-anchor" href="{% url "account_email" %}">
+          <a class="btn primary ghost {% if settings.ENABLE_SOCIAL_LOGINS %}dropdown-anchor{% endif %}" href="{% url "account_email" %}">
             {% include "core/icons/plus-circle.svg" %}
             {% trans "Connect an account" %}
           </a>
+          {% if settings.ENABLE_SOCIAL_LOGINS %}
+          {% get_providers as socialaccount_providers %}
           <div class="dropdown">
             <div class="connect-account-dropdown card">
               <header>
@@ -353,19 +356,18 @@
                   <li class="tab tab-active" data-tab="email" data-tab-active="true">
                     Email
                   </li>
-                  <li class="tab" data-tab="google" data-tab-active="false">
-                    Google
+                  {% for provider in socialaccount_providers %}
+                  <li class="tab" data-tab="{{provider.id}}" data-tab-active="false">
+                    {{provider.name}}
                   </li>
-                  <li class="tab" data-tab="github" data-tab-active="false">
-                    GitHub
-                  </li>
+                  {% endfor %}
                 </ul>
               </header>
               <div class="tab-container">
                 <div class="tab tab-active" data-tab="email" data-tab-active="true">
                   <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
                     {% csrf_token %}
-                    <input class="email-input" type="email" placeholder="Enter your email" class="email-field" />
+                    <input class="email-input" type="email" name="email" placeholder="Enter your email" class="email-field" />
                     <button type=submit" class="primary btn">Add Email</button>
                     <p class="help-text">
                       {% blocktrans %}
@@ -374,29 +376,23 @@
                     </p>
                   </form>
                 </div>
-                <div class="tab" data-tab="google" data-tab-active="false">
-                  <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
-                    <button type=submit" class="primary btn">Connect with Google</button>
+                {% for provider in socialaccount_providers %}
+                <div class="tab" data-tab="{{provider.id}}" data-tab-active="false">
+                  <form class="connect-account-form" method="POST" action="{% provider_login_url provider.id process="connect" %}">
+                    {% csrf_token %}
+                    <button type=submit" class="primary btn">Connect with {{provider.name}}</button>
                     <p class="help-text">
                       {% blocktrans %}
-                      When you connect a Google account, you can use your account as a sign-in method.
+                      When you connect a {{provider.name}} account, you can use your account as a sign-in method.
                       {% endblocktrans %}                      
                     </p>
                   </form>
                 </div>
-                <div class="tab" data-tab="github" data-tab-active="false">
-                  <form class="connect-account-form" method="POST" action="{# AllAuth URL #}">
-                    <button type=submit" class="primary btn">Connect with GitHub</button>
-                    <p class="help-text">
-                      {% blocktrans %}
-                      When you connect a GitHub account, you can use your account as a sign-in method.
-                      {% endblocktrans %}                      
-                    </p>
-                  </form>
-                </div>
+                {% endfor %}
               </div>
             </div>
           </div>
+          {% endif %}
         </div>
       </header>
       <main class="accounts">
@@ -414,10 +410,10 @@
               {% trans "Confirm this email" %}
             </button>
             {% else %}
-            <span class="badge verified">{% trans "Confirmed" %}</span>
+            <span class="badge green">{% trans "Confirmed" %}</span>
             {% endif %}
             {% if email.primary %}
-            <span class="badge">{% trans "Primary" %}</span>
+            <span class="badge blue">{% trans "Primary" %}</span>
             {% else %}
             <button class="btn small" type="submit" name="action_primary" {% if not email.verified %}disabled{% endif %}>
               {% trans "Make primary" %}
@@ -429,6 +425,55 @@
           </form>
         </div>
         {% endfor %}
+        {% if settings.ENABLE_SOCIAL_LOGINS %}
+        {% get_social_accounts user as accounts %}
+        {% for google_account in accounts.google %}
+          <div class="social account">
+            <div class="account-detail">
+              <div class="icon">{% include "core/icons/google.svg" %}</div>
+              <div class="account-detail-text">
+                <h3 class="provider-label">{{google_account.get_provider}}</h3>
+                <p class="provider-account">{{google_account.get_provider_account}}</p>
+              </div>
+              <div class="account-status">
+                <span class="badge green">{% trans "Connected" %}</span>
+              </div>
+            </div>
+            <div class="account-actions">
+              <form method="POST" action="{% url 'socialaccount_connections' %}">
+                {% csrf_token %}
+                <input type="hidden" name="account" value="{{google_account.pk}}" />
+                <button type="submit" class="ghost danger btn" title="Disconnect {{google_account.provider}} account">
+                  {% include "core/icons/trashcan.svg" %}
+                </button>
+              </form>
+            </div>
+          </div>
+        {% endfor %}
+        {% for github_account in accounts.github %}
+          <div class="social account">
+            <div class="account-detail">
+              <div class="icon">{% include "core/icons/github.svg" %}</div>
+              <div class="account-detail-text">
+                <h3 class="provider-label">{{github_account.get_provider}}</h3>
+                <p class="provider-account">{{github_account.get_provider_account}}</p>
+              </div>
+              <div class="account-status">
+                <span class="badge green">{% trans "Connected" %}</span>
+              </div>
+            </div>
+            <div class="account-actions">
+              <form method="POST" action="{% url 'socialaccount_connections' %}">
+                {% csrf_token %}
+                <input type="hidden" name="account" value="{{github_account.pk}}" />
+                <button type="submit" class="ghost danger btn" title="Disconnect {{github_account.provider}} account">
+                  {% include "core/icons/trashcan.svg" %}
+                </button>
+              </form>
+            </div>
+          </div>
+        {% endfor %}
+        {% endif %}
       </main>
     </section>
 
@@ -450,7 +495,7 @@
             <h3>{% trans "Two-factor authentication" %}</h3>
             <div class="mfa-active">
               {% if is_mfa_enabled %}
-              <span class="badge verified">{% trans "Enabled" %}</span>
+              <span class="badge green">{% trans "Enabled" %}</span>
               <a class="small btn ghost" href="{% url "mfa_deactivate_totp" %}">{% trans "Disable two-factor auth" %}</a>
               {% else %}
               <a class="small btn ghost" href="{% url "mfa_activate_totp" %}">{% trans "Enable two-factor auth" %}</a>

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -204,6 +204,12 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         initial = super().get_signup_form_initial_data(sociallogin)
         initial["name"] = f"{initial['first_name']} {initial['last_name']}"
         return initial
+    
+    def get_connect_redirect_url(self, request, sociallogin):
+        """
+        Redirect to the user detail page after connecting a social account.
+        """
+        return reverse("users:detail", kwargs={"username": request.user.username})
 
 
 class MfaAdapter(DefaultMFAAdapter):

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -204,7 +204,7 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         initial = super().get_signup_form_initial_data(sociallogin)
         initial["name"] = f"{initial['first_name']} {initial['last_name']}"
         return initial
-    
+
     def get_connect_redirect_url(self, request, sociallogin):
         """
         Redirect to the user detail page after connecting a social account.

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -80,6 +80,7 @@ class UserConnectionsView(ConnectionsView):
         """Redirect to the user detail page after a successful connection operation."""
         return reverse("users:detail", kwargs={"username": self.request.user.username})
 
+
 class UserDetailView(LoginRequiredMixin, AdminLinkMixin, DetailView):
     model = User
     slug_field = "username"

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -30,6 +30,7 @@ import time
 # Third Party
 from allauth.account.utils import get_next_redirect_url, send_email_confirmation
 from allauth.account.views import (
+    EmailView as AllAuthEmailView,
     LoginView as AllAuthLoginView,
     SignupView as AllAuthSignupView,
 )
@@ -37,6 +38,7 @@ from allauth.mfa import app_settings
 from allauth.mfa.models import Authenticator
 from allauth.mfa.utils import is_mfa_enabled
 from allauth.socialaccount.adapter import get_adapter as get_social_adapter
+from allauth.socialaccount.views import ConnectionsView
 from allauth.socialaccount.internal import flows
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout
@@ -62,6 +64,21 @@ ONBOARDING_SESSION_DEFAULTS = (
     ("subscription", "not_started"),
 )
 
+
+class UserEmailView(AllAuthEmailView):
+    """Custom email view to redirect to user detail page after email operations."""
+
+    def get_success_url(self):
+        """Redirect to the user detail page after a successful email operation."""
+        return reverse("users:detail", kwargs={"username": self.request.user.username})
+
+
+class UserConnectionsView(ConnectionsView):
+    """Override the connections view to redirect to user detail page after operations."""
+
+    def get_success_url(self):
+        """Redirect to the user detail page after a successful connection operation."""
+        return reverse("users:detail", kwargs={"username": self.request.user.username})
 
 class UserDetailView(LoginRequiredMixin, AdminLinkMixin, DetailView):
     model = User


### PR DESCRIPTION
Closes #373 

This adds support for listing connected social accounts and connecting new social accounts from the users account overview page. It adds a drop-down menu to the section that allows a user to easily add an email or connect a third-party account.

## Screenshots

<img width="1624" height="1053" alt="Screenshot 2025-08-01 at 17 47 42" src="https://github.com/user-attachments/assets/c2c5c78d-0e31-48f2-a98c-12338832b8e3" />
<img width="1624" height="1053" alt="Screenshot 2025-08-01 at 17 47 11" src="https://github.com/user-attachments/assets/783c795b-676f-4b80-b207-3eca37829572" />
<img width="1624" height="1053" alt="Screenshot 2025-08-01 at 17 47 22" src="https://github.com/user-attachments/assets/50c599bc-56be-40da-8168-bc55e8023611" />
<img width="1624" height="1053" alt="Screenshot 2025-08-01 at 17 47 27" src="https://github.com/user-attachments/assets/8f3460e3-4a21-4c85-80bf-c825c7b99137" />
