### PR TITLE
Fix onboarding check in `user.post_login`

### DIFF
--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -19,6 +19,7 @@ from furl import furl
 # Squarelet
 from squarelet.core.mail import Email
 from squarelet.organizations.models import Invitation
+from squarelet.users.onboarding import OnboardingStepRegistry
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -138,7 +139,9 @@ class AccountAdapter(DefaultAccountAdapter):
         request.session["intent"] = request.GET.get("intent")
 
         # Check if we need user to go through onboarding
-        requires_onboarding = True  # TODO: Actually check lol
+        registry = OnboardingStepRegistry()
+        current_step, _ = registry.get_current_step(request)
+        requires_onboarding = current_step is not None
 
         if requires_onboarding:
             # Pass the user to the onboarding view

--- a/squarelet/users/tests/test_adapters.py
+++ b/squarelet/users/tests/test_adapters.py
@@ -52,11 +52,13 @@ class AdapterRedirectTests(TestCase):
         request.user = self.user
 
         # Set up a condition that would trigger onboarding
-        # For example, make this the first login and ensure onboarding session is not complete
+        # For example, make this the first login and
+        # ensure onboarding session is not complete
         self.user.last_login = self.user.date_joined
         self.user.save()
 
-        # Initialize onboarding session but leave steps incomplete to trigger onboarding
+        # Initialize onboarding session but leave
+        # steps incomplete to trigger onboarding
         request.session["onboarding"] = {
             "email_check_completed": False,  # This will trigger onboarding
             "mfa_step": "not_started",

--- a/squarelet/users/tests/test_adapters.py
+++ b/squarelet/users/tests/test_adapters.py
@@ -55,7 +55,7 @@ class AdapterRedirectTests(TestCase):
         # For example, make this the first login and ensure onboarding session is not complete
         self.user.last_login = self.user.date_joined
         self.user.save()
-        
+
         # Initialize onboarding session but leave steps incomplete to trigger onboarding
         request.session["onboarding"] = {
             "email_check_completed": False,  # This will trigger onboarding


### PR DESCRIPTION
We bridged the onboarding logic during development in the `post_login`, but never undid the bridge. This may explain some strange login behavior, like in #400.