### PR TITLE
Adds filterable list of subtypes to organization list results

### DIFF
--- a/squarelet/organizations/filters.py
+++ b/squarelet/organizations/filters.py
@@ -10,6 +10,10 @@ class OrganizationFilter(filters.FilterSet):
     verified = filters.BooleanFilter(field_name="verified_journalist")
     individual = filters.BooleanFilter(field_name="individual")
     private = filters.BooleanFilter(field_name="private")
+    subtype = filters.CharFilter(method="filter_subtype", label="Subtype")
+
+    def filter_subtype(self, queryset, name, value):
+        return queryset.filter(subtypes__name=value)
 
     class Meta:
         model = Organization

--- a/squarelet/organizations/filters.py
+++ b/squarelet/organizations/filters.py
@@ -1,6 +1,9 @@
 # Third Party
 from django_filters import rest_framework as filters
 
+# Squarelet
+from squarelet.organizations.models import OrganizationSubtype
+
 # Local
 from .models import Organization
 
@@ -10,11 +13,11 @@ class OrganizationFilter(filters.FilterSet):
     verified = filters.BooleanFilter(field_name="verified_journalist")
     individual = filters.BooleanFilter(field_name="individual")
     private = filters.BooleanFilter(field_name="private")
-    subtype = filters.CharFilter(method="filter_subtype", label="Subtype")
-
-    def filter_subtype(self, queryset, value):
-        return queryset.filter(subtypes__name=value)
+    subtypes = filters.ModelChoiceFilter(
+        queryset=OrganizationSubtype.objects.select_related("type"),
+        to_field_name="name",
+    )
 
     class Meta:
         model = Organization
-        fields = ["name", "verified", "individual", "private"]
+        fields = ["name", "verified", "individual", "private", "subtypes"]

--- a/squarelet/organizations/filters.py
+++ b/squarelet/organizations/filters.py
@@ -12,7 +12,7 @@ class OrganizationFilter(filters.FilterSet):
     private = filters.BooleanFilter(field_name="private")
     subtype = filters.CharFilter(method="filter_subtype", label="Subtype")
 
-    def filter_subtype(self, queryset, name, value):
+    def filter_subtype(self, queryset, value):
         return queryset.filter(subtypes__name=value)
 
     class Meta:

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -522,10 +522,6 @@ class Organization(AvatarMixin, models.Model):
             request=False,
         ).first()
 
-    def get_subtype_names(self):
-        """Retrieve a list of subtypes for this organization."""
-        return list(self.subtypes.values_list("name", flat=True))
-
     @transaction.atomic
     def merge(self, org, user):
         """Merge another organization into this one"""

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -522,6 +522,10 @@ class Organization(AvatarMixin, models.Model):
             request=False,
         ).first()
 
+    def get_subtype_names(self):
+        """Retrieve a list of subtypes for this organization."""
+        return list(self.subtypes.values_list("name", flat=True))
+
     @transaction.atomic
     def merge(self, org, user):
         """Merge another organization into this one"""

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -11,7 +11,6 @@ from squarelet.organizations.models import (
     Charge,
     Membership,
     Organization,
-    OrganizationSubtype,
 )
 
 

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -15,35 +15,10 @@ from squarelet.organizations.models import (
 )
 
 
-def resolve_subtype_names_to_pks(subtype_names):
-    """
-    Given a list of subtype names, return a list of OrganizationSubtype PKs.
-    """
-    if not isinstance(subtype_names, list):
-        raise serializers.ValidationError(
-            {"subtypes": "Must be a list of subtype names."}
-        )
-    subtype_pks = []
-    for name in subtype_names:
-        try:
-            subtype = OrganizationSubtype.objects.get(name=name)
-            subtype_pks.append(subtype.pk)
-        except OrganizationSubtype.DoesNotExist:
-            raise serializers.ValidationError(
-                {"subtypes": f"Invalid subtype name: {name}"}
-            )
-    return subtype_pks
-
-
 class OrganizationSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(required=False)
     merged = serializers.SlugRelatedField(read_only=True, slug_field="uuid")
-    subtypes = serializers.ListField(
-        child=serializers.CharField(),
-        source="get_subtype_names",
-        required=False,
-        allow_null=True,
-    )
+    subtypes = serializers.StringRelatedField(many=True)
 
     class Meta:
         model = Organization
@@ -61,14 +36,6 @@ class OrganizationSerializer(serializers.ModelSerializer):
             "merged",
             "subtypes",
         )
-
-    def to_internal_value(self, data):
-        """Adds custom handling for subtypes"""
-        ret = super().to_internal_value(data)
-        subtype_names = data.get("subtypes")
-        if subtype_names is not None:
-            ret["subtypes"] = resolve_subtype_names_to_pks(subtype_names)
-        return ret
 
 
 class OrganizationDetailSerializer(OrganizationSerializer):

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -7,11 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
 
 # Squarelet
-from squarelet.organizations.models import (
-    Charge,
-    Membership,
-    Organization,
-)
+from squarelet.organizations.models import Charge, Membership, Organization
 
 
 class OrganizationSerializer(serializers.ModelSerializer):

--- a/squarelet/organizations/viewsets.py
+++ b/squarelet/organizations/viewsets.py
@@ -15,8 +15,7 @@ from squarelet.organizations.serializers import (
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):
-    # remove _plan after clients are updated
-    queryset = Organization.objects.select_related("_plan")
+    queryset = Organization.objects.prefetch_related("subtypes")
     serializer_class = OrganizationSerializer
     permission_classes = (ScopePermission | IsAdminUser,)
     read_scopes = ("read_organization",)


### PR DESCRIPTION
Third-party clients want to be able to filter the list of organizations by subtype, so that they can better classify verified organizations using their service.

Related to #377 

## Test steps
1. Sign into the preview deployment
2. Go to `/api/organizations`
3. Try filtering by subtype