### PR TITLE
Remove Wix labels on membership/sub changes

### DIFF
--- a/squarelet/organizations/models/membership.py
+++ b/squarelet/organizations/models/membership.py
@@ -94,9 +94,28 @@ class Membership(models.Model):
                         )
 
     def delete(self, *args, **kwargs):
+        # Prevents circular import
+        # pylint: disable=import-outside-toplevel
+        # Squarelet
+        from squarelet.organizations.tasks import unsync_wix
+
+        # Capture org/plan/user info before delete. Orgs can have BOTH a direct
+        # wix plan and group wix plans (often at different tiers), so always
+        # collect both.
+        org = self.organization
+        user_pk = self.user.pk
+        user_uuid = self.user.uuid
+        direct_plan_pk = org.plan.pk if org.plan and org.plan.wix else None
+        group_wix_plans = [(g.pk, p.pk) for g, p in org.get_wix_plans_from_groups()]
+
         with transaction.atomic():
             super().delete(*args, **kwargs)
-            transaction.on_commit(
-                lambda: send_cache_invalidations("user", self.user.uuid)
-            )
-            # TODO: We need to remove somebody's Wix membership here too
+            transaction.on_commit(lambda: send_cache_invalidations("user", user_uuid))
+            if direct_plan_pk is not None:
+                transaction.on_commit(
+                    lambda: unsync_wix.delay(org.pk, direct_plan_pk, user_pk)
+                )
+            for group_pk, gplan_pk in group_wix_plans:
+                transaction.on_commit(
+                    lambda g=group_pk, p=gplan_pk, u=user_pk: unsync_wix.delay(g, p, u)
+                )

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -570,6 +570,14 @@ class Organization(AvatarMixin, models.Model):
             # modify the subscription
             self.subscription.modify(plan)
 
+        # Remove old Wix labels when plan is changing away from a wix plan
+        if (
+            from_plan
+            and from_plan.wix
+            and (not plan or not plan.wix or from_plan.pk != plan.pk)
+        ):
+            self._dispatch_wix_unsync(from_plan)
+
         self.change_logs.create(
             user=user,
             reason=ChangeLogReason.updated,
@@ -578,6 +586,38 @@ class Organization(AvatarMixin, models.Model):
             to_plan=plan,
             to_max_users=self.max_users,
         )
+
+    def _dispatch_wix_unsync(self, plan):
+        """Dispatch Wix unsync tasks for this org's users and, if this org is a
+        resource-sharing group, its member/child orgs.
+
+        Tasks are deferred until after the current transaction commits so that
+        workers see the post-change state when computing which labels a user
+        still qualifies for.
+        """
+        # pylint: disable=import-outside-toplevel
+        # Squarelet
+        from squarelet.organizations.tasks import (
+            unsync_wix,
+            unsync_wix_for_group_member,
+        )
+
+        org_pk, plan_pk = self.pk, plan.pk
+        user_pks = list(self.users.values_list("pk", flat=True))
+        member_pks = child_pks = []
+        if self.collective_enabled and self.share_resources:
+            member_pks = list(self.members.values_list("pk", flat=True))
+            child_pks = list(self.children.values_list("pk", flat=True))
+
+        def _dispatch():
+            for user_pk in user_pks:
+                unsync_wix.delay(org_pk, plan_pk, user_pk)
+            for member_pk in member_pks:
+                unsync_wix_for_group_member.delay(member_pk, org_pk, plan_pk)
+            for child_pk in child_pks:
+                unsync_wix_for_group_member.delay(child_pk, org_pk, plan_pk)
+
+        transaction.on_commit(_dispatch)
 
     def subscription_cancelled(self):
         """The subscription was cancelled due to payment failure"""
@@ -588,6 +628,9 @@ class Organization(AvatarMixin, models.Model):
             from_max_users=self.max_users,
             to_max_users=self.max_users,
         )
+
+        # Capture plan before subscription delete clears it
+        cancelled_plan = self.plan if self.plan and self.plan.wix else None
 
         # Cancel subscription in Stripe if it exists
         if self.subscription and self.subscription.subscription_id:
@@ -617,6 +660,10 @@ class Organization(AvatarMixin, models.Model):
 
         # Delete local subscription record
         self.subscription.delete()
+
+        # Remove Wix labels now that subscription is gone
+        if cancelled_plan:
+            self._dispatch_wix_unsync(cancelled_plan)
 
     def has_active_subscription(self):
         """Check if the organization has an active subscription"""

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -33,7 +33,7 @@ from squarelet.organizations.querysets import OrganizationQuerySet
 
 logger = logging.getLogger(__name__)
 
-# pylint:disable=too-many-positional-arguments
+# pylint:disable=too-many-positional-arguments,too-many-lines
 
 
 def organization_file_path(instance, filename):

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -579,11 +579,11 @@ class Organization(AvatarMixin, models.Model):
             # modify the subscription
             self.subscription.modify(plan)
 
-        # Remove old Wix labels when plan is changing away from a wix plan
+        # Remove old Wix labels when plan changes
         if (
             from_plan
             and from_plan.wix
-            and (not plan or not plan.wix or from_plan.pk != plan.pk)
+            and (not plan or from_plan.pk != plan.pk)
         ):
             self._dispatch_wix_unsync(from_plan)
 

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -580,11 +580,7 @@ class Organization(AvatarMixin, models.Model):
             self.subscription.modify(plan)
 
         # Remove old Wix labels when plan changes
-        if (
-            from_plan
-            and from_plan.wix
-            and (not plan or from_plan.pk != plan.pk)
-        ):
+        if from_plan and from_plan.wix and (not plan or from_plan.pk != plan.pk):
             self._dispatch_wix_unsync(from_plan)
 
         self.change_logs.create(

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -632,7 +632,7 @@ class Organization(AvatarMixin, models.Model):
                 cancels self.subscription (the org's current subscription).
         """
         subscription = subscription or self.subscription
-        
+
         # Create change log entry
         self.change_logs.create(
             reason=ChangeLogReason.failed,

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -579,6 +579,14 @@ class Organization(AvatarMixin, models.Model):
             # modify the subscription
             self.subscription.modify(plan)
 
+        # Remove old Wix labels when plan is changing away from a wix plan
+        if (
+            from_plan
+            and from_plan.wix
+            and (not plan or not plan.wix or from_plan.pk != plan.pk)
+        ):
+            self._dispatch_wix_unsync(from_plan)
+
         self.change_logs.create(
             user=user,
             reason=ChangeLogReason.updated,
@@ -588,6 +596,38 @@ class Organization(AvatarMixin, models.Model):
             to_max_users=self.max_users,
         )
 
+    def _dispatch_wix_unsync(self, plan):
+        """Dispatch Wix unsync tasks for this org's users and, if this org is a
+        resource-sharing group, its member/child orgs.
+
+        Tasks are deferred until after the current transaction commits so that
+        workers see the post-change state when computing which labels a user
+        still qualifies for.
+        """
+        # pylint: disable=import-outside-toplevel
+        # Squarelet
+        from squarelet.organizations.tasks import (
+            unsync_wix,
+            unsync_wix_for_group_member,
+        )
+
+        org_pk, plan_pk = self.pk, plan.pk
+        user_pks = list(self.users.values_list("pk", flat=True))
+        member_pks = child_pks = []
+        if self.collective_enabled and self.share_resources:
+            member_pks = list(self.members.values_list("pk", flat=True))
+            child_pks = list(self.children.values_list("pk", flat=True))
+
+        def _dispatch():
+            for user_pk in user_pks:
+                unsync_wix.delay(org_pk, plan_pk, user_pk)
+            for member_pk in member_pks:
+                unsync_wix_for_group_member.delay(member_pk, org_pk, plan_pk)
+            for child_pk in child_pks:
+                unsync_wix_for_group_member.delay(child_pk, org_pk, plan_pk)
+
+        transaction.on_commit(_dispatch)
+
     def subscription_cancelled(self, subscription=None):
         """The subscription was cancelled due to payment failure
 
@@ -596,7 +636,7 @@ class Organization(AvatarMixin, models.Model):
                 cancels self.subscription (the org's current subscription).
         """
         subscription = subscription or self.subscription
-
+        
         # Create change log entry
         self.change_logs.create(
             reason=ChangeLogReason.failed,
@@ -604,6 +644,9 @@ class Organization(AvatarMixin, models.Model):
             from_max_users=self.max_users,
             to_max_users=self.max_users,
         )
+
+        # Capture plan before subscription delete clears it
+        cancelled_plan = self.plan if self.plan and self.plan.wix else None
 
         # Cancel subscription in Stripe if it exists
         if subscription and subscription.subscription_id:
@@ -633,6 +676,10 @@ class Organization(AvatarMixin, models.Model):
 
         # Delete local subscription record
         subscription.delete()
+
+        # Remove Wix labels now that subscription is gone
+        if cancelled_plan:
+            self._dispatch_wix_unsync(cancelled_plan)
 
     def has_active_subscription(self):
         """Check if the organization has an active subscription"""

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -601,6 +601,78 @@ def sync_wix_for_group_member(member_org_id, group_org_id, plan_id):
     retry_backoff=60,
     retry_kwargs={"max_retries": 3},
 )
+def unsync_wix(org_id, plan_id, user_id):
+    """Remove Wix labels for a user when they leave an organization or plan changes."""
+    if not is_production_env():
+        logger.info(
+            "[WIX-SYNC] Skipping Wix unsync in non-production environment (ENV=%s)",
+            settings.ENV,
+        )
+        return
+
+    org = Organization.objects.get(pk=org_id)
+    plan = Plan.objects.get(pk=plan_id)
+    user = User.objects.get(pk=user_id)
+    wix.unsync_wix(org, plan, user)
+
+
+@shared_task(
+    autoretry_for=(requests.exceptions.RequestException,),
+    retry_backoff=60,
+    retry_kwargs={"max_retries": 3},
+)
+def unsync_wix_for_group_member(member_org_id, group_org_id, plan_id):
+    """Remove Wix labels for all users of a member organization.
+
+    This is used when:
+    - An organization leaves a group that has a Wix plan
+    - A group's Wix plan subscription is cancelled
+    - share_resources is toggled off for a group with a Wix plan
+    """
+    if not is_production_env():
+        logger.info(
+            "[WIX-SYNC] Skipping group member Wix unsync "
+            "in non-production environment (ENV=%s)",
+            settings.ENV,
+        )
+        return
+
+    member_org = Organization.objects.get(pk=member_org_id)
+    group_org = Organization.objects.get(pk=group_org_id)
+    plan = Plan.objects.get(pk=plan_id)
+
+    if not group_org.share_resources:
+        logger.info(
+            "[WIX-SYNC] Group %s no longer shares resources, skipping unsync",
+            group_org_id,
+        )
+        return
+
+    if not plan.wix:
+        logger.info(
+            "[WIX-SYNC] Plan %s no longer has wix enabled, skipping unsync",
+            plan_id,
+        )
+        return
+
+    logger.info(
+        "[WIX-SYNC] Unsyncing %d users from member org %s "
+        "from group %s's Wix plan %s",
+        member_org.users.count(),
+        member_org_id,
+        group_org_id,
+        plan_id,
+    )
+
+    for user in member_org.users.all():
+        wix.unsync_wix(member_org, plan, user)
+
+
+@shared_task(
+    autoretry_for=(requests.exceptions.RequestException,),
+    retry_backoff=60,
+    retry_kwargs={"max_retries": 3},
+)
 def add_to_waitlist(org_id, plan_id, user_id):
     """Add user to waitlist in Wix"""
     # Only add to waitlist in production

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -663,6 +663,78 @@ def sync_wix_for_group_member(member_org_id, group_org_id, plan_id):
     retry_backoff=60,
     retry_kwargs={"max_retries": 3},
 )
+def unsync_wix(org_id, plan_id, user_id):
+    """Remove Wix labels for a user when they leave an organization or plan changes."""
+    if not is_production_env():
+        logger.info(
+            "[WIX-SYNC] Skipping Wix unsync in non-production environment (ENV=%s)",
+            settings.ENV,
+        )
+        return
+
+    org = Organization.objects.get(pk=org_id)
+    plan = Plan.objects.get(pk=plan_id)
+    user = User.objects.get(pk=user_id)
+    wix.unsync_wix(org, plan, user)
+
+
+@shared_task(
+    autoretry_for=(requests.exceptions.RequestException,),
+    retry_backoff=60,
+    retry_kwargs={"max_retries": 3},
+)
+def unsync_wix_for_group_member(member_org_id, group_org_id, plan_id):
+    """Remove Wix labels for all users of a member organization.
+
+    This is used when:
+    - An organization leaves a group that has a Wix plan
+    - A group's Wix plan subscription is cancelled
+    - share_resources is toggled off for a group with a Wix plan
+    """
+    if not is_production_env():
+        logger.info(
+            "[WIX-SYNC] Skipping group member Wix unsync "
+            "in non-production environment (ENV=%s)",
+            settings.ENV,
+        )
+        return
+
+    member_org = Organization.objects.get(pk=member_org_id)
+    group_org = Organization.objects.get(pk=group_org_id)
+    plan = Plan.objects.get(pk=plan_id)
+
+    if not group_org.share_resources:
+        logger.info(
+            "[WIX-SYNC] Group %s no longer shares resources, skipping unsync",
+            group_org_id,
+        )
+        return
+
+    if not plan.wix:
+        logger.info(
+            "[WIX-SYNC] Plan %s no longer has wix enabled, skipping unsync",
+            plan_id,
+        )
+        return
+
+    logger.info(
+        "[WIX-SYNC] Unsyncing %d users from member org %s "
+        "from group %s's Wix plan %s",
+        member_org.users.count(),
+        member_org_id,
+        group_org_id,
+        plan_id,
+    )
+
+    for user in member_org.users.all():
+        wix.unsync_wix(member_org, plan, user)
+
+
+@shared_task(
+    autoretry_for=(requests.exceptions.RequestException,),
+    retry_backoff=60,
+    retry_kwargs={"max_retries": 3},
+)
 def add_to_waitlist(org_id, plan_id, user_id):
     """Add user to waitlist in Wix"""
     # Only add to waitlist in production

--- a/squarelet/organizations/tests/models/test_membership.py
+++ b/squarelet/organizations/tests/models/test_membership.py
@@ -84,3 +84,77 @@ class TestMembership:
 
         # Should sync user via org's direct plan (not group's)
         mock_sync.assert_called_once_with(member_org.pk, org_wix_plan.pk, user.pk)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_delete_triggers_unsync_for_wix_plan(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Test deleting membership triggers unsync for org with Wix plan"""
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch(
+            "squarelet.organizations.models.membership.send_cache_invalidations"
+        )
+
+        wix_plan = plan_factory(wix=True)
+        org = organization_factory(plans=[wix_plan])
+        user = user_factory()
+
+        membership = Membership.objects.create(user=user, organization=org, admin=False)
+        mock_unsync.reset_mock()
+
+        membership.delete()
+
+        mock_unsync.assert_called_once_with(org.pk, wix_plan.pk, user.pk)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_delete_no_unsync_without_wix_plan(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Test deleting membership does not trigger unsync without Wix plan"""
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+        mocker.patch(
+            "squarelet.organizations.models.membership.send_cache_invalidations"
+        )
+
+        non_wix_plan = plan_factory(wix=False)
+        org = organization_factory(plans=[non_wix_plan])
+        user = user_factory()
+
+        membership = Membership.objects.create(user=user, organization=org, admin=False)
+        mock_unsync.reset_mock()
+
+        membership.delete()
+
+        mock_unsync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_delete_triggers_unsync_for_group_wix_plan(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Test deleting membership triggers unsync via group's Wix plan"""
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch(
+            "squarelet.organizations.models.membership.send_cache_invalidations"
+        )
+        mocker.patch(
+            "squarelet.organizations.models.organization.send_cache_invalidations"
+        )
+
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory()
+        group.members.add(member_org)
+
+        user = user_factory()
+        membership = Membership.objects.create(
+            user=user, organization=member_org, admin=False
+        )
+        mock_unsync.reset_mock()
+
+        membership.delete()
+
+        mock_unsync.assert_called_once_with(group.pk, wix_plan.pk, user.pk)

--- a/squarelet/organizations/tests/models/test_membership.py
+++ b/squarelet/organizations/tests/models/test_membership.py
@@ -135,6 +135,7 @@ class TestMembership:
         """Test deleting membership triggers unsync via group's Wix plan"""
         mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
         mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix_for_group_member.delay")
         mocker.patch(
             "squarelet.organizations.models.membership.send_cache_invalidations"
         )

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -523,6 +523,108 @@ class TestOrganization:
         # Verify local subscription was still deleted
         mocked_subscription.delete.assert_called()
 
+    @pytest.mark.django_db(transaction=True)
+    def test_subscription_cancelled_removes_wix_labels(
+        self, organization_factory, mocker, plan_factory, user_factory
+    ):
+        """Should trigger Wix unsync for all users when subscription is cancelled"""
+        wix_plan = plan_factory(wix=True)
+        user1 = user_factory()
+        user2 = user_factory()
+        organization = organization_factory(plans=[wix_plan], users=[user1, user2])
+
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+        mocked_subscription = mocker.patch(
+            "squarelet.organizations.models.Organization.subscription"
+        )
+        mocked_subscription.subscription_id = "sub_test123"
+        mock_stripe_sub = mocker.MagicMock()
+        type(mocked_subscription).stripe_subscription = mocker.PropertyMock(
+            return_value=mock_stripe_sub
+        )
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+
+        organization.subscription_cancelled()
+
+        # Should call unsync for each user
+        assert mock_unsync.call_count == 2
+        called_user_ids = {call.args[2] for call in mock_unsync.call_args_list}
+        assert called_user_ids == {user1.pk, user2.pk}
+
+    @pytest.mark.django_db
+    def test_subscription_cancelled_no_wix_no_unsync(
+        self, organization_factory, mocker, plan_factory, user_factory
+    ):
+        """Should not trigger Wix unsync when plan is not Wix"""
+        non_wix_plan = plan_factory(wix=False)
+        user = user_factory()
+        organization = organization_factory(plans=[non_wix_plan], users=[user])
+
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+        mocked_subscription = mocker.patch(
+            "squarelet.organizations.models.Organization.subscription"
+        )
+        mocked_subscription.subscription_id = None
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+
+        organization.subscription_cancelled()
+
+        mock_unsync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_set_subscription_plan_change_removes_old_wix_labels(
+        self, organization_factory, mocker, user_factory, plan_factory
+    ):
+        """Downgrading from one Wix plan to another should unsync old and sync new"""
+        old_plan = plan_factory(slug="sunlight-enterprise", wix=True)
+        new_plan = plan_factory(slug="sunlight-essential", wix=True)
+        user = user_factory()
+        organization = organization_factory(admins=[user], plans=[old_plan])
+
+        mocker.patch(
+            "squarelet.organizations.models.Customer.stripe_customer", card=None
+        )
+        mocker.patch("squarelet.organizations.models.Subscription.modify")
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+
+        organization.set_subscription(None, new_plan, 5, user)
+
+        # Should unsync old plan labels
+        assert mock_unsync.call_count >= 1
+        unsync_plan_ids = {call.args[1] for call in mock_unsync.call_args_list}
+        assert old_plan.pk in unsync_plan_ids
+
+        # Should sync new plan labels
+        assert mock_sync.call_count >= 1
+        sync_plan_ids = {call.args[1] for call in mock_sync.call_args_list}
+        assert new_plan.pk in sync_plan_ids
+
+    @pytest.mark.django_db(transaction=True)
+    def test_set_subscription_cancel_wix_removes_labels(
+        self, organization_factory, mocker, user_factory, plan_factory
+    ):
+        """Cancelling a Wix plan subscription should unsync labels"""
+        wix_plan = plan_factory(wix=True)
+        user = user_factory()
+        organization = organization_factory(admins=[user], plans=[wix_plan])
+
+        mocker.patch(
+            "squarelet.organizations.models.Customer.stripe_customer", card=None
+        )
+        mocker.patch("squarelet.organizations.models.Subscription.cancel")
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+
+        organization.set_subscription(None, None, 5, user)
+
+        assert mock_unsync.call_count >= 1
+
     @pytest.mark.django_db()
     def test_set_receipt_emails(self, organization_factory):
         organization = organization_factory()

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -530,6 +530,108 @@ class TestOrganization:
         # Verify local subscription was still deleted
         mocked_subscription.delete.assert_called()
 
+    @pytest.mark.django_db(transaction=True)
+    def test_subscription_cancelled_removes_wix_labels(
+        self, organization_factory, mocker, plan_factory, user_factory
+    ):
+        """Should trigger Wix unsync for all users when subscription is cancelled"""
+        wix_plan = plan_factory(wix=True)
+        user1 = user_factory()
+        user2 = user_factory()
+        organization = organization_factory(plans=[wix_plan], users=[user1, user2])
+
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+        mocked_subscription = mocker.patch(
+            "squarelet.organizations.models.Organization.subscription"
+        )
+        mocked_subscription.subscription_id = "sub_test123"
+        mock_stripe_sub = mocker.MagicMock()
+        type(mocked_subscription).stripe_subscription = mocker.PropertyMock(
+            return_value=mock_stripe_sub
+        )
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+
+        organization.subscription_cancelled()
+
+        # Should call unsync for each user
+        assert mock_unsync.call_count == 2
+        called_user_ids = {call.args[2] for call in mock_unsync.call_args_list}
+        assert called_user_ids == {user1.pk, user2.pk}
+
+    @pytest.mark.django_db
+    def test_subscription_cancelled_no_wix_no_unsync(
+        self, organization_factory, mocker, plan_factory, user_factory
+    ):
+        """Should not trigger Wix unsync when plan is not Wix"""
+        non_wix_plan = plan_factory(wix=False)
+        user = user_factory()
+        organization = organization_factory(plans=[non_wix_plan], users=[user])
+
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+        mocked_subscription = mocker.patch(
+            "squarelet.organizations.models.Organization.subscription"
+        )
+        mocked_subscription.subscription_id = None
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+
+        organization.subscription_cancelled()
+
+        mock_unsync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_set_subscription_plan_change_removes_old_wix_labels(
+        self, organization_factory, mocker, user_factory, plan_factory
+    ):
+        """Downgrading from one Wix plan to another should unsync old and sync new"""
+        old_plan = plan_factory(slug="sunlight-enterprise", wix=True)
+        new_plan = plan_factory(slug="sunlight-essential", wix=True)
+        user = user_factory()
+        organization = organization_factory(admins=[user], plans=[old_plan])
+
+        mocker.patch(
+            "squarelet.organizations.models.Customer.stripe_customer", card=None
+        )
+        mocker.patch("squarelet.organizations.models.Subscription.modify")
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+
+        organization.set_subscription(None, new_plan, 5, user)
+
+        # Should unsync old plan labels
+        assert mock_unsync.call_count >= 1
+        unsync_plan_ids = {call.args[1] for call in mock_unsync.call_args_list}
+        assert old_plan.pk in unsync_plan_ids
+
+        # Should sync new plan labels
+        assert mock_sync.call_count >= 1
+        sync_plan_ids = {call.args[1] for call in mock_sync.call_args_list}
+        assert new_plan.pk in sync_plan_ids
+
+    @pytest.mark.django_db(transaction=True)
+    def test_set_subscription_cancel_wix_removes_labels(
+        self, organization_factory, mocker, user_factory, plan_factory
+    ):
+        """Cancelling a Wix plan subscription should unsync labels"""
+        wix_plan = plan_factory(wix=True)
+        user = user_factory()
+        organization = organization_factory(admins=[user], plans=[wix_plan])
+
+        mocker.patch(
+            "squarelet.organizations.models.Customer.stripe_customer", card=None
+        )
+        mocker.patch("squarelet.organizations.models.Subscription.cancel")
+        mocker.patch("squarelet.organizations.models.Organization.change_logs")
+
+        mock_unsync = mocker.patch("squarelet.organizations.tasks.unsync_wix.delay")
+
+        organization.set_subscription(None, None, 5, user)
+
+        assert mock_unsync.call_count >= 1
+
     @pytest.mark.django_db()
     def test_set_receipt_emails(self, organization_factory):
         organization = organization_factory()

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -591,7 +591,8 @@ class TestOrganization:
         organization = organization_factory(admins=[user], plans=[old_plan])
 
         mocker.patch(
-            "squarelet.organizations.models.Customer.stripe_customer", card=None
+            "squarelet.organizations.models.Customer.stripe_customer",
+            default_source=None,
         )
         mocker.patch("squarelet.organizations.models.Subscription.modify")
         mocker.patch("squarelet.organizations.models.Organization.change_logs")
@@ -621,7 +622,8 @@ class TestOrganization:
         organization = organization_factory(admins=[user], plans=[wix_plan])
 
         mocker.patch(
-            "squarelet.organizations.models.Customer.stripe_customer", card=None
+            "squarelet.organizations.models.Customer.stripe_customer",
+            default_source=None,
         )
         mocker.patch("squarelet.organizations.models.Subscription.cancel")
         mocker.patch("squarelet.organizations.models.Organization.change_logs")

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -1336,3 +1336,108 @@ class TestSyncWixForGroupMember:
         tasks.sync_wix_for_group_member(member_org.id, group.id, non_wix_plan.id)
 
         mock_wix_sync.assert_not_called()
+
+
+class TestUnsyncWix:
+    """Unit tests for the unsync_wix task"""
+
+    @pytest.mark.django_db
+    @override_settings(ENV="prod")
+    def test_unsyncs_in_production(self, plan_factory, user_factory, mocker):
+        """Should unsync from Wix when running in production"""
+        plan = plan_factory(wix=True)
+        user = user_factory()
+        org = user.individual_organization
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix(org.id, plan.id, user.id)
+
+        mock_wix_unsync.assert_called_once_with(org, plan, user)
+
+    @pytest.mark.django_db
+    @override_settings(ENV="staging")
+    def test_does_not_unsync_in_staging(self, plan_factory, user_factory, mocker):
+        """Should not unsync from Wix when running in staging"""
+        plan = plan_factory(wix=True)
+        user = user_factory()
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix(user.individual_organization.id, plan.id, user.id)
+
+        mock_wix_unsync.assert_not_called()
+
+    @pytest.mark.django_db
+    @override_settings(ENV="dev")
+    def test_does_not_unsync_in_dev(self, plan_factory, user_factory, mocker):
+        """Should not unsync from Wix when running in dev"""
+        plan = plan_factory(wix=True)
+        user = user_factory()
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix(user.individual_organization.id, plan.id, user.id)
+
+        mock_wix_unsync.assert_not_called()
+
+
+class TestUnsyncWixForGroupMember:
+    """Unit tests for the unsync_wix_for_group_member task"""
+
+    @pytest.mark.django_db
+    @override_settings(ENV="prod")
+    def test_unsyncs_in_production(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Should unsync all member org users from Wix in production"""
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory(), user_factory()])
+        group.members.add(member_org)
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix_for_group_member(member_org.id, group.id, wix_plan.id)
+
+        assert mock_wix_unsync.call_count == 2
+
+    @pytest.mark.django_db
+    @override_settings(ENV="staging")
+    def test_does_not_unsync_in_staging(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Should not unsync from Wix in staging"""
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+        group.members.add(member_org)
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix_for_group_member(member_org.id, group.id, wix_plan.id)
+
+        mock_wix_unsync.assert_not_called()
+
+    @pytest.mark.django_db
+    @override_settings(ENV="prod")
+    def test_skips_when_share_resources_false(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Should skip unsync if group no longer shares resources"""
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=False, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+        group.members.add(member_org)
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix_for_group_member(member_org.id, group.id, wix_plan.id)
+
+        mock_wix_unsync.assert_not_called()

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -1760,3 +1760,108 @@ class TestSyncWixForGroupMember:
         tasks.sync_wix_for_group_member(member_org.id, group.id, non_wix_plan.id)
 
         mock_wix_sync.assert_not_called()
+
+
+class TestUnsyncWix:
+    """Unit tests for the unsync_wix task"""
+
+    @pytest.mark.django_db
+    @override_settings(ENV="prod")
+    def test_unsyncs_in_production(self, plan_factory, user_factory, mocker):
+        """Should unsync from Wix when running in production"""
+        plan = plan_factory(wix=True)
+        user = user_factory()
+        org = user.individual_organization
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix(org.id, plan.id, user.id)
+
+        mock_wix_unsync.assert_called_once_with(org, plan, user)
+
+    @pytest.mark.django_db
+    @override_settings(ENV="staging")
+    def test_does_not_unsync_in_staging(self, plan_factory, user_factory, mocker):
+        """Should not unsync from Wix when running in staging"""
+        plan = plan_factory(wix=True)
+        user = user_factory()
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix(user.individual_organization.id, plan.id, user.id)
+
+        mock_wix_unsync.assert_not_called()
+
+    @pytest.mark.django_db
+    @override_settings(ENV="dev")
+    def test_does_not_unsync_in_dev(self, plan_factory, user_factory, mocker):
+        """Should not unsync from Wix when running in dev"""
+        plan = plan_factory(wix=True)
+        user = user_factory()
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix(user.individual_organization.id, plan.id, user.id)
+
+        mock_wix_unsync.assert_not_called()
+
+
+class TestUnsyncWixForGroupMember:
+    """Unit tests for the unsync_wix_for_group_member task"""
+
+    @pytest.mark.django_db
+    @override_settings(ENV="prod")
+    def test_unsyncs_in_production(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Should unsync all member org users from Wix in production"""
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory(), user_factory()])
+        group.members.add(member_org)
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix_for_group_member(member_org.id, group.id, wix_plan.id)
+
+        assert mock_wix_unsync.call_count == 2
+
+    @pytest.mark.django_db
+    @override_settings(ENV="staging")
+    def test_does_not_unsync_in_staging(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Should not unsync from Wix in staging"""
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+        group.members.add(member_org)
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix_for_group_member(member_org.id, group.id, wix_plan.id)
+
+        mock_wix_unsync.assert_not_called()
+
+    @pytest.mark.django_db
+    @override_settings(ENV="prod")
+    def test_skips_when_share_resources_false(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Should skip unsync if group no longer shares resources"""
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=False, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+        group.members.add(member_org)
+
+        mock_wix_unsync = mocker.patch("squarelet.organizations.tasks.wix.unsync_wix")
+
+        tasks.unsync_wix_for_group_member(member_org.id, group.id, wix_plan.id)
+
+        mock_wix_unsync.assert_not_called()

--- a/squarelet/organizations/tests/test_wix.py
+++ b/squarelet/organizations/tests/test_wix.py
@@ -16,8 +16,12 @@ from squarelet.organizations.wix import (
     create_member,
     get_contact_by_email,
     get_contact_by_email_v4,
+    get_tier_from_plan,
+    get_wix_labels_for_user,
+    remove_labels,
     send_set_password_email,
     sync_wix,
+    unsync_wix,
 )
 
 
@@ -334,4 +338,183 @@ class TestWix:
 
         # Verify error was logged
         assert "Failed to add" in caplog.text
-        assert user.email in caplog.text
+
+    @pytest.mark.parametrize(
+        "plan_slug,expected_tier",
+        [
+            ("sunlight-essential", "essential"),
+            ("sunlight-essential-annual", "essential"),
+            ("sunlight-enhanced", "enhanced"),
+            ("sunlight-enhanced-annual", "enhanced"),
+            ("sunlight-enterprise", "enterprise"),
+            ("sunlight-enterprise-annual", "enterprise"),
+            ("sunlight-nonprofit-essential", "essential"),
+            ("sunlight-nonprofit-essential-annual", "essential"),
+            ("sunlight-nonprofit-enhanced", "enhanced"),
+            ("sunlight-nonprofit-enhanced-annual", "enhanced"),
+            ("sunlight-enterprise-acme", "enterprise"),
+            ("sunlight-enterprise-acme-annual", "enterprise"),
+            ("sunlight-nonprofit-enterprise-acme", "enterprise"),
+            ("sunlight-basic", "essential"),
+            ("sunlight-basic-annual", "essential"),
+            ("sunlight-nonprofit-basic", "essential"),
+            ("sunlight-premium", "enhanced"),
+            ("sunlight-premium-annual", "enhanced"),
+            ("sunlight-nonprofit-premium", "enhanced"),
+        ],
+    )
+    def test_get_tier_from_plan(self, plan_slug, expected_tier):
+        """Test get_tier_from_plan extracts correct tier from various slug patterns"""
+        plan = PlanFactory.build(slug=plan_slug)
+        assert get_tier_from_plan(plan) == expected_tier
+
+    @pytest.mark.parametrize(
+        "plan_slug,expected_tier",
+        [
+            ("sunlight-essential", "essential"),
+            ("sunlight-enhanced", "enhanced"),
+            ("sunlight-enterprise", "enterprise"),
+            ("sunlight-nonprofit-essential", "essential"),
+            ("sunlight-enterprise-acme", "enterprise"),
+            ("sunlight-basic", "essential"),
+            ("sunlight-premium", "enhanced"),
+            ("sunlight-nonprofit-basic", "essential"),
+            ("sunlight-nonprofit-premium", "enhanced"),
+        ],
+    )
+    def test_remove_labels(self, requests_mock, plan_slug, expected_tier):
+        """Test remove_labels sends correct DELETE request with tier labels"""
+        contact_id = str(uuid.uuid4())
+        plan = PlanFactory.build(slug=plan_slug)
+        requests_mock.delete(
+            f"https://www.wixapis.com/contacts/v4/contacts/{contact_id}/labels",
+            json={"contact": {"id": contact_id}},
+        )
+        headers = {
+            "Authorization": settings.WIX_APP_SECRET,
+            "wix-site-id": settings.WIX_SITE_ID,
+        }
+        remove_labels(headers, contact_id, plan)
+        assert requests_mock.last_request.json() == {
+            "labelKeys": ["custom.paying-member", f"custom.{expected_tier}-member"]
+        }
+
+    @pytest.mark.django_db()
+    def test_unsync_wix_contact_exists(self, requests_mock, user):
+        """Test unsync_wix removes labels when contact exists"""
+        contact_id = str(uuid.uuid4())
+        plan = PlanFactory(slug="sunlight-essential", name="Sunlight Essential")
+
+        # Mock contact lookup
+        requests_mock.post(
+            "https://www.wixapis.com/members/v1/members/query",
+            json={"members": [{"contactId": contact_id}], "metadata": {"count": 1}},
+        )
+        # Mock label removal
+        requests_mock.delete(
+            f"https://www.wixapis.com/contacts/v4/contacts/{contact_id}/labels",
+            json={"contact": {"id": contact_id}},
+        )
+
+        unsync_wix(user.individual_organization, plan, user)
+
+        # Should have made 2 requests: query + delete labels
+        assert len(requests_mock.request_history) == 2
+        assert requests_mock.request_history[1].method == "DELETE"
+        assert set(requests_mock.request_history[1].json()["labelKeys"]) == {
+            "custom.paying-member",
+            "custom.essential-member",
+        }
+
+    @pytest.mark.django_db()
+    def test_unsync_wix_contact_not_found(self, requests_mock, user):
+        """Test unsync_wix is a no-op when contact doesn't exist in Wix"""
+        plan = PlanFactory(slug="sunlight-essential", name="Sunlight Essential")
+
+        # Mock contact lookup returning no results
+        requests_mock.post(
+            "https://www.wixapis.com/members/v1/members/query",
+            json={"metadata": {"count": 0}},
+        )
+
+        unsync_wix(user.individual_organization, plan, user)
+
+        # Should have only made 1 request (the query)
+        assert len(requests_mock.request_history) == 1
+
+    @pytest.mark.django_db()
+    def test_unsync_wix_skips_remaining_labels(self, requests_mock, user, mocker):
+        """Test unsync_wix does not remove labels the user still qualifies for"""
+        contact_id = str(uuid.uuid4())
+        plan = PlanFactory(slug="sunlight-essential", name="Sunlight Essential")
+
+        # Mock contact lookup
+        requests_mock.post(
+            "https://www.wixapis.com/members/v1/members/query",
+            json={"members": [{"contactId": contact_id}], "metadata": {"count": 1}},
+        )
+        # Mock label removal (should not be called)
+        requests_mock.delete(
+            f"https://www.wixapis.com/contacts/v4/contacts/{contact_id}/labels",
+            json={"contact": {"id": contact_id}},
+        )
+        # User still qualifies for both labels via another membership
+        mocker.patch(
+            "squarelet.organizations.wix.get_wix_labels_for_user",
+            return_value={"custom.paying-member", "custom.essential-member"},
+        )
+
+        unsync_wix(user.individual_organization, plan, user)
+
+        # Should have only made 1 request (the query) — no delete needed
+        assert len(requests_mock.request_history) == 1
+
+    @pytest.mark.django_db()
+    def test_unsync_wix_partial_remaining_labels(self, requests_mock, user, mocker):
+        """Test unsync_wix only removes labels the user no longer qualifies for"""
+        contact_id = str(uuid.uuid4())
+        plan = PlanFactory(slug="sunlight-essential", name="Sunlight Essential")
+
+        requests_mock.post(
+            "https://www.wixapis.com/members/v1/members/query",
+            json={"members": [{"contactId": contact_id}], "metadata": {"count": 1}},
+        )
+        requests_mock.delete(
+            f"https://www.wixapis.com/contacts/v4/contacts/{contact_id}/labels",
+            json={"contact": {"id": contact_id}},
+        )
+        # User still qualifies for paying-member but not essential-member
+        mocker.patch(
+            "squarelet.organizations.wix.get_wix_labels_for_user",
+            return_value={"custom.paying-member"},
+        )
+
+        unsync_wix(user.individual_organization, plan, user)
+
+        # Should remove only essential-member (paying-member is retained)
+        assert len(requests_mock.request_history) == 2
+        assert requests_mock.request_history[1].json() == {
+            "labelKeys": ["custom.essential-member"]
+        }
+
+    @pytest.mark.django_db()
+    def test_get_wix_labels_for_user(
+        self, user_factory, organization_factory, plan_factory, membership_factory
+    ):
+        """Test get_wix_labels_for_user returns all labels across memberships"""
+        user = user_factory()
+        essential_plan = plan_factory(slug="sunlight-essential", wix=True)
+        enhanced_plan = plan_factory(slug="sunlight-enhanced", wix=True)
+
+        org1 = organization_factory(plans=[essential_plan])
+        org2 = organization_factory(plans=[enhanced_plan])
+
+        membership_factory(user=user, organization=org1)
+        membership_factory(user=user, organization=org2)
+
+        labels = get_wix_labels_for_user(user)
+        assert labels == {
+            "custom.paying-member",
+            "custom.essential-member",
+            "custom.enhanced-member",
+        }

--- a/squarelet/organizations/tests/test_wix.py
+++ b/squarelet/organizations/tests/test_wix.py
@@ -361,6 +361,8 @@ class TestWix:
             ("sunlight-premium", "enhanced"),
             ("sunlight-premium-annual", "enhanced"),
             ("sunlight-nonprofit-premium", "enhanced"),
+            # Non-tiered plans fall back to the raw slug
+            ("election-accountability-cohort", "election-accountability-cohort"),
         ],
     )
     def test_get_tier_from_plan(self, plan_slug, expected_tier):

--- a/squarelet/organizations/wix.py
+++ b/squarelet/organizations/wix.py
@@ -73,29 +73,61 @@ def create_member(headers, organization, user):
     return response.json()["member"]["contactId"]
 
 
-def add_labels(headers, contact_id, plan):
-    logger.warning("[WIX-SYNC] add labels")
-    # Extract the tier name from the plan slug
-    # Maps legacy names (basic→essential, premium→enhanced) and current names
-    tier_labels = {
+def get_tier_from_plan(plan):
+    """Extract the tier name (essential, enhanced, enterprise) from a plan slug.
+
+    Handles all variants: sunlight-essential, sunlight-enterprise-custom,
+    sunlight-nonprofit-enhanced-annual, etc. Also maps legacy tier names
+    (basic→essential, premium→enhanced) to their current equivalents.
+    """
+    tier_aliases = {
         "enterprise": "enterprise",
         "enhanced": "enhanced",
         "essential": "essential",
         "basic": "essential",
         "premium": "enhanced",
     }
-    plan_slug = next(
-        (label for tier, label in tier_labels.items() if tier in plan.slug),
+    return next(
+        (label for alias, label in tier_aliases.items() if alias in plan.slug),
         plan.slug,
     )
+
+
+def add_labels(headers, contact_id, plan):
+    logger.warning("[WIX-SYNC] add labels")
+    tier = get_tier_from_plan(plan)
     response = requests.post(
         f"https://www.wixapis.com/contacts/v4/contacts/{contact_id}/labels",
         headers=headers,
-        json={"labelKeys": ["custom.paying-member", f"custom.{plan_slug}-member"]},
+        json={"labelKeys": ["custom.paying-member", f"custom.{tier}-member"]},
         timeout=(5, 15),
     )
     logger.warning(
         "[WIX-SYNC] add labels response %d %s", response.status_code, response.json()
+    )
+    response.raise_for_status()
+
+
+def remove_labels(headers, contact_id, plan, label_keys=None):
+    """Remove Wix labels from a contact.
+
+    If label_keys is provided, remove exactly those labels.
+    Otherwise, remove the default labels for the given plan.
+    """
+    logger.warning("[WIX-SYNC] remove labels")
+    if label_keys is None:
+        tier = get_tier_from_plan(plan)
+        label_keys = ["custom.paying-member", f"custom.{tier}-member"]
+    response = requests.delete(
+        f"https://www.wixapis.com/contacts/v4/contacts/{contact_id}/labels",
+        headers=headers,
+        json={"labelKeys": label_keys},
+        timeout=(5, 15),
+    )
+    logger.warning(
+        "[WIX-SYNC] remove labels response %d %s",
+        response.status_code,
+        response.json(),
     )
     response.raise_for_status()
 
@@ -137,6 +169,61 @@ def sync_wix(organization, plan, user):
         # only set password for new members
         send_set_password_email(headers, user.email)
     add_labels(headers, contact_id, plan)
+
+
+def unsync_wix(organization, plan, user):
+    """Remove Wix labels for a user when they leave an organization or plan changes.
+
+    The user's still-qualified labels are computed from their current memberships.
+    Callers must ensure any relevant membership/plan changes are persisted before
+    invoking this function (e.g. by dispatching the task via transaction.on_commit).
+    """
+    remaining_labels = get_wix_labels_for_user(user)
+
+    headers = {
+        "Authorization": settings.WIX_APP_SECRET,
+        "wix-site-id": settings.WIX_SITE_ID,
+    }
+
+    logger.warning(
+        "[WIX-SYNC] unsync wix org: %s plan: %s user: %s", organization, plan, user
+    )
+    contact_id = get_contact_by_email(headers, user.email)
+    if contact_id is None:
+        logger.warning(
+            "[WIX-SYNC] contact not found for %s, skipping label removal", user.email
+        )
+        return
+
+    # Compute which labels to actually remove
+    tier = get_tier_from_plan(plan)
+    plan_labels = {"custom.paying-member", f"custom.{tier}-member"}
+    labels_to_remove = sorted(plan_labels - remaining_labels)
+
+    if not labels_to_remove:
+        logger.warning(
+            "[WIX-SYNC] all labels for %s still needed, skipping removal", user.email
+        )
+        return
+
+    remove_labels(headers, contact_id, plan, label_keys=labels_to_remove)
+
+
+def get_wix_labels_for_user(user):
+    """Get all Wix labels a user qualifies for across all their memberships."""
+    labels = set()
+    for membership in user.memberships.select_related("organization___plan").all():
+        org = membership.organization
+        plan = org.plan
+        if plan and plan.wix:
+            tier = get_tier_from_plan(plan)
+            labels.add(f"custom.{tier}-member")
+            labels.add("custom.paying-member")
+        for _group, group_plan in org.get_wix_plans_from_groups():
+            tier = get_tier_from_plan(group_plan)
+            labels.add(f"custom.{tier}-member")
+            labels.add("custom.paying-member")
+    return labels
 
 
 def create_contact(headers, organization, user):

--- a/squarelet/organizations/wix.py
+++ b/squarelet/organizations/wix.py
@@ -212,7 +212,7 @@ def unsync_wix(organization, plan, user):
 def get_wix_labels_for_user(user):
     """Get all Wix labels a user qualifies for across all their memberships."""
     labels = set()
-    for membership in user.memberships.select_related("organization___plan").all():
+    for membership in user.memberships.select_related("organization__plan").all():
         org = membership.organization
         plan = org.plan
         if plan and plan.wix:

--- a/squarelet/organizations/wix.py
+++ b/squarelet/organizations/wix.py
@@ -212,13 +212,13 @@ def unsync_wix(organization, plan, user):
 def get_wix_labels_for_user(user):
     """Get all Wix labels a user qualifies for across all their memberships."""
     labels = set()
-    for membership in user.memberships.select_related("organization__plan").all():
+    for membership in user.memberships.prefetch_related("organization__plans").all():
         org = membership.organization
-        plan = org.plan
-        if plan and plan.wix:
-            tier = get_tier_from_plan(plan)
-            labels.add(f"custom.{tier}-member")
-            labels.add("custom.paying-member")
+        for plan in org.plans.all():
+            if plan and plan.wix:
+                tier = get_tier_from_plan(plan)
+                labels.add(f"custom.{tier}-member")
+                labels.add("custom.paying-member")
         for _group, group_plan in org.get_wix_plans_from_groups():
             tier = get_tier_from_plan(group_plan)
             labels.add(f"custom.{tier}-member")


### PR DESCRIPTION
Closes #589

Adds missing "unsync" handling for when a subscription ends or a user leaves an org subscribed to a Sunlight plan.