### PR TITLE
Help and airtable links open in new tabs

### DIFF
--- a/squarelet/templates/account/email/email_confirmation_signup_message.html
+++ b/squarelet/templates/account/email/email_confirmation_signup_message.html
@@ -37,7 +37,7 @@
       Before continuing, please
       <a href="{{ activate_url }}">verify your email</a>.
       You can also verify your email from your
-      <a href="https://accounts.muckrock.com/">account page</a>.
+      <a target="_blank" rel="noopener noreferrer" href="https://accounts.muckrock.com/">account page</a>.
     </p>
   {% endblocktrans %}
 
@@ -54,12 +54,12 @@
     <ul>
       <li>
         Bookmark our
-        <a href="https://help.muckrock.com/">User Guide</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/">User Guide</a>
         to learn more about MuckRock and our services.
       </li>
       <li>
         For technical support and customer service,
-        <a href="mailto:info@muckrock.com">email us</a>.
+        <a target="_blank" rel="noopener noreferrer" href="mailto:info@muckrock.com">email us</a>.
       </li>
     </ul>
   {% endblocktrans %}

--- a/squarelet/templates/account/onboarding/confirm_email.html
+++ b/squarelet/templates/account/onboarding/confirm_email.html
@@ -75,5 +75,5 @@
     <input type="hidden" name="step" value="confirm_email" />
     <button class="button primary" type="submit">Continue{% if service %} to {{service.name}}{% endif %}</button>
   </div>
-    <a class="small inline button primary ghost" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1caf889269638080b222ebe360ffa1d9">{% trans "Why do I need to confirm my email?" %}</a>
+    <a target="_blank" rel="noopener noreferrer" class="small inline button primary ghost" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1caf889269638080b222ebe360ffa1d9">{% trans "Why do I need to confirm my email?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/mfa_opt_in.html
+++ b/squarelet/templates/account/onboarding/mfa_opt_in.html
@@ -60,5 +60,5 @@
     <button class="button primary" type="submit" name="enable_mfa" value="yes">{% trans "Enable Two-Factor Authentication" %}</button>
     <button class="button primary ghost" type="submit" name="enable_mfa" value="skip">{% trans "Skip" %}</button>
   </form>
-  <a class="help link" target="_blank" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
+  <a class="help link" target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/mfa_setup.html
+++ b/squarelet/templates/account/onboarding/mfa_setup.html
@@ -96,5 +96,5 @@
     <button class="button primary" type="submit" name="mfa_setup" value="code">{% trans "Submit" %}</button>
     <button class="button primary ghost" type="submit" name="mfa_setup" value="skip">{% trans "Skip" %}</button>
   </form>
-  <a class="help link" target="_blank" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
+  <a class="help link" target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380ccbbe7d6194a1dbe57">{% trans "What is two-factor authentication?" %}</a>
 {% endblock %}

--- a/squarelet/templates/account/onboarding/verification.html
+++ b/squarelet/templates/account/onboarding/verification.html
@@ -108,7 +108,7 @@
       </p>
       <p class="detail">
         {% blocktrans %}
-        Our help pages include an in-depth <a href="https://help.muckrock.com/Request-verification-19ef8892696381dba944e17e14938433" target="_blank">guide to verification</a> and guidance on everything you can do in DocumentCloud without verification. 
+        Our help pages include an in-depth <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/Request-verification-19ef8892696381dba944e17e14938433">guide to verification</a> and guidance on everything you can do in DocumentCloud without verification. 
         {% endblocktrans %}
       </p>
     </header>
@@ -117,7 +117,7 @@
         {% for organization in unverified_orgs %}
           <div class="unverified org">
             {% include "account/team_list_item.html" %}
-            <a class="ghost button" href="{% airtable_verification_url organization %}" target="_blank">
+            <a target="_blank" rel="noopener noreferrer" class="ghost button" href="{% airtable_verification_url organization %}">
               Request verification
             </a>
           </div>
@@ -130,7 +130,7 @@
               although we <em>strongly</em> encourage verification through a newsroom or other affiliated organization.
               {% endblocktrans %}
             </p>
-            <a class="ghost primary button" href="{% airtable_verification_url organization %}" target="_blank">
+            <a target="_blank" rel="noopener noreferrer" class="ghost primary button" href="{% airtable_verification_url organization %}">
               Verify yourself
             </a>
           </div>

--- a/squarelet/templates/mfa/authenticate.html
+++ b/squarelet/templates/mfa/authenticate.html
@@ -97,7 +97,7 @@
         If you can't provide an authentication code from your second device,
         you can provide a recovery code in its place. Recovery codes are
         one-time use and will not work on subsequent logins.
-        <a href="https://help.muckrock.com/Two-Factor-Authentication-1f9f8892696380e59857c19341a324af?source=copy_link#207f889269638028a939c82281c5c6f3" target="_blank" rel="noopener noreferrer">
+        <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/Two-Factor-Authentication-1f9f8892696380e59857c19341a324af?source=copy_link#207f889269638028a939c82281c5c6f3">
           Learn more
         </a>
         {% endblocktrans %}

--- a/squarelet/templates/organizations/your_organizations.html
+++ b/squarelet/templates/organizations/your_organizations.html
@@ -55,7 +55,7 @@
       {% include "account/team_list_item.html" with organization=org %}
       <div class="actions">
         {% if not org.verified_journalist %}
-        <a class="btn ghost small" href="{% airtable_verification_url org %}">
+        <a target="_blank" rel="noopener noreferrer" class="btn ghost small" href="{% airtable_verification_url org %}">
           {% trans "Request verification" %}
         </a>
         {% endif %}

--- a/squarelet/templates/pages/selectplan.html
+++ b/squarelet/templates/pages/selectplan.html
@@ -469,7 +469,7 @@
               </span>
               <span class="text">
                 {% blocktrans %}
-                Includes 2,000 AI Credits per month on DocumentCloud for advanced OCR and <a href="https://help.muckrock.com/19ef88926963810c9df9e46762194322?pvs=4#19ef8892696381fa8ec6d1bc0c4b5f6a" target="_blank">premium Add-Ons</a>
+                Includes 2,000 AI Credits per month on DocumentCloud for advanced OCR and <atarget="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/19ef88926963810c9df9e46762194322?pvs=4#19ef8892696381fa8ec6d1bc0c4b5f6a">premium Add-Ons</a>
                 {% endblocktrans %}
               </span>
             </li>
@@ -527,7 +527,7 @@
               </span>
               <span class="text">
                 {% blocktrans %}
-                Includes 5,000 AI Credits per month on DocumentCloud for advanced OCR and <a href="https://help.muckrock.com/19ef88926963810c9df9e46762194322?pvs=4#19ef8892696381fa8ec6d1bc0c4b5f6a" target="_blank">premium Add-Ons</a>
+                Includes 5,000 AI Credits per month on DocumentCloud for advanced OCR and <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/19ef88926963810c9df9e46762194322?pvs=4#19ef8892696381fa8ec6d1bc0c4b5f6a">premium Add-Ons</a>
                 {% endblocktrans %}
               </span>
             </li>
@@ -556,7 +556,7 @@
           {% if user.is_anonymous %}
           <p>Apply to verify your organization after signing up or signing in</p>
           {% else %}
-          <p><a href="https://help.muckrock.com/19ef8892696381dba944e17e14938433?pvs=4">Learn more about verification</a></p>
+          <p><a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/19ef8892696381dba944e17e14938433?pvs=4">Learn more about verification</a></p>
           {% endif %}
         </header>
         <main>

--- a/squarelet/templates/templatetags/sign_up_message.html
+++ b/squarelet/templates/templatetags/sign_up_message.html
@@ -10,5 +10,5 @@
 
 <div>
   <h2>{{ header }}</h2>
-  <a class="help link" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380a1b918e94ec25d62b2">What is a MuckRock account?</a>
+  <a target="_blank" rel="noopener noreferrer" class="help link" href="https://help.muckrock.com/1c4f889269638026b507dc08b6561335?pvs=4#1c4f8892696380a1b918e94ec25d62b2">What is a MuckRock account?</a>
 </div>

--- a/squarelet/templates/users/user_detail.html
+++ b/squarelet/templates/users/user_detail.html
@@ -230,7 +230,7 @@
     <section id="verification">
       <header>
         <h2>{% trans "Your Verification" %}</h2>
-        <a href="https://help.muckrock.com/Request-verification-19ef8892696381dba944e17e14938433" class="btn ghost" target="_blank" rel="noopener noreferer">
+        <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/Request-verification-19ef8892696381dba944e17e14938433" class="btn ghost">
           {% include "core/icons/book.svg" %}
           {% trans "Learn about verification" %}
         </a>
@@ -251,7 +251,7 @@
         <div class="status unverified">
           {% include "core/icons/unverified-24.svg" %}
           <h3>{% trans "You are not a verified journalist. Some features are restricted." %}</h3>
-          <p class="help-text">Request newsroom verification for one of your organizations, or <a href="{% airtable_verification_url %}">request journalist verification for yourself</a>, to upload and publish documents.</p>
+          <p class="help-text">Request newsroom verification for one of your organizations, or <a target="_blank" rel="noopener noreferrer" href="{% airtable_verification_url %}">request journalist verification for yourself</a>, to upload and publish documents.</p>
         </div>
         <dl class="locked features">
           <dt class="checklist-item">{% include "core/icons/lock.svg" %}{% trans "Locked features:" %}</dt>
@@ -422,7 +422,7 @@
     <section id="security">
       <header>
         <h2>{% trans "Your Security Settings" %}</h2>
-        <a class="btn primary ghost" href="https://help.muckrock.com/Two-Factor-Authentication-1f9f8892696380e59857c19341a324af" target="_blank" rel="noopener noreferer">
+        <a target="_blank" rel="noopener noreferrer" class="btn primary ghost" href="https://help.muckrock.com/Two-Factor-Authentication-1f9f8892696380e59857c19341a324af">
           {% include "core/icons/book.svg" %}
           {% trans "Security best practices" %}
         </a>

--- a/squarelet/templates/users/user_form.html
+++ b/squarelet/templates/users/user_form.html
@@ -76,12 +76,12 @@
                 {% if user.can_change_username %}
                 {% blocktrans %}
                 You may only change your username once.
-                <a href="https://help.muckrock.com/Change-your-email-address-or-username-19ef889269638171afdcf13cd47608ba">Learn more</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/Change-your-email-address-or-username-19ef889269638171afdcf13cd47608ba">Learn more</a>
                 {% endblocktrans %}
                 {% else %}
                 {% blocktrans %}
                 You have already changed your username once.
-                <a href="https://help.muckrock.com/Change-your-email-address-or-username-19ef889269638171afdcf13cd47608ba">Learn more</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://help.muckrock.com/Change-your-email-address-or-username-19ef889269638171afdcf13cd47608ba">Learn more</a>
                 {% endblocktrans %}
                 {% endif %}
               </span>


### PR DESCRIPTION
This should get everything in #389 but it's possible I missed some. I normalized links so `target="_blank" rel="noopener norefferer"` is the first attribute, just so it's easier to check.