### PR TITLE
Removed private=false

### DIFF
--- a/frontend/components/OrgSearch.svelte
+++ b/frontend/components/OrgSearch.svelte
@@ -21,7 +21,7 @@
     bind:value={selected}
     valueAsObject
     labelField="name"
-    fetch="/fe_api/organizations/?individual=false&private=false&search=[query]"
+    fetch="/fe_api/organizations/?individual=false&search=[query]"
     fetchCallback={(resp) => resp.results}
     fetchResetOnBlur={false}
     resetOnBlur={false}


### PR DESCRIPTION
The organization queryset handles whether a user can see a private org or not already, so providing it here makes it so that staff users cannot see private orgs in the search. 

To test:
Login as staff user and do an org search for a private org. You should be able to see it. 

Login as a regular user and search for the same private org. You should not  be able to see it. 