### PR TITLE
Fix org layout for non-admins

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -752,16 +752,16 @@ nav a:hover ._cls-serviceName {
 ._cls-profileColumn {
   display: flex;
   flex-direction: column;
-  flex: 0.5;
-  border-right: solid 1px #dedede;
+  flex: 1 1 auto;
   padding: 0 2em 0 0;
 }
 
 ._cls-planColumn {
   display: flex;
   flex-direction: column;
-  flex: 1;
+  flex: 1 1 auto;
   padding: 0 0 0 2em;
+  border-left: solid 1px #dedede;
 }
 
 ._cls-planInfo {

--- a/squarelet/templates/organizations/organization_detail.html
+++ b/squarelet/templates/organizations/organization_detail.html
@@ -34,8 +34,6 @@
           </div>
         {% endif %}
 
-
-
         <div class="_cls-profileSection">
           <div class="_cls-profileInfo _cls-organizationInfo">
             <div class="_cls-profileAvatar">
@@ -139,45 +137,45 @@
           {% endif %}
         </div>
       </div>
+      {% if is_admin %}
       <div class="_cls-planColumn">
-        {% if is_admin %}
-          <div class="_cls-currentPlan">
-            {% with subscription=organization.subscription %}
-              {% if subscription %}
-                <div class="_cls-planInfo">
-                  {% trans "Current plan" %}: <b>{{ subscription.plan.name }}</b>
-                  {% if subscription.cancelled %}
-                    <div class="_cls-info _cls-infoSpaced">
-                      {% blocktrans with update_on=subscription.update_on|date:"m/d/Y" %}
-                        Subscription ends  on {{ update_on }}
-                      {% endblocktrans %}
-                    </div>
-                  {% endif %}
-                </div>
-                <p>
-                  <a class="_cls-nostyle" href="{% url 'organizations:payment' organization.slug %}">
-                    <div class="_cls-action">{% trans 'Edit plans and payment' %}</div>
-                  </a>
-                </p>
-              {% else %}
-                <div class="_cls-planInfo">
-                  {% trans "Current plan" %}: <b>{% trans "Free" %}</b>
-                </div>
-                <div class="_cls-actionSmall">
-                  <a href="{% url 'organizations:payment' organization.slug %}">
-                    <button>{% trans 'Upgrade' %}</button>
-                  </a>
-                </div>
-              {% endif %}
-            {% endwith %}
-            <p>
-              <a class="_cls-nostyle" href="{% url 'users:receipts' username=user.username %}">
-                <div class="_cls-action">{% trans 'View receipts' %}</div>
-              </a>
-            </p>
-          </div>
-        {% endif %}
+        <div class="_cls-currentPlan">
+          {% with subscription=organization.subscription %}
+            {% if subscription %}
+              <div class="_cls-planInfo">
+                {% trans "Current plan" %}: <b>{{ subscription.plan.name }}</b>
+                {% if subscription.cancelled %}
+                  <div class="_cls-info _cls-infoSpaced">
+                    {% blocktrans with update_on=subscription.update_on|date:"m/d/Y" %}
+                      Subscription ends  on {{ update_on }}
+                    {% endblocktrans %}
+                  </div>
+                {% endif %}
+              </div>
+              <p>
+                <a class="_cls-nostyle" href="{% url 'organizations:payment' organization.slug %}">
+                  <div class="_cls-action">{% trans 'Edit plans and payment' %}</div>
+                </a>
+              </p>
+            {% else %}
+              <div class="_cls-planInfo">
+                {% trans "Current plan" %}: <b>{% trans "Free" %}</b>
+              </div>
+              <div class="_cls-actionSmall">
+                <a href="{% url 'organizations:payment' organization.slug %}">
+                  <button>{% trans 'Upgrade' %}</button>
+                </a>
+              </div>
+            {% endif %}
+          {% endwith %}
+          <p>
+            <a class="_cls-nostyle" href="{% url 'users:receipts' username=user.username %}">
+              <div class="_cls-action">{% trans 'View receipts' %}</div>
+            </a>
+          </p>
+        </div>
       </div>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
Removing the services list (#550) meant that there's no column content when a user isn't an org admin.

This updates the flex layout so that the profile sidebar fills and shares the available space.