### PR TITLE
Swap to npm ci & add .npmrc with more secure settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=3
+ignore-scripts=true

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ End-to-end tests use [Playwright][playwright] and run against the Docker develop
 Install Playwright and the browser engines (host-side, not in Docker):
 
 ```bash
-npm install
+npm ci
 npx playwright install chromium firefox webkit
 ```
 

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -72,6 +72,6 @@ RUN chmod +x /start-celerybeat
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/local/vite.Dockerfile
+++ b/compose/local/vite.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # Install node modules
 COPY package*.json ./
-RUN npm install --include=dev
+RUN npm ci
 
 # Note: vite.config.js and src code will be mounted via volumes
 # COPY . .


### PR DESCRIPTION
npm ci adds some determinism to our local builds, so that developer machines aren't susceptible to supply chain attacks. 

https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci