### PR TITLE
Adds "Created At" column to users list in Django admin

### DIFF
--- a/squarelet/users/admin.py
+++ b/squarelet/users/admin.py
@@ -173,6 +173,7 @@ class MyUserAdmin(VersionAdmin, AuthUserAdmin):
         "is_staff",
         "is_superuser",
         "is_active",
+        "created_at",
     )
     list_filter = AuthUserAdmin.list_filter + (PermissionFilter,)
     search_fields = ("username_deterministic", "name", "email_deterministic")


### PR DESCRIPTION
To more easily investigate recent signups, we need a way to sort users by their signup date.