### PR TITLE
Always lists primary email address first

### DIFF
--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -147,7 +147,7 @@ class UserDetailView(LoginRequiredMixin, StaffAccessMixin, AdminLinkMixin, Detai
         context["individually_verified"] = (
             user.individual_organization.verified_journalist
         )
-        context["emails"] = user.emailaddress_set.all()
+        context["emails"] = user.emailaddress_set.order_by("-primary")
         context["has_unverified_emails"] = user.emailaddress_set.filter(
             verified=False
         ).exists()


### PR DESCRIPTION
Resolves #515 by sorting the email address list before adding it to the template context.

Adds a test to ensure emails are returned in the expected order.

Produced in collaboration with Claude Code.