### PR TITLE
Adds local HTTPS config for Minio

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           echo "127.0.0.1 dev.squarelet.com" | sudo tee -a /etc/hosts
           echo "127.0.0.1 dev.mailhog.com" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 minio.documentcloud.org" | sudo tee -a /etc/hosts
 
       - name: Generate environment files
         run: python initialize_dotenvs.py
@@ -53,7 +54,7 @@ jobs:
             -keyout config/certs/dev.squarelet.com-key.pem \
             -out config/certs/dev.squarelet.com.pem \
             -subj "/CN=dev.squarelet.com" \
-            -addext "subjectAltName=DNS:dev.squarelet.com,DNS:*.dev.documentcloud.org,DNS:dev.muckrock.com,DNS:dev.foiamachine.org,DNS:dev.mailhog.com"
+            -addext "subjectAltName=DNS:dev.squarelet.com,DNS:*.dev.documentcloud.org,DNS:dev.muckrock.com,DNS:dev.foiamachine.org,DNS:dev.mailhog.com,DNS:minio.documentcloud.org"
 
       - name: Build and start services
         run: docker compose -f local.yml up -d --build

--- a/compose/local/nginx/nginx.conf
+++ b/compose/local/nginx/nginx.conf
@@ -31,6 +31,19 @@ http {
 
     server {
         listen *:443 ssl;
+        server_name minio.documentcloud.org;
+        ssl_certificate /etc/nginx/certs/dev.squarelet.com.pem;
+        ssl_certificate_key /etc/nginx/certs/dev.squarelet.com-key.pem;
+
+        location / {
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Host $http_host;
+            proxy_pass http://internal.minio.documentcloud.org:9000;
+       }
+    }
+
+    server {
+        listen *:443 ssl;
         server_name ~^(.*)$;
         ssl_certificate /etc/nginx/certs/dev.squarelet.com.pem;
         ssl_certificate_key /etc/nginx/certs/dev.squarelet.com-key.pem;

--- a/compose/local/nginx/nginx.conf
+++ b/compose/local/nginx/nginx.conf
@@ -34,13 +34,13 @@ http {
         server_name minio.documentcloud.org;
         ssl_certificate /etc/nginx/certs/dev.squarelet.com.pem;
         ssl_certificate_key /etc/nginx/certs/dev.squarelet.com-key.pem;
-
+        client_max_body_size 500M;
         location / {
-            set $minio_upstream http://internal.minio.documentcloud.org:9000;
+            set $minio_upstream http://minio.documentcloud.org:9000;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header Host $http_host;
             proxy_pass $minio_upstream;
-       }
+        }
     }
 
     server {
@@ -48,7 +48,6 @@ http {
         server_name ~^(.*)$;
         ssl_certificate /etc/nginx/certs/dev.squarelet.com.pem;
         ssl_certificate_key /etc/nginx/certs/dev.squarelet.com-key.pem;
-
         location / {
             proxy_set_header X-Forwarded-Proto https;
 			proxy_set_header Host $http_host;

--- a/compose/local/nginx/nginx.conf
+++ b/compose/local/nginx/nginx.conf
@@ -36,9 +36,10 @@ http {
         ssl_certificate_key /etc/nginx/certs/dev.squarelet.com-key.pem;
 
         location / {
+            set $minio_upstream http://internal.minio.documentcloud.org:9000;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header Host $http_host;
-            proxy_pass http://internal.minio.documentcloud.org:9000;
+            proxy_pass $minio_upstream;
        }
     }
 

--- a/local.yml
+++ b/local.yml
@@ -24,6 +24,7 @@ services:
           - www.dev.documentcloud.org
           - dev.muckrock.com
           - dev.foiamachine.org
+          - minio.documentcloud.org
 
   squarelet_mailhog:
     image: mailhog/mailhog:v1.0.0

--- a/tasks.py
+++ b/tasks.py
@@ -391,5 +391,6 @@ def mkcert(c):
             '"*.dev.documentcloud.org" '
             "dev.muckrock.com "
             "dev.foiamachine.org "
-            "dev.mailhog.com"
+            "dev.mailhog.com "
+            "minio.documentcloud.org"
         )


### PR DESCRIPTION
While getting my local DocumentCloud stack working, I ran into an upload error with Minio related to calling an unsecured `http` URL from the `https://www.api.documentcloud.org` server. I updated my local app to use `https://` as the minio address, and local uploads worked with our local SSL config.

This should only impact local development.