### PR TITLE
Create a new org when purchasing a plan

### DIFF
--- a/frontend/css/plan.css
+++ b/frontend/css/plan.css
@@ -467,6 +467,20 @@
   flex: 1;
 }
 
+.organization-selection .new-org-name-field {
+  display: none;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.organization-selection .new-org-name-field.showField {
+  display: flex;
+}
+
+.new-card-option.only-option {
+  display: none;
+}
+
 .org-select {
   width: 100%;
   padding: 0.5rem;

--- a/squarelet/payments/tests/test_views.py
+++ b/squarelet/payments/tests/test_views.py
@@ -6,6 +6,8 @@ from squarelet.core.tests.mixins import ViewTestMixin
 from squarelet.organizations.models import Organization
 from squarelet.payments import views
 
+# pylint: disable=invalid-name
+
 
 @pytest.mark.django_db()
 class TestPlanDetailViewCreateOrganization(ViewTestMixin):
@@ -32,9 +34,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             "stripe_token": "tok_visa",
         }
 
-        response = self.call_view(
-            rf, user, data=data, pk=plan.pk, slug=plan.slug
-        )
+        response = self.call_view(rf, user, data=data, pk=plan.pk, slug=plan.slug)
 
         # Verify organization was created
         org = Organization.objects.get(name="My New Organization")
@@ -53,9 +53,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
         assert response.status_code == 302
         assert response.url == org.get_absolute_url()
 
-    def test_create_new_organization_without_name(
-        self, rf, user_factory, plan_factory
-    ):
+    def test_create_new_organization_without_name(self, rf, user_factory, plan_factory):
         """Test validation when creating organization without a name"""
         user = user_factory()
         plan = plan_factory(for_groups=True, public=True)
@@ -66,9 +64,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             "stripe_token": "tok_visa",
         }
 
-        response = self.call_view(
-            rf, user, data=data, pk=plan.pk, slug=plan.slug
-        )
+        response = self.call_view(rf, user, data=data, pk=plan.pk, slug=plan.slug)
 
         # Should redirect with error message
         assert response.status_code == 302
@@ -122,9 +118,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             "stripe_token": "tok_visa",
         }
 
-        response = self.call_view(
-            rf, user, data=data, pk=plan.pk, slug=plan.slug
-        )
+        response = self.call_view(rf, user, data=data, pk=plan.pk, slug=plan.slug)
 
         # Verify subscription was created with existing org
         mock_set_subscription.assert_called_once_with(
@@ -138,9 +132,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
         assert response.status_code == 302
         assert response.url == org.get_absolute_url()
 
-    def test_unauthenticated_user_redirected_to_login(
-        self, rf, plan_factory
-    ):
+    def test_unauthenticated_user_redirected_to_login(self, rf, plan_factory):
         """Test that unauthenticated users are redirected to login"""
         plan = plan_factory(public=True)
 
@@ -150,9 +142,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             "stripe_token": "tok_visa",
         }
 
-        response = self.call_view(
-            rf, user=None, data=data, pk=plan.pk, slug=plan.slug
-        )
+        response = self.call_view(rf, user=None, data=data, pk=plan.pk, slug=plan.slug)
 
         # Should redirect to login
         assert response.status_code == 302
@@ -175,9 +165,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             "stripe_token": "tok_visa",
         }
 
-        response = self.call_view(
-            rf, user, data=data, pk=plan.pk, slug=plan.slug
-        )
+        response = self.call_view(rf, user, data=data, pk=plan.pk, slug=plan.slug)
 
         # Should redirect back to plan
         assert response.status_code == 302

--- a/squarelet/payments/tests/test_views.py
+++ b/squarelet/payments/tests/test_views.py
@@ -1,0 +1,180 @@
+# Third Party
+import pytest
+
+# Squarelet
+from squarelet.core.tests.mixins import ViewTestMixin
+from squarelet.organizations.models import Organization
+from squarelet.payments import views
+
+
+@pytest.mark.django_db()
+class TestPlanDetailViewCreateOrganization(ViewTestMixin):
+    """Test the Plan Detail view with new organization creation"""
+
+    view = views.PlanDetailView
+    url = "/plans/{pk}/{slug}/"
+
+    def test_create_new_organization_with_subscription(
+        self, rf, user_factory, plan_factory, mocker
+    ):
+        """Test creating a new organization during plan subscription"""
+        user = user_factory()
+        plan = plan_factory(for_groups=True, public=True)
+
+        # Mock the set_subscription method to avoid Stripe calls
+        mock_set_subscription = mocker.patch.object(
+            Organization, "set_subscription", return_value=None
+        )
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "My New Organization",
+            "stripe_token": "tok_visa",
+        }
+
+        response = self.call_view(
+            rf, user, data=data, pk=plan.pk, slug=plan.slug
+        )
+
+        # Verify organization was created
+        org = Organization.objects.get(name="My New Organization")
+        assert org.private is False
+        assert org.has_admin(user)
+
+        # Verify subscription was created
+        mock_set_subscription.assert_called_once_with(
+            token="tok_visa",
+            plan=plan,
+            max_users=plan.minimum_users,
+            user=user,
+        )
+
+        # Should redirect back to plan
+        assert response.status_code == 302
+
+    def test_create_new_organization_without_name(
+        self, rf, user_factory, plan_factory
+    ):
+        """Test validation when creating organization without a name"""
+        user = user_factory()
+        plan = plan_factory(for_groups=True, public=True)
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "",  # Empty name
+            "stripe_token": "tok_visa",
+        }
+
+        response = self.call_view(
+            rf, user, data=data, pk=plan.pk, slug=plan.slug
+        )
+
+        # Should redirect with error message
+        assert response.status_code == 302
+
+        # Verify no organization was created
+        assert not Organization.objects.filter(name="").exists()
+
+    def test_new_organization_adds_user_as_admin(
+        self, rf, user_factory, plan_factory, mocker
+    ):
+        """Test that user is added as admin when creating new organization"""
+        user = user_factory()
+        plan = plan_factory(for_groups=True, public=True)
+
+        # Mock set_subscription
+        mocker.patch.object(Organization, "set_subscription", return_value=None)
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "Test Org",
+            "stripe_token": "tok_visa",
+        }
+
+        self.call_view(rf, user, data=data, pk=plan.pk, slug=plan.slug)
+
+        org = Organization.objects.get(name="Test Org")
+
+        # Verify user is admin
+        assert org.has_admin(user)
+
+        # Verify user's email is added as receipt email
+        if user.email:
+            assert org.receipt_emails.filter(email=user.email).exists()
+
+    def test_existing_organization_flow_still_works(
+        self, rf, user_factory, organization_factory, plan_factory, mocker
+    ):
+        """Test that existing organization subscription still works"""
+        user = user_factory()
+        org = organization_factory()
+        org.add_creator(user)
+        plan = plan_factory(for_groups=True, public=True)
+
+        # Mock set_subscription
+        mock_set_subscription = mocker.patch.object(
+            Organization, "set_subscription", return_value=None
+        )
+
+        data = {
+            "organization": str(org.pk),
+            "stripe_token": "tok_visa",
+        }
+
+        response = self.call_view(
+            rf, user, data=data, pk=plan.pk, slug=plan.slug
+        )
+
+        # Verify subscription was created with existing org
+        mock_set_subscription.assert_called_once_with(
+            token="tok_visa",
+            plan=plan,
+            max_users=plan.minimum_users,
+            user=user,
+        )
+
+        assert response.status_code == 302
+
+    def test_unauthenticated_user_redirected_to_login(
+        self, rf, plan_factory
+    ):
+        """Test that unauthenticated users are redirected to login"""
+        plan = plan_factory(public=True)
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "Test Org",
+            "stripe_token": "tok_visa",
+        }
+
+        response = self.call_view(
+            rf, user=None, data=data, pk=plan.pk, slug=plan.slug
+        )
+
+        # Should redirect to login
+        assert response.status_code == 302
+        assert "/accounts/login/" in response.url
+
+    def test_already_subscribed_organization(
+        self, rf, user_factory, organization_factory, plan_factory, subscription_factory
+    ):
+        """Test that already subscribed organizations show warning"""
+        user = user_factory()
+        plan = plan_factory(for_groups=True, public=True)
+        org = organization_factory()
+        org.add_creator(user)
+
+        # Create existing subscription
+        subscription_factory(organization=org, plan=plan, cancelled=False)
+
+        data = {
+            "organization": str(org.pk),
+            "stripe_token": "tok_visa",
+        }
+
+        response = self.call_view(
+            rf, user, data=data, pk=plan.pk, slug=plan.slug
+        )
+
+        # Should redirect back to plan
+        assert response.status_code == 302

--- a/squarelet/payments/tests/test_views.py
+++ b/squarelet/payments/tests/test_views.py
@@ -49,8 +49,9 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             user=user,
         )
 
-        # Should redirect back to plan
+        # Should redirect to the organization
         assert response.status_code == 302
+        assert response.url == org.get_absolute_url()
 
     def test_create_new_organization_without_name(
         self, rf, user_factory, plan_factory
@@ -133,7 +134,9 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             user=user,
         )
 
+        # Should redirect to the organization
         assert response.status_code == 302
+        assert response.url == org.get_absolute_url()
 
     def test_unauthenticated_user_redirected_to_login(
         self, rf, plan_factory

--- a/squarelet/payments/views.py
+++ b/squarelet/payments/views.py
@@ -147,11 +147,26 @@ class PlanDetailView(DetailView):
 
         # Get form data
         organization_id = request.POST.get("organization")
+        new_organization_name = request.POST.get("new_organization_name")
         stripe_token = request.POST.get("stripe_token")
 
         try:
-            # Get the organization
-            if organization_id:
+            # Get or create the organization
+            if organization_id == "new":
+                # Create a new organization
+                if not new_organization_name:
+                    messages.error(
+                        request, _("Please provide a name for the new organization")
+                    )
+                    return redirect(plan)
+
+                organization = Organization.objects.create(
+                    name=new_organization_name,
+                    private=False,
+                )
+                # Add the user as an admin
+                organization.add_creator(request.user)
+            elif organization_id:
                 organization = Organization.objects.get(
                     pk=organization_id, users=request.user, memberships__admin=True
                 )

--- a/squarelet/payments/views.py
+++ b/squarelet/payments/views.py
@@ -215,9 +215,9 @@ class PlanDetailView(DetailView):
                 user=request.user,
             )
 
-            # Success - redirect to plan page or success page
+            # Success - redirect to organization page
             messages.success(request, _("Succesfully subscribed"))
-            return redirect(plan)
+            return redirect(organization)
 
         except Organization.DoesNotExist:
             # Invalid organization

--- a/squarelet/templates/payments/plan.html
+++ b/squarelet/templates/payments/plan.html
@@ -68,7 +68,7 @@
             {% endif %}
 
             {% if user.is_authenticated %}
-              {% if can_subscribe_individual and plan.for_individuals or admin_organizations and plan.for_groups %}
+              {% if can_subscribe_individual and plan.for_individuals or plan.for_groups %}
               <!-- Organization selection -->
               <div class="organization-selection">
                 <label>
@@ -84,8 +84,13 @@
                       {% for org in admin_organizations %}
                         <option value="{{ org.pk }}" data-slug="{{ org.slug }}" data-individual="false">{{ org.name }}</option>
                       {% endfor %}
+                      <option value="new" data-slug="" data-individual="false">{% trans "Create a new organization" %}</option>
                     {% endif %}
                   </select>
+                </label>
+                <label for="id_new_organization_name" class="new-org-name-field field">
+                  {% trans "Organization name" %}
+                  <input type="text" name="new_organization_name" id="id_new_organization_name" maxlength="255">
                 </label>
                 <a href="#" class="manage-payment-link small ghost button" style="display:none;">
                   {% trans "Manage payment methods" %}
@@ -120,7 +125,7 @@
               <!-- Save card option -->
               <label style="display:none;">
                 <input type="checkbox" name="save_card" checked>
-                {% trans "Save as new default card" %}
+                {% trans "Save as default card" %}
               </label>
             {% else %}
               <div class="no-subscription-options">


### PR DESCRIPTION
Fixes #417

This improves our onboarding experience for new users. After creating an account, they can create an org when purchasing a Sunlight research plan.

This depends on some changes made in #459, so that branch is its base. If that merges before this does, I'll update the base to be `master`. 