### PR TITLE
Fix button colors in `user_form.html`

### DIFF
--- a/squarelet/templates/users/user_form.html
+++ b/squarelet/templates/users/user_form.html
@@ -54,7 +54,7 @@
   <div class="user-profile-view">
     <header>
       <nav class="links">
-        <a class="ghost btn" href="{% url "users:detail" username=user.username %}">
+        <a class="ghost btn primary" href="{% url "users:detail" username=user.username %}">
           {% include "core/icons/arrow-left.svg" %}
           {% trans "Back to your account" %}
         </a>

--- a/squarelet/templates/widgets/avatar.html
+++ b/squarelet/templates/widgets/avatar.html
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class="avatar-actions">
-    <label class="avatar-upload ghost btn">
+    <label class="avatar-upload ghost btn primary">
       {% include 'core/icons/upload.svg' %}
       {{ widget.upload_label }}
       <input


### PR DESCRIPTION
A few of the buttons were missing a primary styling, so they fell back to our default gray color. This fixes the color of the buttons.