### PR TITLE
Provide action to confirm email from empty invitation/request view

### DIFF
--- a/squarelet/templates/organizations/organization_list.html
+++ b/squarelet/templates/organizations/organization_list.html
@@ -77,6 +77,13 @@
           or receive invitations to join an organization.
           {% endblocktrans %}
         </p>
+        <form class="email-actions" action="{% url "account_email" %}" method="post">
+          {% csrf_token %}
+          <input type="hidden" name="email" value="{{user.email}}" />
+          <button class="btn primary small" type="submit" name="action_send">
+            {% trans "Confirm your email address" %}
+          </button>
+        </form>
       </div>
       {% elif not has_pending %}
       <div class="empty">

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -94,11 +94,13 @@ class StaffAccessMixin:
 
 
 class UserEmailView(AllAuthEmailView):
-    """Custom email view to redirect to user detail page after email operations."""
+    """Custom email view to redirect user after email operations."""
 
     def get_success_url(self):
-        """Redirect to the user detail page after a successful email operation."""
-        return reverse("users:detail", kwargs={"username": self.request.user.username})
+        """Redirect to the previous page after a successful email operation."""
+        return self.request.META.get("HTTP_REFERER") or reverse(
+            "users:detail", kwargs={"username": self.request.user.username}
+        )
 
 
 class UserConnectionsView(ConnectionsView):


### PR DESCRIPTION
Fixes #393

Uses the same HTTP_REFERRER redirect approach as #444, but doesn't use the utility from that PR.