### PR TITLE
Improve member invitation logic

### DIFF
--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -345,6 +345,20 @@ test.describe("Member Management", () => {
     await page.locator('section#pending button[value="revokeinvite"]').first().click();
   });
 
+  test("inviting an existing member shows info, not success", async ({ page }) => {
+    await login(page, "e2e-admin");
+    await page.goto("/organizations/e2e-public-org/manage-members/");
+
+    // e2e-member is already a member per the seed data
+    await page.locator("input[name='emails']").fill("e2e-member@example.com");
+    await page.locator('button[value="addmember"]').click();
+
+    // Should see an info message, not a "0 invitations sent" success message
+    await expectFlashMessage(page, "info");
+    const successAlerts = page.locator("._cls-alerts .alert-success");
+    await expect(successAlerts).toHaveCount(0);
+  });
+
   test("user can request to join and admin can accept", async ({ page }) => {
     // Login as requester and submit join request
     await login(page, "e2e-requester");

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -60,10 +60,8 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
 
                 if existing_open_invite:
                     existing_open_invite.send()
-                    messages.success(
-                        self.request,
-                        f"Resent invitation to {email}.",
-                    )
+                    invitations_sent += 1
+                    invited_emails.append(email)
                     continue
 
                 invitation = Invitation.objects.create(
@@ -91,10 +89,12 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
                     description=email_list,
                 )
 
-            messages.success(
-                self.request,
-                f"{invitations_sent} {pluralize(invitations_sent, 'invitation')} sent",
-            )
+            if invitations_sent > 0:
+                messages.success(
+                    self.request,
+                    f"{invitations_sent}"
+                    f" {pluralize(invitations_sent, 'invitation')} sent",
+                )
 
         return redirect("organizations:manage-members", slug=self.organization.slug)
 


### PR DESCRIPTION
Currently, inviting an existing member returns "0 invitations sent" success message.

This omits the success message when no emails are sent.

It also rolls resends into the total send count to reduce the number of alerts we show following an invitation.