### PR TITLE
Fix service item text alignment

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1782,6 +1782,7 @@ a.service-provider:focus {
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+  text-align: left;
 }
 
 .button {


### PR DESCRIPTION
On the reauthenticate view, a `p` selector is messing with the alignment of the service list items. I added a more specific selector for `.service-provider p` to enforce left alignment for these elements.