### PR TITLE
Adds API endpoint on staging/dev environment to add redirect URIs

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -14,7 +14,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 # Squarelet
 from squarelet.core.views import HomeView, SelectPlanView
-from squarelet.oidc.views import token_view
+from squarelet.oidc.views import OIDCRedirectURIUpdater, token_view
 from squarelet.organizations.fe_api.viewsets import (
     InvitationViewSet as FEInvitationViewSet,
     OrganizationViewSet as FEOrganizationViewSet,
@@ -107,6 +107,17 @@ if settings.DEBUG:
         ),
         path("500/", default_views.server_error),
     ]
+
+# Conditionally add the API endpoint based on the environment
+if settings.ENV == "staging" or settings.ENV == "dev":
+    urlpatterns.append(
+        path(
+            "api/clients/<int:client_id>/redirect_uris/",
+            OIDCRedirectURIUpdater.as_view(),
+            name="oidc_redirect_uri_updater",
+        )
+    )
+
 if "debug_toolbar" in settings.INSTALLED_APPS:
     # Third Party
     import debug_toolbar

--- a/squarelet/oidc/views.py
+++ b/squarelet/oidc/views.py
@@ -103,7 +103,8 @@ class OIDCRedirectURIUpdater(APIView):
             if not action or action not in ["add", "remove"]:
                 return Response(
                     {
-                        "error": "Invalid or missing 'action'. Must be 'add' or 'remove'."
+                        "error": "Invalid or missing 'action'. "
+                        "Must be 'add' or 'remove'."
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )

--- a/squarelet/oidc/views.py
+++ b/squarelet/oidc/views.py
@@ -1,7 +1,7 @@
 # Standard
 # Django
-from django.db import transaction
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.views.decorators.csrf import csrf_exempt
 
 # Third Party
@@ -103,8 +103,7 @@ class OIDCRedirectURIUpdater(APIView):
             if not action or action not in ["add", "remove"]:
                 return Response(
                     {
-                        "error":
-                            "Invalid or missing 'action'. Must be 'add' or 'remove'."
+                        "error": "Invalid or missing 'action'. Must be 'add' or 'remove'."
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
@@ -112,16 +111,15 @@ class OIDCRedirectURIUpdater(APIView):
             if not uris_to_modify or not isinstance(uris_to_modify, list):
                 return Response(
                     {
-                        "error":
-                            "Invalid or missing 'redirect_uris'. "
-                            "It must be a list of strings."
+                        "error": "Invalid or missing 'redirect_uris'. "
+                        "It must be a list of strings."
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
         except (ValidationError, TypeError) as exc:
             return Response(
                 {"error": f"Invalid request format: {str(exc)}"},
-                status=status.HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         with transaction.atomic():


### PR DESCRIPTION
This enables MuckRock staging review apps to add their URIs on squarelet staging with an admin account. 

Should be able to go to the web from for one of your local clients and do a POST with a payload like this

{
    "action": "add",
    "redirect_uris": [
        "https://example.com",
    ]
}