### PR TITLE
Redirect users correctly after leaving private org

### DIFF
--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -333,6 +333,23 @@ class TestDetail(ViewTestMixin):
         assert response.status_code == 302
         assert not organization.has_member(leaver)
 
+    def test_post_member_leave_private_org_redirects_to_profile(
+        self, rf, organization_factory, user_factory
+    ):
+        """When a member leaves a private org, they should be redirected to
+        their profile page instead of back to the org page (which they can
+        no longer access)."""
+        admin, leaver = user_factory.create_batch(2)
+        organization = organization_factory(
+            admins=[admin], users=[leaver], private=True
+        )
+        response = self.call_view(
+            rf, leaver, {"action": "leave"}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert not organization.has_member(leaver)
+        assert response.url == leaver.get_absolute_url()
+
     def test_post_staff_remove_user(self, rf, organization_factory, user_factory):
         """Staff with can_manage_members should be able to remove a user"""
         staff_member = user_factory(is_staff=True)

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -198,11 +198,13 @@ class Detail(AdminLinkMixin, DetailView):
             "organizations.can_manage_members", self.organization
         )
         userid = request.POST.get("userid")
+        user_left = False
         if userid:
             if userid == str(request.user.id) and is_member:
                 # Users removing themselves
                 request.user.memberships.filter(organization=self.organization).delete()
                 messages.success(request, _("You left the organization"))
+                user_left = True
             elif can_manage:
                 # User with can_manage_members permission removing another user
                 user_model = get_user_model()
@@ -236,6 +238,13 @@ class Detail(AdminLinkMixin, DetailView):
             # User removing themselves (no userid provided)
             request.user.memberships.filter(organization=self.organization).delete()
             messages.success(request, _("You left the organization"))
+            user_left = True
+
+        # Redirect to profile if the user left a private org they can no
+        # longer view, otherwise redirect following default behavior
+        if user_left and self.organization.private:
+            return redirect(request.user)
+        return None
 
     def handle_sync_wix(self, request):
         if self.request.user.is_staff and self.organization.plan.wix:
@@ -256,7 +265,9 @@ class Detail(AdminLinkMixin, DetailView):
         if request.POST.get("action") == "join":
             self.handle_join(request)
         elif request.POST.get("action") == "leave":
-            self.handle_leave(request)
+            response = self.handle_leave(request)
+            if response:
+                return response
         elif request.POST.get("action") == "sync_wix":
             self.handle_sync_wix(request)
         return get_redirect_url(request, redirect(self.organization))


### PR DESCRIPTION
Fixes #609

- Reproduced reported bug with a failing test
- Updated `handle_leave` to pass the test