### PR TITLE
Fix issuer so refresh works

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -512,7 +512,7 @@ SIMPLE_JWT = {
     "BLACKLIST_AFTER_ROTATION": False,
     "ALGORITHM": "RS256",
     "AUDIENCE": ["squarelet", "muckrock", "documentcloud"],
-    "ISSUER": ["squarelet"],
+    "ISSUER": "squarelet",
     "USER_ID_FIELD": "individual_organization_id",
     # These are set in `users/apps.py` as they need to fetch from the database
     "SIGNING_KEY": "",


### PR DESCRIPTION
Right now refresh token generation is broken because the issuer is being marked as invalid

In [1]: from rest_framework_simplejwt.tokens import RefreshToken

In [2]: RefreshToken("REDACTED_TOKEN_HERE")

InvalidIssuerError: Invalid issuer

This change makes it so that a refresh token you get from /api/token/ will work again at /api/refresh/ 

Mandating that issuer be a string and not a list wasn't documented anywhere that I saw, but must have been a breaking change in one of the jwt related dependency updates