### PR TITLE
Fix AttributeError when rendering password reset form for expired links

### DIFF
--- a/squarelet/users/forms.py
+++ b/squarelet/users/forms.py
@@ -337,12 +337,19 @@ class ResetPasswordKeyForm(mfa.BaseAuthenticateForm, allauth.ResetPasswordKeyFor
     """Customize the reset password key form layout"""
 
     def __init__(self, *args, **kwargs):
-        # save user here as it can be overridden in the parent class
-        user = kwargs["user"]
-        mfa_enabled = user.has_mfa_enabled
+        # Save user (may be None if link is invalid/expired)
+        user = kwargs.get("user")
+
         super().__init__(*args, **kwargs)
-        # restore user here
+
+        # If user is None, this is an invalid/expired link.
+        # Let allauth handle rendering its invalid key page.
+        if user is None:
+            return
+
+        # Restore user (parent may override it)
         self.user = user
+        mfa_enabled = user.has_mfa_enabled
 
         # remove the code field if 2FA is not enabled
         if not mfa_enabled:


### PR DESCRIPTION
This small PR closes #590 
We check to make sure the user is not none first(this would be the case if the password reset link was already used or expired). If it is, return and render the allauth badtoken page (screenshot below). Otherwise, load the password reset form. 

<img width="1509" height="457" alt="Allauth badtoken page" src="https://github.com/user-attachments/assets/2bce797b-233e-48b3-9ec2-2e41a2a34784" />
