### PR TITLE
Update django-weasyprint to fix a bug in generating receipts and run format

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -153,7 +153,7 @@ django-storages[boto3]==1.12.3
     # via -r requirements/base.in
 django-vite==3.0.4
     # via -r requirements/base.in
-django-weasyprint==2.3.0
+django-weasyprint==2.4.0
     # via -r requirements/base.in
 djangorestframework==3.16.1
     # via
@@ -178,8 +178,6 @@ fuzzywuzzy==0.18.0
     # via -r requirements/base.in
 html2text==2018.1.9
     # via -r requirements/base.in
-html5lib==1.1
-    # via weasyprint
 idna==3.7
     # via requests
 inflection==0.5.1
@@ -248,7 +246,7 @@ pydantic==2.7.4
     # via pyairtable
 pydantic-core==2.18.4
     # via pydantic
-pydyf==0.5.0
+pydyf==0.12.1
     # via weasyprint
 pygments==2.15.1
     # via ipython
@@ -309,7 +307,6 @@ six==1.16.0
     #   django-choices
     #   django-environ
     #   furl
-    #   html5lib
     #   orderedmultidict
     #   python-dateutil
     #   zenpy
@@ -326,10 +323,12 @@ stack-data==0.3.0
     # via ipython
 stripe==8.11.0
     # via -r requirements/base.in
-tinycss2==1.2.1
+tinycss2==1.5.1
     # via
     #   cssselect2
     #   weasyprint
+tinyhtml5==2.1.0
+    # via weasyprint
 toml==0.10.2
     # via ipdb
 traitlets==5.3.0
@@ -360,14 +359,14 @@ vine==5.1.0
     #   kombu
 wcwidth==0.1.7
     # via prompt-toolkit
-weasyprint==58.1
+weasyprint==64.1
     # via django-weasyprint
 webencodings==0.5.1
     # via
     #   bleach
     #   cssselect2
-    #   html5lib
     #   tinycss2
+    #   tinyhtml5
 wrapt==1.11.2
     # via deprecated
 zenpy==2.0.56

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -232,7 +232,7 @@ django-test-plus==2.2.0
     # via -r requirements/local.in
 django-vite==3.0.4
     # via -r /app/requirements/base.txt
-django-weasyprint==2.3.0
+django-weasyprint==2.4.0
     # via -r /app/requirements/base.txt
 djangorestframework==3.16.1
     # via
@@ -277,10 +277,6 @@ fuzzywuzzy==0.18.0
     # via -r /app/requirements/base.txt
 html2text==2018.1.9
     # via -r /app/requirements/base.txt
-html5lib==1.1
-    # via
-    #   -r /app/requirements/base.txt
-    #   weasyprint
 idna==3.7
     # via
     #   -r /app/requirements/base.txt
@@ -452,7 +448,7 @@ pydantic-core==2.18.4
     # via
     #   -r /app/requirements/base.txt
     #   pydantic
-pydyf==0.5.0
+pydyf==0.12.1
     # via
     #   -r /app/requirements/base.txt
     #   weasyprint
@@ -584,7 +580,6 @@ six==1.16.0
     #   django-coverage-plugin
     #   django-environ
     #   furl
-    #   html5lib
     #   orderedmultidict
     #   python-dateutil
     #   sphinx
@@ -617,10 +612,14 @@ termcolor==1.1.0
     # via pytest-sugar
 text-unidecode==1.3
     # via faker
-tinycss2==1.2.1
+tinycss2==1.5.1
     # via
     #   -r /app/requirements/base.txt
     #   cssselect2
+    #   weasyprint
+tinyhtml5==2.1.0
+    # via
+    #   -r /app/requirements/base.txt
     #   weasyprint
 toml==0.10.2
     # via
@@ -666,7 +665,7 @@ wcwidth==0.1.7
     # via
     #   -r /app/requirements/base.txt
     #   prompt-toolkit
-weasyprint==58.1
+weasyprint==64.1
     # via
     #   -r /app/requirements/base.txt
     #   django-weasyprint
@@ -675,8 +674,8 @@ webencodings==0.5.1
     #   -r /app/requirements/base.txt
     #   bleach
     #   cssselect2
-    #   html5lib
     #   tinycss2
+    #   tinyhtml5
 werkzeug==3.0.2
     # via -r requirements/local.in
 wheel==0.45.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -215,7 +215,7 @@ django-storages[boto3]==1.12.3
     #   collectfast
 django-vite==3.0.4
     # via -r /app/requirements/base.txt
-django-weasyprint==2.3.0
+django-weasyprint==2.4.0
     # via -r /app/requirements/base.txt
 djangorestframework==3.16.1
     # via
@@ -248,10 +248,6 @@ gunicorn==22.0.0
     # via -r requirements/production.in
 html2text==2018.1.9
     # via -r /app/requirements/base.txt
-html5lib==1.1
-    # via
-    #   -r /app/requirements/base.txt
-    #   weasyprint
 idna==3.7
     # via
     #   -r /app/requirements/base.txt
@@ -368,7 +364,7 @@ pydantic-core==2.18.4
     # via
     #   -r /app/requirements/base.txt
     #   pydantic
-pydyf==0.5.0
+pydyf==0.12.1
     # via
     #   -r /app/requirements/base.txt
     #   weasyprint
@@ -449,7 +445,6 @@ six==1.16.0
     #   django-choices
     #   django-environ
     #   furl
-    #   html5lib
     #   orderedmultidict
     #   python-dateutil
     #   zenpy
@@ -469,10 +464,14 @@ stack-data==0.3.0
     #   ipython
 stripe==8.11.0
     # via -r /app/requirements/base.txt
-tinycss2==1.2.1
+tinycss2==1.5.1
     # via
     #   -r /app/requirements/base.txt
     #   cssselect2
+    #   weasyprint
+tinyhtml5==2.1.0
+    # via
+    #   -r /app/requirements/base.txt
     #   weasyprint
 toml==0.10.2
     # via
@@ -518,7 +517,7 @@ wcwidth==0.1.7
     # via
     #   -r /app/requirements/base.txt
     #   prompt-toolkit
-weasyprint==58.1
+weasyprint==64.1
     # via
     #   -r /app/requirements/base.txt
     #   django-weasyprint
@@ -527,8 +526,8 @@ webencodings==0.5.1
     #   -r /app/requirements/base.txt
     #   bleach
     #   cssselect2
-    #   html5lib
     #   tinycss2
+    #   tinyhtml5
 wrapt==1.11.2
     # via
     #   -r /app/requirements/base.txt

--- a/squarelet/core/rules.py
+++ b/squarelet/core/rules.py
@@ -2,6 +2,7 @@
 # Django
 from django.contrib.auth import load_backend
 
+# Standard Library
 from functools import wraps
 
 # Third Party

--- a/squarelet/oidc/tasks.py
+++ b/squarelet/oidc/tasks.py
@@ -9,6 +9,7 @@ from .models import ClientProfile
 @shared_task(name="squarelet.oidc.tasks.send_cache_invalidation")
 def send_cache_invalidation(client_profile_pk, model, uuids):
     # pylint: disable=import-outside-toplevel
+    # Squarelet
     from squarelet.organizations.models import Organization
     from squarelet.users.models import User
 


### PR DESCRIPTION
Wasn't something caught during testing, but I noticed it in [this issue](https://muckrock.sentry.io/issues/7321583133/?environment=production&project=1422309&query=is%3Aunresolved) on Sentry and was able to replicate. When a user goes to download their receipt, it fails and throws that error. It is due to incompatible versions of django-weasyprint, weasyprint, and pydyf.


django-weasyprint 2.3.0 had this noted in an issue: https://github.com/fdemmer/django-weasyprint/issues/94 which was resolved in 2.3.1. Since 2.4.0 is available, I just updated to that.

Also, even though the workflow in the PR showed that formatting checks passed, I guess two files in master weren't formatted so when I merged isort failed when it merged in. This should fix both small issues 



