### PR TITLE
Redirect to previous page when taking POST actions on invitations

### DIFF
--- a/squarelet/core/tests/test_utils.py
+++ b/squarelet/core/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Django
 from django.conf import settings
+from django.http import HttpRequest, HttpResponseRedirect
 from django.test import TestCase, override_settings
 
 # Standard Library
@@ -10,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import requests
 
 # Squarelet
-from squarelet.core.utils import file_path, mailchimp_journey
+from squarelet.core.utils import file_path, get_redirect_url, mailchimp_journey
 
 
 def test_file_path_normal():
@@ -178,3 +179,46 @@ class TestMailchimpJourney(TestCase):
         # Call the function and verify logger is called
         mailchimp_journey(self.email, self.journey)
         assert mock_logger.call_count == 1
+
+
+class TestGetRedirectUrl:
+    """Test the get_redirect_url utility function"""
+
+    def test_redirect_with_referer(self):
+        """Test redirect uses HTTP_REFERER when available"""
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = '/previous/page/'
+
+        response = get_redirect_url(request, '/fallback/page/')
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == '/previous/page/'
+
+    def test_redirect_without_referer_string_fallback(self):
+        """Test redirect uses string fallback when no HTTP_REFERER"""
+        request = HttpRequest()
+
+        response = get_redirect_url(request, '/fallback/page/')
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == '/fallback/page/'
+
+    def test_redirect_without_referer_httpresponse_fallback(self):
+        """Test redirect uses HttpResponseRedirect fallback when no HTTP_REFERER"""
+        request = HttpRequest()
+        fallback = HttpResponseRedirect('/fallback/page/')
+
+        response = get_redirect_url(request, fallback)
+
+        assert response is fallback
+        assert response.url == '/fallback/page/'
+
+    def test_redirect_empty_referer(self):
+        """Test redirect uses fallback when HTTP_REFERER is empty"""
+        request = HttpRequest()
+        request.META['HTTP_REFERER'] = ''
+
+        response = get_redirect_url(request, '/fallback/page/')
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == '/fallback/page/'

--- a/squarelet/core/utils.py
+++ b/squarelet/core/utils.py
@@ -1,5 +1,6 @@
 # Django
 from django.conf import settings
+from django.http import HttpResponseRedirect
 
 # Standard Library
 import logging
@@ -150,3 +151,21 @@ def mailchimp_journey(email, journey):
     except (requests.ConnectionError, ValueError):
         logger.error("[JOURNEY] Error starting journey", exc_info=sys.exc_info())
     return response
+
+
+def get_redirect_url(request, fallback):
+    """
+    Try to get a redirect URL from HTTP_REFERER header first,
+    falling back to the provided fallback if not available.
+    This way, we can send users back to the page they came from.
+    """
+    referer = request.META.get('HTTP_REFERER')
+    if referer:
+        return HttpResponseRedirect(referer)
+
+    # If fallback is already an HttpResponseRedirect, return it
+    if isinstance(fallback, HttpResponseRedirect):
+        return fallback
+
+    # Otherwise, treat it as a URL string
+    return HttpResponseRedirect(fallback)

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 # Standard Library
 import json
+from unittest.mock import MagicMock
 
 # Third Party
 import pytest
@@ -452,6 +453,64 @@ class TestInvitationAccept(ViewTestMixin):
         invitation.refresh_from_db()
         assert invitation.accepted_at is None
         assert invitation.rejected_at is None
+
+    def test_accept_with_referer(self, rf, invitation_factory, user_factory):
+        """Test that accept redirects to HTTP_REFERER when present"""
+        invitation = invitation_factory()
+        user = user_factory()
+
+        # Create request with HTTP_REFERER
+        url = self.url.format(uuid=invitation.uuid)
+        request = rf.post(url, {"action": "accept"})
+        request.user = user
+        request._messages = MagicMock()
+        request.session = MagicMock()
+        request.META['HTTP_REFERER'] = '/some/previous/page/'
+
+        response = self.view.as_view()(request, uuid=invitation.uuid)
+
+        assert response.status_code == 302
+        assert response.url == '/some/previous/page/'
+
+    def test_reject_with_referer(self, rf, invitation_factory, user_factory):
+        """Test that reject redirects to HTTP_REFERER when present"""
+        invitation = invitation_factory()
+        user = user_factory()
+
+        # Create request with HTTP_REFERER
+        url = self.url.format(uuid=invitation.uuid)
+        request = rf.post(url, {"action": "reject"})
+        request.user = user
+        request._messages = MagicMock()
+        request.session = MagicMock()
+        request.META['HTTP_REFERER'] = '/another/page/'
+
+        response = self.view.as_view()(request, uuid=invitation.uuid)
+
+        assert response.status_code == 302
+        assert response.url == '/another/page/'
+
+    def test_accept_without_referer(self, rf, invitation_factory, user_factory):
+        """Test that accept falls back to default redirect when no HTTP_REFERER"""
+        invitation = invitation_factory()
+        user = user_factory()
+
+        response = self.call_view(rf, user, {"action": "accept"}, uuid=invitation.uuid)
+
+        assert response.status_code == 302
+        # Should redirect to the organization (default fallback)
+        assert f'/organizations/{invitation.organization.slug}/' in response.url
+
+    def test_reject_without_referer(self, rf, invitation_factory, user_factory):
+        """Test that reject falls back to default redirect when no HTTP_REFERER"""
+        invitation = invitation_factory()
+        user = user_factory()
+
+        response = self.call_view(rf, user, {"action": "reject"}, uuid=invitation.uuid)
+
+        assert response.status_code == 302
+        # Should redirect to the user (default fallback)
+        assert f'/users/{user.username}/' in response.url
 
 
 @pytest.mark.django_db()

--- a/squarelet/organizations/views.py
+++ b/squarelet/organizations/views.py
@@ -40,6 +40,7 @@ from fuzzywuzzy import fuzz, process
 
 # Squarelet
 from squarelet.core.mixins import AdminLinkMixin
+from squarelet.core.utils import get_redirect_url
 from squarelet.organizations.choices import ChangeLogReason
 from squarelet.organizations.denylist_domains import DENYLIST_DOMAINS
 from squarelet.organizations.forms import (
@@ -158,7 +159,8 @@ class Detail(AdminLinkMixin, DetailView):
                     self.organization.plan.pk,
                     wix_user.pk,
                 )
-        return redirect(self.organization)
+            messages.success(request, _("Wix sync started"))
+        return get_redirect_url(request, redirect(self.organization))
 
 
 class List(ListView):
@@ -534,17 +536,17 @@ class InvitationAccept(DetailView):
         if action == "accept":
             invitation.accept(request.user)
             messages.success(request, "Invitation accepted")
-            return redirect(invitation.organization)
+            return get_redirect_url(request, redirect(invitation.organization))
         elif action == "reject":
             invitation.reject()
             if invitation.request:
                 messages.info(request, "Invitation withdrawn")
             else:
                 messages.info(request, "Invitation rejected")
-            return redirect(request.user)
+            return get_redirect_url(request, redirect(request.user))
         else:
             messages.error(request, "Invalid choice")
-            return redirect(request.user)
+            return get_redirect_url(request, redirect(request.user))
 
 
 @method_decorator(xframe_options_sameorigin, name="dispatch")


### PR DESCRIPTION
Fixes #441

Creates a utility function that will return the user to the page they came from when taking a POST action, or redirect to a fallback URL if the `HTTP_REFERRER` is unavailable. This improves the user experience by keeping people on their current page when taking an action, instead of sending them to the page of the object they're taking action on.