### PR TITLE
Limits visible organizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,8 +163,8 @@ typings/
 !.vscode/launch.json
 !.vscode/extensions.json
 
-
-
+### Claude Code
+CLAUDE.md
 
 
 ### Windows template

--- a/squarelet/core/tests/test_utils.py
+++ b/squarelet/core/tests/test_utils.py
@@ -50,6 +50,38 @@ class TestMailchimpJourney(TestCase):
             "Authorization": f"apikey {settings.MAILCHIMP_API_KEY}",
         }
 
+    @override_settings(ENV="dev", MAILCHIMP_API_KEY="test-key")
+    @patch("squarelet.core.utils.requests.put")
+    @patch("squarelet.core.utils.requests.post")
+    def test_mailchimp_journey_skipped_in_dev_environment(self, mock_post, mock_put):
+        """MailChimp journey should be skipped in dev environment"""
+        result = mailchimp_journey(self.email, self.journey)
+        assert result is None
+        mock_put.assert_not_called()
+        mock_post.assert_not_called()
+
+    @override_settings(ENV="staging", MAILCHIMP_API_KEY="test-key")
+    @patch("squarelet.core.utils.requests.put")
+    @patch("squarelet.core.utils.requests.post")
+    def test_mailchimp_journey_skipped_in_staging_environment(
+        self, mock_post, mock_put
+    ):
+        """MailChimp journey should be skipped in staging environment"""
+        result = mailchimp_journey(self.email, self.journey)
+        assert result is None
+        mock_put.assert_not_called()
+        mock_post.assert_not_called()
+
+    @override_settings(ENV="production", MAILCHIMP_API_KEY="")
+    @patch("squarelet.core.utils.requests.put")
+    @patch("squarelet.core.utils.requests.post")
+    def test_mailchimp_journey_skipped_without_api_key(self, mock_post, mock_put):
+        """MailChimp journey should be skipped when API key is missing"""
+        result = mailchimp_journey(self.email, self.journey)
+        assert result is None
+        mock_put.assert_not_called()
+        mock_post.assert_not_called()
+
     @patch("squarelet.core.utils.requests.put")
     @patch("squarelet.core.utils.requests.post")
     def test_successful_journey(self, mock_post, mock_put):

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -27,17 +27,18 @@ class OrganizationQuerySet(models.QuerySet):
             return self
         elif user.is_authenticated:
             # other users may not see private organizations unless they are a member
-            # and they can only see public organizations that are visible (verified or have charges)
+            # and they can only see public organizations that are visible
+            # (verified or have charges)
             return self.filter(
-                Q(private=False, verified_journalist=True) |
-                Q(private=False, charges__isnull=False) |
-                Q(users=user)
+                Q(private=False, verified_journalist=True)
+                | Q(private=False, charges__isnull=False)
+                | Q(users=user)
             ).distinct()
         else:
             # anonymous users may only see public organizations that are visible
             return self.filter(
-                Q(private=False, verified_journalist=True) |
-                Q(private=False, charges__isnull=False)
+                Q(private=False, verified_journalist=True)
+                | Q(private=False, charges__isnull=False)
             ).distinct()
 
     def create_individual(self, user, uuid=None):

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -27,10 +27,18 @@ class OrganizationQuerySet(models.QuerySet):
             return self
         elif user.is_authenticated:
             # other users may not see private organizations unless they are a member
-            return self.filter(Q(private=False) | Q(users=user)).distinct()
+            # and they can only see public organizations that are visible (verified or have charges)
+            return self.filter(
+                Q(private=False, verified_journalist=True) |
+                Q(private=False, charges__isnull=False) |
+                Q(users=user)
+            ).distinct()
         else:
-            # anonymous users may not see any private organizations
-            return self.filter(private=False)
+            # anonymous users may only see public organizations that are visible
+            return self.filter(
+                Q(private=False, verified_journalist=True) |
+                Q(private=False, charges__isnull=False)
+            ).distinct()
 
     def create_individual(self, user, uuid=None):
         """Create an individual organization for user

--- a/squarelet/organizations/tests/factories.py
+++ b/squarelet/organizations/tests/factories.py
@@ -16,7 +16,7 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
         "squarelet.organizations.tests.factories.CustomerFactory", "organization"
     )
     allow_auto_join = False
-    verified_journalist = False
+    verified_journalist = True
 
     class Meta:
         model = "organizations.Organization"

--- a/squarelet/organizations/tests/test_querysets.py
+++ b/squarelet/organizations/tests/test_querysets.py
@@ -1,16 +1,127 @@
 # Django
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
 # Third Party
 import pytest
 
 # Squarelet
-from squarelet.organizations.models import Membership
+from squarelet.organizations.models import Membership, Organization
 from squarelet.organizations.tests.factories import (
+    ChargeFactory,
     MembershipFactory,
     OrganizationFactory,
 )
 from squarelet.users.tests.factories import UserFactory
+
+
+class TestOrganizationQuerySet(TestCase):
+    """Unit tests for Organization queryset"""
+
+    @pytest.mark.django_db
+    def test_get_viewable_staff_user(self):
+        """Staff users can view all organizations"""
+        staff_user = UserFactory(is_staff=True)
+        private_org = OrganizationFactory(private=True, verified_journalist=False)
+        public_org = OrganizationFactory(private=False, verified_journalist=True)
+
+        viewable = Organization.objects.get_viewable(staff_user)
+        assert private_org in viewable
+        assert public_org in viewable
+        assert viewable.count() >= 2
+
+    @pytest.mark.django_db
+    def test_get_viewable_authenticated_user_public_verified(self):
+        """Authenticated users can view public, verified orgs"""
+        user = UserFactory()
+        public_verified_org = OrganizationFactory(
+            private=False, verified_journalist=True
+        )
+        private_org = OrganizationFactory(private=True, verified_journalist=True)
+        public_unverified_org = OrganizationFactory(
+            private=False, verified_journalist=False
+        )
+
+        viewable = Organization.objects.get_viewable(user)
+        assert public_verified_org in viewable
+        assert private_org not in viewable
+        assert public_unverified_org not in viewable
+
+    @pytest.mark.django_db
+    def test_get_viewable_authenticated_user_public_with_charges(self):
+        """Authenticated users can view public orgs with charges"""
+        user = UserFactory()
+        public_org_with_charges = OrganizationFactory(
+            private=False, verified_journalist=False
+        )
+        ChargeFactory(organization=public_org_with_charges)
+        public_org_without_charges = OrganizationFactory(
+            private=False, verified_journalist=False
+        )
+
+        viewable = Organization.objects.get_viewable(user)
+        assert public_org_with_charges in viewable
+        assert public_org_without_charges not in viewable
+
+    @pytest.mark.django_db
+    def test_get_viewable_authenticated_user_member_of_private_org(self):
+        """Authenticated users can view private orgs they are members of"""
+        user = UserFactory()
+        private_org = OrganizationFactory(private=True, verified_journalist=False)
+        MembershipFactory(user=user, organization=private_org)
+        other_private_org = OrganizationFactory(private=True, verified_journalist=False)
+
+        viewable = Organization.objects.get_viewable(user)
+        assert private_org in viewable
+        assert other_private_org not in viewable
+
+    @pytest.mark.django_db
+    def test_get_viewable_anonymous_user_public_verified(self):
+        """Anonymous users can only view public verified journalist orgs"""
+        user = AnonymousUser()
+        public_verified_org = OrganizationFactory(
+            private=False, verified_journalist=True
+        )
+        private_verified_org = OrganizationFactory(
+            private=True, verified_journalist=True
+        )
+        public_unverified_org = OrganizationFactory(
+            private=False, verified_journalist=False
+        )
+
+        viewable = Organization.objects.get_viewable(user)
+        assert public_verified_org in viewable
+        assert private_verified_org not in viewable
+        assert public_unverified_org not in viewable
+
+    @pytest.mark.django_db
+    def test_get_viewable_anonymous_user_public_with_charges(self):
+        """Anonymous users can view public orgs with charges"""
+        user = AnonymousUser()
+        public_org_with_charges = OrganizationFactory(
+            private=False, verified_journalist=False
+        )
+        ChargeFactory(organization=public_org_with_charges)
+        public_org_without_charges = OrganizationFactory(
+            private=False, verified_journalist=False
+        )
+
+        viewable = Organization.objects.get_viewable(user)
+        assert public_org_with_charges in viewable
+        assert public_org_without_charges not in viewable
+
+    @pytest.mark.django_db
+    def test_get_viewable_distinct_results(self):
+        """Ensure queryset returns distinct results"""
+        user = UserFactory()
+        org = OrganizationFactory(private=False, verified_journalist=True)
+        # Create a charge and membership to potentially cause duplicates
+        ChargeFactory(organization=org)
+        MembershipFactory(user=user, organization=org)
+
+        viewable = Organization.objects.get_viewable(user)
+        # Should only appear once despite meeting multiple criteria
+        assert viewable.filter(id=org.id).count() == 1
 
 
 class TestMembershipQuerySet(TestCase):


### PR DESCRIPTION
Fixes #322

- Adds conditions to the `OrganizationQuerySet.get_viewable` method to only return organizations that have been verified or have exisiting charges.
- Adds test coverage for `OrganizationQuerySet`.