### PR TITLE
Display errors on reauthentication page

### DIFF
--- a/squarelet/templates/account/reauthenticate.html
+++ b/squarelet/templates/account/reauthenticate.html
@@ -65,9 +65,11 @@
 {% block reauthenticate_content %}
   <form class="m-0" method="post" action="{% url 'account_reauthenticate' %}">
     {% csrf_token %}
+    {{ form.non_field_errors }}
     <label class="field">
       {% trans "Password" %}
       <input type="password" name="password" />
+      {{ form.password.errors }}
     </label>
     {{ redirect_field }}
     <button type="submit" class="button primary">{% trans "Confirm" %}</button>


### PR DESCRIPTION
If a user puts in the wrong password in the reauthentication page, they don't get any feedback that this happened! This displays the errors on the page as expected.