### PR TITLE
Avoid starting Mailchimp journeys outside production environments

### DIFF
--- a/squarelet/core/tests/test_utils.py
+++ b/squarelet/core/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Django
 from django.conf import settings
+from django.test import TestCase, override_settings
 
 # Standard Library
 import hashlib
@@ -23,8 +24,13 @@ def test_file_path_long():
     assert len(file_path("base", None, file_name)) == 92
 
 
-class TestMailchimpJourney:
-    def setup_method(self):
+@override_settings(
+    ENV="production",
+    MAILCHIMP_API_KEY="test-api-key-12345",
+    MAILCHIMP_API_ROOT="https://us1.api.mailchimp.com/3.0",
+)
+class TestMailchimpJourney(TestCase):
+    def setUp(self):
         self.email = "test@example.com"
         self.journey = "welcome_sq"
         self.journey_id = 24

--- a/squarelet/core/utils.py
+++ b/squarelet/core/utils.py
@@ -64,6 +64,11 @@ def mailchimp_subscribe(emails, list_=settings.MAILCHIMP_LIST_DEFAULT):
     """Adds the email to the mailing list throught the MailChimp API.
     https://mailchimp.com/developer/marketing/api/lists/"""
 
+    in_dev_env = settings.ENV in ("staging", "dev")
+    missing_api_key = not settings.MAILCHIMP_API_KEY
+    if in_dev_env or missing_api_key:
+        return None
+
     api_url = f"{settings.MAILCHIMP_API_ROOT}/lists/{list_}/"
     headers = {
         "Content-Type": "application/json",
@@ -86,6 +91,11 @@ def mailchimp_subscribe(emails, list_=settings.MAILCHIMP_LIST_DEFAULT):
 
 def mailchimp_journey(email, journey):
     """Trigger a mailchimp journey for the given email address"""
+
+    in_dev_env = settings.ENV in ("staging", "dev")
+    missing_api_key = not settings.MAILCHIMP_API_KEY
+    if in_dev_env or missing_api_key:
+        return None
 
     # IDs for our journeys
     journey_map = {


### PR DESCRIPTION
Fixes #398

- Escapes from `mailchimp_subscribe` and `mailchimp_journey` functions when missing an API key or in a dev environment
- Overrides these settings when testing with `TestMailchimpJourney`