### PR TITLE
Adds E2E tests for critical paths

### DIFF
--- a/.claude/skills/write-e2e-tests/SKILL.md
+++ b/.claude/skills/write-e2e-tests/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: write-e2e-tests
+description: Instructions for how to effectively write end-to-end tests.
+---
+
+We have a stable foundation for introducing E2E tests with Playwright, and documentation for how to write them at @docs/contributors/writing-e2e-tests.md.
+
+Before running E2E tests, our Docker services must be running. `inv up` will start up our containers and run them in the background.
+
+`inv test-e2e` will run all E2E tests headlessly. The global setup automatically creates a `test_squarelet` database, restarts Django to use it, runs migrations, and seeds test data. After tests complete, the original Django service is restored and the test database is dropped.
+
+`inv test-e2e --grep "org viewing"` will run only tests matching the given pattern.
+
+When introducing new functionality, we follow a red/green TDD method. We should always add tests first expecting them to fail, while defining the shape of our inputs and outputs. Only then do we change or add functionality to pass the test.
+
+When testing existing functionality, we want to ensure we obtain wide coverage. This means testing the expected, "happy" path a user will follow _and_ trying out edge cases and intentionally mocking error responses cases to test fallback handling.

--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import { E2E_PASSWORD, deleteTestUser } from "./helpers";
+
+const SIGNUP_USER = "e2e-signup-user";
+const SIGNUP_PASSWORD = "correct-horse-battery-staple";
+
+test.describe("Signup", () => {
+  test.afterAll(() => {
+    deleteTestUser(SIGNUP_USER);
+  });
+
+  test.describe("Successful signup", () => {
+    test("creates account and redirects away from signup", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/signup/");
+      await page.locator("#signup_form input[name='email']").fill(`${SIGNUP_USER}@example.com`);
+      await page.locator("#signup_form input[name='name']").fill("E2E Signup Test");
+      await page.locator("#signup_form input[name='username']").fill(SIGNUP_USER);
+      await page.locator("#signup_form input[name='password1']").fill(SIGNUP_PASSWORD);
+      await page.locator("#signup_form input[name='tos']").check();
+      const signupResponse = page.waitForResponse(
+        (resp) => resp.url().includes("/accounts/signup/") && resp.request().method() === "POST",
+      );
+      await page.locator("#signup_form footer button.primary").click();
+      expect((await signupResponse).status()).toBe(302);
+      await page.waitForURL(/\/accounts\/onboard\//);
+    });
+  });
+
+  test.describe("Validation errors", () => {
+    test("duplicate username shows error", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/signup/");
+      await page.locator("#signup_form input[name='email']").fill("unique-email@example.com");
+      await page.locator("#signup_form input[name='name']").fill("Duplicate Test");
+      await page.locator("#signup_form input[name='username']").fill("e2e-regular");
+      await page.locator("#signup_form input[name='password1']").fill(E2E_PASSWORD);
+      await page.locator("#signup_form input[name='tos']").check();
+      await page.locator("#signup_form footer button.primary").click();
+      // reload the signup page and see a validation error for the username field
+      await expect(page).toHaveURL(/\/accounts\/signup\//);
+      await expect(page.locator("#signup_form .errorlist")).toBeVisible();
+    });
+
+    test("missing TOS prevents submission", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/signup/");
+      await page.locator("#signup_form input[name='email']").fill("tos-test@example.com");
+      await page.locator("#signup_form input[name='name']").fill("TOS Test");
+      await page.locator("#signup_form input[name='username']").fill("e2e-tos-test");
+      await page.locator("#signup_form input[name='password1']").fill(E2E_PASSWORD);
+      // intentionally skip checking tos — browser validation blocks submission
+      await page.locator("#signup_form footer button.primary").click();
+      // stay on the signup page and see a browser error for the tos field
+      await expect(page).toHaveURL(/\/accounts\/signup\//);
+    });
+
+    test("empty form submission stays on signup page", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/signup/");
+      // browser validation blocks submission of empty required fields
+      await page.locator("#signup_form footer button.primary").click();
+      // stay on the signup page and see a browser error for the tos field
+      await expect(page).toHaveURL(/\/accounts\/signup\//);
+    });
+  });
+});
+
+
+test.describe("Login", () => {
+  test.describe("Valid credentials", () => {
+    test("login with username redirects away from login page", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/login/");
+      await page.locator("#login_form input[name='login']").fill("e2e-regular");
+      await page.locator("#login_form input[name='password']").fill(E2E_PASSWORD);
+      const loginResponse = page.waitForResponse(
+        (resp) => resp.url().includes("/accounts/login/") && resp.request().method() === "POST",
+      );
+      await page.locator("#login_form button.primary").click();
+      expect((await loginResponse).status()).toBe(302);
+      await page.waitForURL((url) => !url.pathname.includes("/accounts/login/"));
+    });
+
+    test("login with email redirects away from login page", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/login/");
+      await page.locator("#login_form input[name='login']").fill("e2e-regular@example.com");
+      await page.locator("#login_form input[name='password']").fill(E2E_PASSWORD);
+      const loginResponse = page.waitForResponse(
+        (resp) => resp.url().includes("/accounts/login/") && resp.request().method() === "POST",
+      );
+      await page.locator("#login_form button.primary").click();
+      expect((await loginResponse).status()).toBe(302);
+      await page.waitForURL((url) => !url.pathname.includes("/accounts/login/"));
+    });
+  });
+
+  test.describe("Invalid credentials", () => {
+    test("wrong password shows error", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/login/");
+      await page.locator("#login_form input[name='login']").fill("e2e-regular");
+      await page.locator("#login_form input[name='password']").fill("wrong-password");
+      await page.locator("#login_form button.primary").click();
+      await expect(page).toHaveURL(/\/accounts\/login\//);
+      await expect(page.locator("#login_form .errorlist")).toBeVisible();
+    });
+
+    test("nonexistent user shows error", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/login/");
+      await page.locator("#login_form input[name='login']").fill("no-such-user-xyz");
+      await page.locator("#login_form input[name='password']").fill("any-password");
+      await page.locator("#login_form button.primary").click();
+      await expect(page).toHaveURL(/\/accounts\/login\//);
+      await expect(page.locator("#login_form .errorlist")).toBeVisible();
+    });
+  });
+
+  test.describe("Redirects", () => {
+    test("unauthenticated user accessing protected page is sent to login", async ({
+      page,
+    }) => {
+      await page.context().clearCookies();
+      await page.goto("/organizations/~create");
+      await expect(page).toHaveURL(/\/accounts\/login\//);
+      await expect(page).toHaveURL(/next=.*organizations/);
+    });
+
+    test("next parameter is honored after login", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/accounts/login/?next=/organizations/e2e-public-org/");
+      await page.locator("#login_form input[name='login']").fill("e2e-regular");
+      await page.locator("#login_form input[name='password']").fill(E2E_PASSWORD);
+      const loginResponse = page.waitForResponse(
+        (resp) => resp.url().includes("/accounts/login/") && resp.request().method() === "POST",
+      );
+      await page.locator("#login_form button.primary").click();
+      expect((await loginResponse).status()).toBe(302);
+      await expect(page).toHaveURL(/\/organizations\/e2e-public-org\//);
+    });
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -12,7 +12,11 @@ export async function login(page: Page, username: string) {
   await page.goto("/accounts/login/");
   await page.locator("#login_form input[name='login']").fill(username);
   await page.locator("#login_form input[name='password']").fill(E2E_PASSWORD);
+  const loginResponse = page.waitForResponse(
+    (resp) => resp.url().includes("/accounts/login/") && resp.request().method() === "POST",
+  );
   await page.locator("#login_form button.primary").click();
+  expect((await loginResponse).status()).toBe(302);
   await page.waitForURL((url) => !url.pathname.includes("/accounts/login/"));
 }
 
@@ -22,10 +26,44 @@ export async function expectFlashMessage(page: Page, level: string) {
 }
 
 export function runManageCommand(args: string): string {
-  return execSync(`${COMPOSE_E2E} exec -T squarelet_django python manage.py ${args}`, {
-    stdio: "pipe",
-    timeout: 30_000,
-  })
+  return execSync(
+    `${COMPOSE_E2E} exec -T squarelet_django /entrypoint python manage.py ${args}`,
+    {
+      stdio: "pipe",
+      timeout: 30_000,
+    },
+  )
     .toString()
     .trim();
+}
+
+export function deleteTestUser(username: string) {
+  runManageCommand(
+    `shell -c "
+from squarelet.users.models import User
+from squarelet.organizations.models import Organization, OrganizationChangeLog
+for u in User.objects.filter(username='${username}'):
+    org_pks = list(u.organizations.values_list('pk', flat=True))
+    OrganizationChangeLog.objects.filter(user=u).delete()
+    OrganizationChangeLog.objects.filter(organization__in=org_pks).delete()
+    u.delete()
+    Organization.objects.filter(pk__in=org_pks).delete()
+"`,
+  );
+}
+
+export function deleteTestOrg(slug: string) {
+  runManageCommand(
+    `shell -c "from squarelet.organizations.models import Organization; Organization.objects.filter(slug__startswith='${slug}', individual=False).delete()"`,
+  );
+}
+
+export function resetOrgProfileState(slug: string) {
+  runManageCommand(
+    `shell -c "
+from squarelet.organizations.models import Organization, ProfileChangeRequest
+ProfileChangeRequest.objects.filter(organization__slug='${slug}').delete()
+Organization.objects.filter(slug='${slug}').update(city='')
+"`,
+  );
 }

--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -1,5 +1,50 @@
 import { test, expect } from "@playwright/test";
-import { login, expectFlashMessage } from "./helpers";
+import { login, deleteTestOrg, expectFlashMessage, resetOrgProfileState } from "./helpers";
+
+const NEW_ORG_SLUG = "e2e-new-org";
+
+test.describe("Organization Creation", () => {
+  test.afterAll(() => {
+    deleteTestOrg(NEW_ORG_SLUG);
+  });
+
+  test.describe("Authenticated user", () => {
+    test.beforeEach(async ({ page }) => {
+      await login(page, "e2e-regular");
+    });
+
+    test("creates org with unique name and redirects to org page", async ({ page }) => {
+      await page.goto("/organizations/~create");
+      await page.locator("input[name='name']").fill("e2e-new-org");
+      await page.locator("button[type='submit']").click();
+      await expect(page).toHaveURL(/\/organizations\/e2e-new-org\//);
+    });
+
+    test("similar name shows matching orgs, force-create works", async ({ page }) => {
+      await page.goto("/organizations/~create");
+      await page.locator("input[name='name']").fill("e2e public org");
+      await page.locator("button[type='submit']").click();
+
+      // Should show matching organizations and a force-create form
+      await expect(page).toHaveURL(/\/organizations\/~create/);
+      await expect(page.locator("input[name='force'][value='true']")).toBeAttached();
+
+      // The force form reuses the #login_form id with the hidden force field
+      await page.locator("#login_form button[type='submit']").click();
+      await page.waitForURL((url) => !url.pathname.includes("~create"));
+      await expect(page).toHaveURL(/\/organizations\//);
+    });
+  });
+
+  test.describe("Unauthenticated user", () => {
+    test("redirected to login", async ({ page }) => {
+      await page.context().clearCookies();
+      await page.goto("/organizations/~create");
+      await expect(page).toHaveURL(/\/accounts\/login\//);
+    });
+  });
+});
+
 
 test.describe("Organization Viewing", () => {
   test.describe("Anonymous user", () => {
@@ -170,6 +215,10 @@ test.describe("Organization Viewing", () => {
 });
 
 test.describe("Profile Editing", () => {
+  test.beforeEach(() => {
+    resetOrgProfileState("e2e-public-org");
+  });
+
   test("admin can edit unprotected fields", async ({ page }) => {
     await login(page, "e2e-admin");
     await page.goto("/organizations/e2e-public-org/update/");

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
-  workers: 1,
+  workers: 2,
   fullyParallel: false,
   timeout: 30_000,
   expect: {

--- a/squarelet/core/management/commands/seed_e2e_data.py
+++ b/squarelet/core/management/commands/seed_e2e_data.py
@@ -1,6 +1,7 @@
 # Django
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from django.utils import timezone
 
 # Standard Library
 import json
@@ -105,6 +106,11 @@ class Command(BaseCommand):
                 primary=True,
                 verified=True,
             )
+
+            # Set last_mfa_prompt so the MFA onboarding step is snoozed,
+            # preventing onboarding from intercepting login redirects
+            user.last_mfa_prompt = timezone.now()
+            user.save(update_fields=["last_mfa_prompt"])
 
             created_users[username] = user
             self.stderr.write(f"Created user: {username}")

--- a/tasks.py
+++ b/tasks.py
@@ -131,7 +131,7 @@ def test_e2e(c, ui=False, grep=""):
     """
     playwright_args = []
     if ui:
-        playwright_args.append("--headed")
+        playwright_args.append("--ui")
     if grep:
         playwright_args.append(f"--grep '{grep}'")
     pw_flags = " ".join(playwright_args)


### PR DESCRIPTION
- Account login
- Account creation
- Org creation

Adds a basic Claude skill for writing E2E tests and improves some of our testing ergonomics:

- fix --ui command
- use 2 workers for testing each spec file