### PR TITLE
Non-profit plan fixes

### DIFF
--- a/frontend/views/plan.ts
+++ b/frontend/views/plan.ts
@@ -252,20 +252,6 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  function updateNonprofitCheckboxVisibility(
-    selectedOrg: string,
-    elements: FormElements,
-    planData: any
-  ) {
-    if (!elements.nonprofitContainer) return;
-
-    if (planData.is_sunlight_plan && selectedOrg && selectedOrg !== '') {
-      elements.nonprofitContainer.style.display = 'block';
-    } else {
-      elements.nonprofitContainer.style.display = 'none';
-    }
-  }
-
   // Organization selection handling
   const orgSelects = document.querySelectorAll('.org-select');
   orgSelects.forEach(select => {
@@ -293,8 +279,7 @@ document.addEventListener("DOMContentLoaded", function () {
         // Enable the submit button
         updateSubmitButton(selectedOrg, elements);
 
-        // Update nonprofit checkbox visibility and price display
-        updateNonprofitCheckboxVisibility(selectedOrg, elements, planData);
+        // Update price display for nonprofit checkbox
         updatePriceDisplay(elements, planData);
       } else {
         // No organization selected - hide everything
@@ -303,11 +288,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
         // Disable the submit button
         updateSubmitButton(selectedOrg, elements);
-
-        // Hide nonprofit checkbox when no org selected
-        if (elements.nonprofitContainer) {
-          elements.nonprofitContainer.style.display = 'none';
-        }
       }
     });
     select.dispatchEvent(new Event("change"));

--- a/squarelet/templates/payments/plan.html
+++ b/squarelet/templates/payments/plan.html
@@ -138,8 +138,9 @@
                 {% trans "Save as default card" %}
               </label>
 
-              <!-- Nonprofit checkbox (only shown for Sunlight plans) -->
-              <div class="nonprofit-checkbox" style="display:none;">
+              <!-- Nonprofit checkbox (shown for Sunlight plans that aren't already nonprofit variants) -->
+              {% if plan.is_sunlight_plan and not is_nonprofit_variant %}
+              <div class="nonprofit-checkbox">
                 <label class="checkbox-label">
                   <input type="checkbox" name="is_nonprofit" id="id_is_nonprofit"
                           {% if request.POST.is_nonprofit %}checked{% endif %}>
@@ -149,6 +150,7 @@
                   {% trans "Non-profit organizations receive a discount on Sunlight Research Desk plans." %}
                 </p>
               </div>
+              {% endif %}
             {% else %}
               <div class="no-subscription-options">
                 <p>{% trans "You are already subscribed to this plan or don't have permission to subscribe." %}</p>


### PR DESCRIPTION
1. Always show the "My organization is non-profit" checkbox so users know they can purchase non-profit variants of a plan.
2. Don't show the checkbox when viewing the page for a non-profit plan.