### PR TITLE
Don't send Slack webhooks outside production

### DIFF
--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -270,6 +270,9 @@ class Subscription(models.Model):
 
     def send_slack_notification(self, event, **kwargs):
         """Queue a Slack notification asynchronously for subscription events."""
+        if settings.ENV != "production":
+            return
+
         if not self.plan.slack_webhook_url:
             return
 


### PR DESCRIPTION
I found that subscribing in my local environment sent an alert to our Slack channel. We only want to send these alerts for actual subscriptions, which means only sending when in production environments.