### PR TITLE
Fixes bugs in organization list

### DIFF
--- a/squarelet/templates/organizations/organization_list.html
+++ b/squarelet/templates/organizations/organization_list.html
@@ -97,7 +97,7 @@
               
               <form method="post" action="{% url "organizations:detail" slug=organization.slug %}" class="actions join">
                 {% csrf_token %}
-                <button class="button primary" name="action" value="join">
+                <button class="btn small primary" name="action" value="join">
                   <img src="{% static "icons/check.svg" %}">
                   {% trans "Join" %}
                 </button>
@@ -124,7 +124,7 @@
               
               <form method="post" action="{% url "organizations:invitation" uuid=invite.uuid %}" class="actions">
                 {% csrf_token %}
-                <button class="btn small primary ghost" type="submit" name="action" value="accept">
+                <button class="btn small primary" type="submit" name="action" value="accept">
                   {% trans "Accept" %}
                 </button>
                 <button class="btn small danger ghost" type="submit" name="action" value="reject">

--- a/squarelet/templates/organizations/your_organizations.html
+++ b/squarelet/templates/organizations/your_organizations.html
@@ -1,6 +1,6 @@
 {% load airtable i18n static %}
 
-{% if potential_organizations %}
+{% if show_invitations and potential_organizations %}
 <div class="org-list">
   <header class="org-list-header">
     <h3>{% trans "Pre-approved" %}</h3>
@@ -21,7 +21,7 @@
 </div>
 {% endif %}
 
-{% if pending_invitations %}
+{% if show_invitations and pending_invitations %}
 <div class="org-list">
   <header class="org-list-header">
     <h3>{% trans "Open invitations" %}</h3>
@@ -42,6 +42,31 @@
     </div>
   {% endfor %}
 </div>
+{% endif %}
+
+{% if show_invitations and pending_requests %}
+  <div class="org-list">
+    <header class="org-list-header">
+      <h3>{% trans "Open requests" %}</h3>
+      <p>{% trans "Organizations you’ve requested to join:" %}</p>
+    </header>
+    {% for invite in pending_requests %}
+    <div class="invite">
+      {% include "account/team_list_item.html" with organization=invite.organization %}
+
+      <form method="post" action="{% url "organizations:invitation" uuid=invite.uuid %}" class="actions">
+        {% csrf_token %}
+        <button class="btn small danger ghost" type="submit" name="action" value="reject">
+          {% trans "Withdraw request" %}
+        </button>
+      </form>
+    </div>
+    {% empty %}
+    <div class="empty">
+      <p>{% trans "No pending requests." %}</p>
+    </div>
+    {% endfor %}
+  </div>
 {% endif %}
 
 {% if admin_orgs %}

--- a/squarelet/templates/users/user_detail.html
+++ b/squarelet/templates/users/user_detail.html
@@ -344,7 +344,7 @@
         </div>
       </header>
       <main class="orgs">
-        {% include "organizations/your_organizations.html" %}
+        {% include "organizations/your_organizations.html" with show_invitations=True %}
       </main>
       <footer>
         <p class="help-text">If you’re a freelancer who works with multiple organizations, you may <a target="_blank" rel="noopener noreferrer" href="{% airtable_verification_url %}">request individual verification as a journalist</a>.</p>

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -135,6 +135,7 @@ class UserDetailView(LoginRequiredMixin, StaffAccessMixin, AdminLinkMixin, Detai
         context["is_own_page"] = user == self.request.user
         context["potential_organizations"] = list(user.get_potential_organizations())
         context["pending_invitations"] = list(user.get_pending_invitations())
+        context["pending_requests"] = list(user.get_pending_requests())
         context["verified"] = user.verified_journalist()
         context["verified_organizations"] = list(
             user.organizations.filter(verified_journalist=True, individual=False)


### PR DESCRIPTION
Discovered these issues while working on #444. They're unrelated, so opened a new PR for them.

- On the `/organizations/` page, invitations to orgs were duplicated in the left and right columns. This deduplicates invitations in the `organization_list` view by adding a flag to show invitations in the `your_organizations.html` fragment.
- Pending requests to join an organization were missing from the `your_organizations.html` fragment and the `UserDetailView` context.
- Fix button styling on invitation actions on the `/organizations/` route.