### PR TITLE
Fix onboarding step mismatch

### DIFF
--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -379,6 +379,16 @@ class UserOnboardingView(TemplateView):
             if success is False:
                 context = self.get_context_data(**kwargs)
                 return self.render_to_response(context)
+        # Often times, a user confirms their email in another tab and thus
+        # a mismatch gets thrown erroneously. This should redirect them.
+        elif step == "confirm_email":
+            # Re-check server state
+            if request.user.emailaddress_set.filter(
+                email=request.user.email,
+                verified=True,
+            ).exists():
+                # Email is now verified — just continue onboarding
+                return redirect("account_onboarding")
         else:
             logger.error(
                 "[ONBOARDING] Onboarding step mismatch", exc_info=sys.exc_info()


### PR DESCRIPTION
Close #520 

When a user signs up for the first time, they get told to check their email to confirm their email. Many do, and they go through the verification process. Then, when they return to their original tab and click continue, it throws an onboarding step mismatch. This adds a special case so that even if the steps are a mismatch (which they would be in cross-tab work), if it is the confirm email step, it checks if there is a valid email for the user and if there is, it redirects them back to onboarding correctly. 

To test this, we should follow the replication steps in the issue and verify Sentry doesn't log any erroneous 
[ONBOARDING] Onboarding step mismatch errors. 

