### PR TITLE
Resize images wherever we can

### DIFF
--- a/frontend/components/TeamListItem.svelte
+++ b/frontend/components/TeamListItem.svelte
@@ -11,7 +11,8 @@
   let { organization }: { organization: Organization } = $props();
 
   let count = $derived(organization.member_count);
-  let avatar = $derived(organization.avatar_url);
+  // Use avatar_medium for better performance (150x150 instead of full size)
+  let avatar = $derived(organization.avatar_medium || organization.avatar_url);
 
   // Helper function for pluralization
   function pluralize(

--- a/frontend/types.d.ts
+++ b/frontend/types.d.ts
@@ -10,6 +10,8 @@ export interface Organization {
   updated_at: string | Date;
   payment_failed: boolean;
   avatar_url: string | URL;
+  avatar_small?: string | URL;
+  avatar_medium?: string | URL;
   merged: Date | null;
   member_count: number;
 }

--- a/squarelet/core/templatetags/avatar.py
+++ b/squarelet/core/templatetags/avatar.py
@@ -2,6 +2,10 @@
 from django import template
 from django.utils.html import format_html
 
+# Third Party
+from sorl.thumbnail import get_thumbnail
+from sorl.thumbnail.helpers import ThumbnailError
+
 # Squarelet
 from squarelet.users.models import User
 
@@ -10,10 +14,32 @@ register = template.Library()
 
 @register.simple_tag
 def avatar(profile_or_org, size=45):
-    if profile_or_org is not None:
-        src = profile_or_org.avatar_url
+    """
+    Render an avatar image with actual resizing using sorl-thumbnail.
+
+    Args:
+        profile_or_org: User or Organization object with an avatar
+        size: Size in pixels for the square avatar (default 45)
+
+    Returns:
+        HTML string with resized avatar image
+    """
+    if profile_or_org is not None and profile_or_org.avatar:
+        # Generate a resized thumbnail
+        try:
+            thumbnail = get_thumbnail(
+                profile_or_org.avatar,
+                f"{size}x{size}",
+                crop="center",
+                quality=85,
+            )
+            src = thumbnail.url
+        except (ThumbnailError, IOError, OSError):
+            # Fallback to default avatar if thumbnail generation fails
+            src = User.default_avatar
     else:
         src = User.default_avatar
+
     return format_html(
         '<div class="_cls-avatar"><img width="{size}" height="{size}" src="{src}">'
         "</div>",

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 # TODO: Refactor tests for each view file
 # Django
 from django.contrib import messages

--- a/squarelet/templates/templatetags/orgs_dropdown.html
+++ b/squarelet/templates/templatetags/orgs_dropdown.html
@@ -1,7 +1,13 @@
-{% load static %}
+{% load static thumbnail %}
 {% for org in organizations %}
   <a href="{{ org.get_absolute_url }}" class="_cls-orgItem">
-    <img src="{{ org.avatar_url }}" alt="{{ org.name }}">
+    {% if org.avatar %}
+      {% thumbnail org.avatar "40x40" crop="center" as im %}
+        <img src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}" alt="{{ org.name }}">
+      {% endthumbnail %}
+    {% else %}
+      <img src="{% static 'icons/people-24.svg' %}" alt="{{ org.name }}">
+    {% endif %}
     <div class="_cls-orgName">
       {{ org.name }}
       {% if org.is_admin %}

--- a/squarelet/templates/templatetags/services_dropdown.html
+++ b/squarelet/templates/templatetags/services_dropdown.html
@@ -1,7 +1,14 @@
+{% load thumbnail %}
 {% for provider in service_providers %}
   {% if provider.base_url %}
     <a href="{{ provider.base_url }}" class="_cls-serviceItem">
-      <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+      {% if provider.icon %}
+        {% thumbnail provider.icon "40x40" crop="center" as im %}
+          <img src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}" alt="{{ provider.name }}">
+        {% endthumbnail %}
+      {% else %}
+        <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+      {% endif %}
       <div>
         <div class="_cls-serviceName">{{ provider.name }}</div>
         <div class="_cls-serviceDescription">{{ provider.description }}</div>

--- a/squarelet/templates/templatetags/services_list.html
+++ b/squarelet/templates/templatetags/services_list.html
@@ -1,8 +1,15 @@
+{% load thumbnail %}
 <div class="service-providers">
   {% for provider in service_providers %}
     {% if provider.base_url %}
       <a href="{{provider.base_url}}" target="_blank" class="service-provider">
-        <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+        {% if provider.icon %}
+          {% thumbnail provider.icon "60x60" crop="center" as im %}
+            <img src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}" alt="{{ provider.name }}">
+          {% endthumbnail %}
+        {% else %}
+          <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+        {% endif %}
         <div class="service-provider-text">
           <h3>{{ provider.name }}</h3>
           <p>{{ provider.description }}</p>
@@ -10,7 +17,13 @@
       </a>
     {% else %}
       <div class="service-provider">
-        <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+        {% if provider.icon %}
+          {% thumbnail provider.icon "60x60" crop="center" as im %}
+            <img src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}" alt="{{ provider.name }}">
+          {% endthumbnail %}
+        {% else %}
+          <img src="{{ provider.icon.url }}" alt="{{ provider.name }}">
+        {% endif %}
         <div class="service-provider-text">
           <h3>{{ provider.name }}</h3>
           <p>{{ provider.description }}</p>

--- a/squarelet/templates/widgets/avatar.html
+++ b/squarelet/templates/widgets/avatar.html
@@ -1,8 +1,14 @@
-{% load i18n %}
+{% load i18n thumbnail %}
 
 <div class="avatar-widget" data-avatar-widget>
   <div class="avatar-preview-wrapper {% if widget.has_file %}has-file{% endif %}">
-    <img src="{{widget.value.url}}" alt="{% trans 'Current avatar' %}" class="avatar-preview" data-avatar-preview>
+    {% if widget.has_file %}
+      {% thumbnail widget.value "80x80" crop="center" as im %}
+        <img src="{{ im.url }}" alt="{% trans 'Current avatar' %}" class="avatar-preview" data-avatar-preview>
+      {% endthumbnail %}
+    {% else %}
+      <img src="" alt="{% trans 'Current avatar' %}" class="avatar-preview" data-avatar-preview>
+    {% endif %}
     <div class="avatar-placeholder" data-avatar-preview>
       {% include "core/icons/person-24.svg" %}
     </div>


### PR DESCRIPTION
Closes #469 

Wherever possible, images are now wrapped in `sorl.thumbnail` resizing, either in templates or in Python code. 

Testing Recommendations

  - Verify navigation avatar displays correctly at 25px
  - Check organization dropdown shows 40x40 avatars
  - Test profile edit page shows resized preview
  - Confirm API returns avatar_small and avatar_medium fields
  - Verify graceful fallback when thumbnail generation fails
  - Test with missing/corrupted avatar files

Claude did all of this.