### PR TITLE
Adds org dropdown to top navigation

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1317,6 +1317,92 @@ button._cls-navItem:hover {
   line-height: 1.3;
 }
 
+/* Organizations dropdown */
+._cls-orgsDropdown {
+  position: relative;
+}
+
+._cls-orgsToggle {
+  cursor: pointer;
+}
+
+._cls-orgsMenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 280px;
+  max-height: 400px;
+  overflow-y: auto;
+  background: var(--white);
+  border: 1px solid var(--gray-2);
+  border-radius: var(--radius-3);
+  box-shadow: var(--shadow-2);
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  z-index: var(--z-dropdown);
+}
+
+._cls-orgsDropdown[data-open="true"] ._cls-orgsMenu {
+  display: block;
+}
+
+._cls-orgItem {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-2);
+  text-decoration: none;
+  color: var(--gray-5);
+  transition: background 0.2s ease;
+  align-items: center;
+}
+
+._cls-orgItem:hover {
+  background: var(--blue-1);
+  text-decoration: none;
+  color: var(--gray-5);
+}
+
+._cls-orgItem img {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: var(--radius-2);
+  object-fit: cover;
+}
+
+._cls-orgName {
+  flex: 1 1 auto;
+  font-weight: 600;
+  color: var(--gray-5);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+._cls-orgBadge {
+  font-size: var(--font-xs, 0.75rem);
+  font-weight: 500;
+  color: var(--blue-4, #1a6bc4);
+  background: var(--blue-1, #e8f0fe);
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--radius-1, 3px);
+}
+
+._cls-orgsDivider {
+  height: 1px;
+  border: none;
+  border-bottom: 1px solid var(--gray-2);
+  margin: 0.25rem 0;
+}
+
+._cls-orgsViewAll {
+  font-size: var(--font-sm);
+  justify-content: center;
+}
+
 ._cls-profDropdown._cls-active ._cls-avatar {
   background: #f1f1f1;
   border-bottom: solid 2px transparent;

--- a/squarelet/organizations/templatetags/orgs_dropdown.py
+++ b/squarelet/organizations/templatetags/orgs_dropdown.py
@@ -1,0 +1,41 @@
+# Django
+from django import template
+from django.db.models import BooleanField, Value
+from django.db.models.expressions import Case, When
+
+# Squarelet
+from squarelet.organizations.models import Organization
+
+register = template.Library()
+
+
+@register.inclusion_tag("templatetags/orgs_dropdown.html", takes_context=True)
+def orgs_dropdown(context):
+    request = context.get("request")
+    if not request or not request.user.is_authenticated:
+        return {"organizations": [], "is_authenticated": False}
+
+    organizations = (
+        Organization.objects.filter(
+            users=request.user,
+            individual=False,
+        )
+        .annotate(
+            is_admin=Case(
+                When(
+                    memberships__user=request.user,
+                    memberships__admin=True,
+                    then=Value(True),
+                ),
+                default=Value(False),
+                output_field=BooleanField(),
+            )
+        )
+        .order_by("-is_admin", "name")
+        .distinct()
+    )
+
+    return {
+        "organizations": organizations,
+        "is_authenticated": True,
+    }

--- a/squarelet/templates/core/component/navigation.html
+++ b/squarelet/templates/core/component/navigation.html
@@ -1,4 +1,4 @@
-{% load static i18n avatar pass_query handleintent %}
+{% load static i18n avatar pass_query handleintent orgs_dropdown %}
 
 <header class="_cls-heading">
   <div class="_cls-headingContainer">
@@ -23,10 +23,23 @@
             {% services_dropdown %}
           </div>
         </div>
-        <a href="{% url 'organizations:list' %}" class="_cls-navItem">
-          <span class="icon">{% include 'core/icons/organization.svg' %}</span>
-          Organizations
-        </a>
+        {% if request.user.is_authenticated %}
+          <div class="_cls-orgsDropdown">
+            <button class="_cls-navItem _cls-orgsToggle">
+              {% include "core/icons/organization.svg" %}
+              Organizations
+              {% include "core/icons/chevron-down.svg" %}
+            </button>
+            <div class="_cls-orgsMenu">
+              {% orgs_dropdown %}
+            </div>
+          </div>
+        {% else %}
+          <a href="{% url 'organizations:list' %}" class="_cls-navItem">
+            <span class="icon">{% include 'core/icons/organization.svg' %}</span>
+            Organizations
+          </a>
+        {% endif %}
       </nav>
       </nav>
       {% if request.user.is_authenticated %}
@@ -84,6 +97,7 @@
     e.stopPropagation();
     servicesOpen = !servicesOpen;
     servicesDropdown.dataset.open = String(servicesOpen);
+    closeOrgs();
   }
 
   function closeServices() {
@@ -94,5 +108,29 @@
   if (servicesToggle) {
     servicesToggle.addEventListener('click', toggleServices);
     document.addEventListener('click', closeServices);
+  }
+
+  // Organizations dropdown
+  let orgsOpen = false;
+  const orgsToggle = document.querySelector('._cls-orgsToggle');
+  const orgsDropdown = document.querySelector('._cls-orgsDropdown');
+
+  function toggleOrgs(e) {
+    e.stopPropagation();
+    orgsOpen = !orgsOpen;
+    orgsDropdown.dataset.open = String(orgsOpen);
+    closeServices();
+  }
+
+  function closeOrgs() {
+    orgsOpen = false;
+    if (orgsDropdown) {
+      orgsDropdown.dataset.open = 'false';
+    }
+  }
+
+  if (orgsToggle) {
+    orgsToggle.addEventListener('click', toggleOrgs);
+    document.addEventListener('click', closeOrgs);
   }
 </script>

--- a/squarelet/templates/templatetags/orgs_dropdown.html
+++ b/squarelet/templates/templatetags/orgs_dropdown.html
@@ -1,0 +1,21 @@
+{% load static %}
+{% for org in organizations %}
+  <a href="{{ org.get_absolute_url }}" class="_cls-orgItem">
+    <img src="{{ org.avatar_url }}" alt="{{ org.name }}">
+    <div class="_cls-orgName">
+      {{ org.name }}
+      {% if org.is_admin %}
+        <span class="_cls-orgBadge">Admin</span>
+      {% endif %}
+    </div>
+  </a>
+{% empty %}
+<a href="{% url 'organizations:create' %}" class="btn primary ghost full">
+  {% include "core/icons/plus-circle.svg" %}
+  Create an organization
+</a>
+{% endfor %}
+<hr class="_cls-orgsDivider" />
+<a href="{% url 'organizations:list' %}" class="btn primary ghost full">
+  Browse organizations
+</a>


### PR DESCRIPTION
Provides users with easier access to their org pages with a dropdown in the header naviagation. Orgs administered come first, then orgs the user belongs to. If no memberships, presents a button to create a new organization. Bottom of the list is always "Browse organizations."

When a user is signed out, they see the link to the organization page without the dropdown.

<img width="368" height="532" alt="Screenshot 2026-02-06 at 14 06 42" src="https://github.com/user-attachments/assets/11833978-997e-40a9-96c0-9067fbe8d27d" />
