### PR TITLE
Adds an autologin setting to the account security section

### DIFF
--- a/frontend/css/user_detail.css
+++ b/frontend/css/user_detail.css
@@ -567,6 +567,29 @@ section .orgs {
   white-space: nowrap;
 }
 
+.content .security .autologin {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-self: stretch;
+}
+
+.autologin .help-text {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--gray-4);
+}
+
+.autologin .status-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.autologin .status-row h3 {
+  flex: 1 0 auto;
+}
+
 .content .security .password {
   display: flex;
   align-items: center;

--- a/squarelet/templates/users/user_detail.html
+++ b/squarelet/templates/users/user_detail.html
@@ -428,6 +428,24 @@
         </a>
       </header>
       <main class="security">
+        <form class="autologin" method="post" action="{% url 'users:detail' username=user.username %}">
+          {% csrf_token %}
+          <div class="status-row">
+            <h3>{% trans "Automatic login links" %}</h3>
+            {% if user.use_autologin %}
+              <span class="badge green">{% trans "Enabled" %}</span>
+              <input type="hidden" name="use_autologin" value="False" />
+              <button type="submit" class="btn ghost danger small">{% trans "Disable" %}</button>
+            {% else %}
+              <span class="badge">{% trans "Disabled" %}</span>
+              <input type="hidden" name="use_autologin" value="True" />
+              <button type="submit" class="btn ghost primary small">{% trans "Enable" %}</button>
+            {% endif %}
+          </div>
+          <p class="help-text">
+            {% trans "When enabled, links we email you (like notifications) include a secure token that signs you in automatically." %}
+          </p>
+        </form>
         <div class="password">
           <h3>{% trans "Password" %}</h3>
           <a href="{% url "account_change_password" %}" class="small btn ghost primary">{% trans "Change password" %}</a>

--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -453,3 +453,27 @@ class UserUpdateForm(forms.ModelForm):
                 "once and cannot change it again."
             )
         )
+
+
+class UserAutologinPreferenceForm(forms.ModelForm):
+    """Simple form to allow a user to opt in/out of autologin links.
+
+    Exposes only the ``use_autologin`` boolean from the ``User`` model so it can
+    be rendered independently on a settings/privacy page without the rest of
+    the profile fields.
+    """
+
+    class Meta:
+        model = User
+        fields = ["use_autologin"]
+        labels = {
+            "use_autologin": _("Use automatic login links"),
+        }
+        help_texts = {
+            "use_autologin": _(
+                "If enabled, links we email you (like notifications and password "
+                "resets) will include a secure token that logs you in automatically. "
+                "Disable this if you prefer to always enter your password."
+            )
+        }
+        widgets = {"use_autologin": forms.CheckboxInput()}


### PR DESCRIPTION
Closes #385 

This adds an autologin setting to the security section. This setting was previously mixed in with profile settings, like name and avatar. By colocating this alongside password and 2FA settings, this option will be easier for users to find.

<img width="787" height="335" alt="Screenshot 2025-08-21 at 16 14 03" src="https://github.com/user-attachments/assets/597d2e50-35d0-454f-be98-ac8419f4857d" />

Adds a `UserAutologinPreferenceForm`, a handler for POST requests on the `UserDetail` view, and updates the `user_detail` template files.