### PR TITLE
Fix Wix sync for orgs in resource-sharing groups

### DIFF
--- a/squarelet/organizations/models/invitation.py
+++ b/squarelet/organizations/models/invitation.py
@@ -350,11 +350,6 @@ class OrganizationInvitation(models.Model):
     @transaction.atomic
     def accept(self):
         """Accept this invitation/request"""
-        # Prevent circular import
-        # pylint: disable=import-outside-toplevel
-        # Squarelet
-        from squarelet.organizations.tasks import sync_wix_for_group_member
-
         if not self.is_pending:
             raise ValueError("This invitation has already been processed")
 
@@ -369,16 +364,6 @@ class OrganizationInvitation(models.Model):
             # Set parent relationship
             self.to_organization.parent = self.from_organization
             self.to_organization.save()
-
-        # Trigger Wix sync if the group has a Wix plan and shares resources
-        group = self.from_organization
-        if group.share_resources and group.plan and group.plan.wix:
-            to_org_pk = self.to_organization.pk
-            group_pk = group.pk
-            plan_pk = group.plan.pk
-            transaction.on_commit(
-                lambda: sync_wix_for_group_member.delay(to_org_pk, group_pk, plan_pk)
-            )
 
     @transaction.atomic
     def reject(self):

--- a/squarelet/organizations/models/membership.py
+++ b/squarelet/organizations/models/membership.py
@@ -80,12 +80,16 @@ class Membership(models.Model):
                     )
                 else:
                     # Group Wix plans - sync new user to each group's plan
-                    for group, plan in group_wix_plans:
+                    for _, plan in group_wix_plans:
                         # Capture values to avoid closure issues
-                        group_pk, plan_pk, user_pk = group.pk, plan.pk, self.user.pk
+                        org_pk, plan_pk, user_pk = (
+                            self.organization.pk,
+                            plan.pk,
+                            self.user.pk,
+                        )
                         transaction.on_commit(
-                            lambda g=group_pk, p=plan_pk, u=user_pk: sync_wix.delay(
-                                g, p, u
+                            lambda o=org_pk, p=plan_pk, u=user_pk: sync_wix.delay(
+                                o, p, u
                             )
                         )
 

--- a/squarelet/organizations/signals.py
+++ b/squarelet/organizations/signals.py
@@ -1,4 +1,5 @@
 # Django
+from django.db import transaction
 from django.db.models import signals
 from django.dispatch import receiver
 
@@ -12,6 +13,7 @@ from squarelet.organizations.models import (
     Plan,
     ProfileChangeRequest,
 )
+from squarelet.organizations.tasks import sync_wix_for_group_member
 
 # Register models with django-activity-stream
 registry.register(Organization)
@@ -19,6 +21,11 @@ registry.register(ProfileChangeRequest)
 registry.register(Invitation)
 
 # pylint:disable=too-many-positional-arguments
+
+
+def should_sync_wix(org):
+    """Should we sync this org with Wix?"""
+    return org and org.share_resources and org.plan and org.plan.wix
 
 
 @receiver(
@@ -42,3 +49,100 @@ def delete_stripe_plan(sender, instance, using, **kwargs):
     """Create a stripe plan on plan creation"""
     # pylint: disable=unused-argument
     instance.delete_stripe_plan()
+
+
+@receiver(
+    signals.pre_save,
+    sender=Organization,
+    dispatch_uid="squarelet.organizations.signals.track_parent_change",
+)
+def track_parent_change(sender, instance, **kwargs):
+    """Stash the previous parent_id so post_save can detect changes."""
+    # pylint: disable=unused-argument,protected-access
+    if instance.pk:
+        try:
+            instance._previous_parent_id = (
+                Organization.objects.filter(pk=instance.pk)
+                .values_list("parent_id", flat=True)
+                .get()
+            )
+        except Organization.DoesNotExist:
+            instance._previous_parent_id = None
+    else:
+        instance._previous_parent_id = None
+
+
+@receiver(
+    signals.post_save,
+    sender=Organization,
+    dispatch_uid="squarelet.organizations.signals.sync_wix_on_parent_change",
+)
+def sync_wix_on_parent_change(sender, instance, **kwargs):
+    """Trigger Wix sync when a child org's parent FK is set or changed to a
+    resource-sharing parent with a Wix plan.
+
+    This covers the case where staff sets the parent directly via Django admin
+    (bypassing the OrganizationInvitation flow).
+    """
+    # pylint: disable=unused-argument
+    if instance.parent_id == getattr(instance, "_previous_parent_id", None):
+        return
+
+    parent = instance.parent
+    if not should_sync_wix(parent):
+        return
+
+    child_pk = instance.pk
+    parent_pk = parent.pk
+    plan_pk = parent.plan.pk
+    transaction.on_commit(
+        lambda: sync_wix_for_group_member.delay(child_pk, parent_pk, plan_pk)
+    )
+
+
+@receiver(
+    signals.m2m_changed,
+    sender=Organization.members.through,
+    dispatch_uid="squarelet.organizations.signals.sync_wix_on_member_add",
+)
+def sync_wix_on_member_add(sender, instance, action, pk_set, reverse, **kwargs):
+    """Trigger Wix sync when a member org is added to a group's members M2M.
+
+    This covers the case where staff directly assigns a ChildOrg to a ParentOrg
+    via the Django admin (bypassing the OrganizationInvitation flow).
+
+    - For forward relationships (reverse=False), the instance is the group
+      and the pk_set contains added member org PKs.
+    - For reverse relationships (reverse=True), the instances is the member_org,
+      and the pk_set contains group PKs it joined.
+    """
+    # pylint: disable=unused-argument
+    if action != "post_add" or not pk_set:
+        return
+
+    if not reverse:
+        group = instance
+        if not should_sync_wix(group):
+            return
+        group_pk = group.pk
+        plan_pk = group.plan.pk
+        for member_pk in pk_set:
+            transaction.on_commit(
+                lambda m=member_pk: sync_wix_for_group_member.delay(
+                    m, group_pk, plan_pk
+                )
+            )
+    else:
+        member_org = instance
+        member_pk = member_org.pk
+        for group_pk in pk_set:
+            group = (
+                Organization.objects.filter(pk=group_pk).select_related("_plan").first()
+            )
+            if should_sync_wix(group):
+                plan_pk = group.plan.pk
+                transaction.on_commit(
+                    lambda g=group_pk, p=plan_pk: sync_wix_for_group_member.delay(
+                        member_pk, g, p
+                    )
+                )

--- a/squarelet/organizations/tests/models/test_invitation.py
+++ b/squarelet/organizations/tests/models/test_invitation.py
@@ -402,6 +402,76 @@ class TestOrganizationInvitationAccept:
 
         mock_sync.assert_not_called()
 
+    # --- Tests for child relationship type ---
+
+    @pytest.mark.django_db(transaction=True)
+    def test_accept_child_invitation_triggers_wix_sync(
+        self, organization_invitation_factory, plan_factory, mocker
+    ):
+        """Accepting a child invitation triggers Wix sync when parent has Wix plan.
+
+        Child relationships set the parent FK (not M2M), so Wix sync must be
+        triggered directly inside accept() rather than via the m2m_changed signal.
+        """
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        invitation = organization_invitation_factory(
+            from_organization__collective_enabled=True,
+            from_organization__share_resources=True,
+            from_organization__plans=[wix_plan],
+            relationship_type=RelationshipType.child,
+        )
+
+        invitation.accept()
+
+        mock_sync.assert_called_once_with(
+            invitation.to_organization.pk,
+            invitation.from_organization.pk,
+            wix_plan.pk,
+        )
+
+    @pytest.mark.django_db(transaction=True)
+    def test_accept_child_invitation_no_wix_sync_when_share_resources_false(
+        self, organization_invitation_factory, plan_factory, mocker
+    ):
+        """Child invitation accept does not trigger sync when share_resources=False"""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        invitation = organization_invitation_factory(
+            from_organization__collective_enabled=True,
+            from_organization__share_resources=False,
+            from_organization__plans=[wix_plan],
+            relationship_type=RelationshipType.child,
+        )
+
+        invitation.accept()
+
+        mock_sync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_accept_child_invitation_no_wix_sync_when_no_wix_plan(
+        self, organization_invitation_factory, plan_factory, mocker
+    ):
+        """Child invitation accept does not trigger sync when no Wix plan"""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        non_wix_plan = plan_factory(wix=False)
+        invitation = organization_invitation_factory(
+            from_organization__collective_enabled=True,
+            from_organization__share_resources=True,
+            from_organization__plans=[non_wix_plan],
+            relationship_type=RelationshipType.child,
+        )
+
+        invitation.accept()
+
+        mock_sync.assert_not_called()
+
 
 class TestOrganizationInvitationReject:
     """Tests for OrganizationInvitation reject functionality"""

--- a/squarelet/organizations/tests/models/test_membership.py
+++ b/squarelet/organizations/tests/models/test_membership.py
@@ -40,6 +40,7 @@ class TestMembership:
     ):
         """Test new membership syncs user via group's Wix plan"""
         mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix_for_group_member.delay")
         mocker.patch(
             "squarelet.organizations.models.organization.send_cache_invalidations"
         )
@@ -55,8 +56,8 @@ class TestMembership:
 
         Membership.objects.create(user=user, organization=member_org, admin=False)
 
-        # Should sync user via group's plan
-        mock_sync.assert_called_once_with(group.pk, wix_plan.pk, user.pk)
+        # Should sync user under their org via group's plan
+        mock_sync.assert_called_once_with(member_org.pk, wix_plan.pk, user.pk)
 
     @pytest.mark.django_db(transaction=True)
     def test_save_prefers_direct_wix_plan_over_group(
@@ -64,6 +65,7 @@ class TestMembership:
     ):
         """Test new membership uses direct org Wix plan over group plan"""
         mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix_for_group_member.delay")
         mocker.patch(
             "squarelet.organizations.models.organization.send_cache_invalidations"
         )

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -9,7 +9,7 @@ import stripe
 from squarelet.organizations.choices import ChangeLogReason
 from squarelet.organizations.models import Organization
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods,too-many-lines
 
 
 class TestOrganization:
@@ -805,6 +805,170 @@ class TestOrganization:
 class TestOrganizationWixSyncIntegration:
     """Integration tests for Wix sync triggers in Organization model"""
 
+    # --- Tests for direct M2M assignment (Bug #637) ---
+
+    @pytest.mark.django_db(transaction=True)
+    def test_direct_member_add_triggers_wix_sync(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Directly adding a member org to group.members should trigger Wix sync.
+
+        This reproduces the bug where staff assigns ChildOrg to ParentOrg via
+        Django admin (bypassing OrganizationInvitation), and Wix sync is not triggered.
+        """
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+
+        # Simulate admin directly assigning ChildOrg to ParentOrg.members
+        # (bypasses OrganizationInvitation.accept)
+        group.members.add(member_org)
+
+        # Should trigger Wix sync for member org's users via the group's plan
+        mock_sync.assert_called_once_with(member_org.pk, group.pk, wix_plan.pk)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_direct_member_add_no_sync_when_share_resources_false(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """
+        Direct member add should not trigger sync
+        when group has share_resources=False
+        """
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=False, plans=[wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+
+        group.members.add(member_org)
+
+        mock_sync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_direct_member_add_no_sync_when_no_wix_plan(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Direct member add should not trigger sync when group has no Wix plan"""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        non_wix_plan = plan_factory(wix=False)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[non_wix_plan]
+        )
+        member_org = organization_factory(users=[user_factory()])
+
+        group.members.add(member_org)
+
+        mock_sync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_direct_member_add_no_sync_when_no_plan(
+        self, organization_factory, user_factory, mocker
+    ):
+        """Direct member add should not trigger sync when group has no plan at all"""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        group = organization_factory(collective_enabled=True, share_resources=True)
+        member_org = organization_factory(users=[user_factory()])
+
+        group.members.add(member_org)
+
+        mock_sync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_setting_parent_triggers_wix_sync(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Setting parent FK via admin should trigger Wix sync when parent
+        has a Wix plan with share_resources=True."""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        parent = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        child = organization_factory(users=[user_factory()])
+
+        child.parent = parent
+        child.save()
+
+        mock_sync.assert_called_once_with(child.pk, parent.pk, wix_plan.pk)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_setting_parent_no_sync_when_share_resources_false(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Setting parent FK should not trigger sync when parent has
+        share_resources=False."""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        parent = organization_factory(
+            collective_enabled=True, share_resources=False, plans=[wix_plan]
+        )
+        child = organization_factory(users=[user_factory()])
+
+        child.parent = parent
+        child.save()
+
+        mock_sync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_setting_parent_no_sync_when_no_wix_plan(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Setting parent FK should not trigger sync when parent has no Wix plan."""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        non_wix_plan = plan_factory(wix=False)
+        parent = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[non_wix_plan]
+        )
+        child = organization_factory(users=[user_factory()])
+
+        child.parent = parent
+        child.save()
+
+        mock_sync.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_saving_without_parent_change_no_sync(
+        self, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Saving an org that already has a parent should not re-trigger sync."""
+        mock_sync = mocker.patch(
+            "squarelet.organizations.tasks.sync_wix_for_group_member.delay"
+        )
+        wix_plan = plan_factory(wix=True)
+        parent = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        child = organization_factory(users=[user_factory()], parent=parent)
+
+        # Reset after factory creation which triggers the signal
+        mock_sync.reset_mock()
+
+        # Save without changing parent
+        child.save()
+
+        mock_sync.assert_not_called()
+
+    # --- Tests for share_resources toggle (existing behaviour) ---
+
     @pytest.mark.django_db(transaction=True)
     def test_save_triggers_wix_sync_on_share_resources_toggle(
         self, organization_factory, plan_factory, mocker
@@ -840,6 +1004,10 @@ class TestOrganizationWixSyncIntegration:
         )
         member_org = organization_factory()
         group.members.add(member_org)
+
+        # The m2m_changed signal fires sync on the add above; reset to verify
+        # the save itself does not trigger additional syncs.
+        mock_sync.reset_mock()
 
         # Save without changing share_resources
         group.save()

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 # Standard Library
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 # Third Party
 import pytest
@@ -26,7 +26,7 @@ from .. import views
 from ..choices import InvitationRole
 from ..models import Organization, OrganizationEmailDomain, Plan, ReceiptEmail
 
-# pylint: disable=too-many-public-methods, too-many-lines
+# pylint: disable=too-many-public-methods, too-many-lines, too-many-positional-arguments
 
 
 def _assign_org_perm(user, codename):
@@ -491,6 +491,206 @@ class TestDetail(ViewTestMixin):
 
 
 @pytest.mark.django_db()
+class TestSyncWix(ViewTestMixin):
+    """Tests for the Wix sync staff action on the Organization detail page."""
+
+    view = views.Detail
+    url = "/organizations/{slug}/"
+
+    @pytest.fixture(autouse=True)
+    def _setup_plan(self):
+        Plan.objects.get_or_create(
+            slug="organization", defaults={"name": "Organization"}
+        )
+
+    def test_staff_can_sync_wix_for_org_with_direct_wix_plan(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Staff can trigger Wix sync for an org that has a direct Wix plan."""
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        member_user = user_factory()
+        org = organization_factory(plans=[wix_plan], users=[member_user])
+
+        response = self.call_view(
+            rf, staff_user, data={"action": "sync_wix"}, slug=org.slug
+        )
+
+        assert response.status_code == 302
+        mock_sync.assert_called_once_with(org.pk, wix_plan.pk, member_user.pk)
+
+    def test_staff_can_sync_wix_for_child_org_with_inherited_wix_plan(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Staff can trigger Wix sync for a ChildOrg that inherits a Wix plan."""
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_user = user_factory()
+        member_org = organization_factory(users=[member_user])
+        group.members.add(member_org)
+
+        # member_org has no direct plan; it inherits from group
+        response = self.call_view(
+            rf, staff_user, data={"action": "sync_wix"}, slug=member_org.slug
+        )
+
+        assert response.status_code == 302
+        # Should sync member_user under member_org via the group's plan
+        mock_sync.assert_called_once_with(member_org.pk, wix_plan.pk, member_user.pk)
+
+    def test_wix_sync_button_shown_in_context_for_org_with_inherited_plan(
+        self, rf, organization_factory, plan_factory, user_factory
+    ):
+        """
+        The view context should signal that the Wix sync button can be shown
+        for a ChildOrg that inherits a Wix plan from its resource-sharing group.
+        """
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        group = organization_factory(
+            collective_enabled=True, share_resources=True, plans=[wix_plan]
+        )
+        member_org = organization_factory()
+        group.members.add(member_org)
+
+        response = self.call_view(rf, staff_user, slug=member_org.slug)
+
+        assert response.status_code == 200
+        # Context should indicate Wix sync is available even without a direct plan
+        assert response.context_data.get("show_wix_sync") is True
+
+    def test_wix_sync_button_shown_in_context_for_org_with_direct_plan(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """The view context should signal Wix sync button for org with direct plan."""
+        mocker.patch("squarelet.organizations.models.Customer.card", None)
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        org = organization_factory(plans=[wix_plan])
+
+        response = self.call_view(rf, staff_user, slug=org.slug)
+
+        assert response.status_code == 200
+        assert response.context_data.get("show_wix_sync") is True
+
+    def test_wix_sync_button_not_shown_when_no_wix_plan(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """The view context should NOT signal Wix sync button when no Wix plan."""
+        mocker.patch("squarelet.organizations.models.Customer.card", None)
+        staff_user = user_factory(is_staff=True)
+        non_wix_plan = plan_factory(wix=False)
+        org = organization_factory(plans=[non_wix_plan])
+
+        response = self.call_view(rf, staff_user, slug=org.slug)
+
+        assert response.status_code == 200
+        assert not response.context_data.get("show_wix_sync")
+
+    def test_wix_sync_button_not_shown_when_no_plan_at_all(
+        self, rf, organization_factory, user_factory
+    ):
+        """The view context should NOT signal Wix sync button when org has no plan."""
+        staff_user = user_factory(is_staff=True)
+        org = organization_factory()
+
+        response = self.call_view(rf, staff_user, slug=org.slug)
+
+        assert response.status_code == 200
+        assert not response.context_data.get("show_wix_sync")
+
+    def test_sync_wix_cascades_to_member_orgs(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Syncing Wix on a group should also sync users in its member orgs."""
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix_for_group_member.delay")
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        group_user = user_factory()
+        group = organization_factory(
+            collective_enabled=True,
+            share_resources=True,
+            plans=[wix_plan],
+            users=[group_user],
+        )
+        member_user = user_factory()
+        member_org = organization_factory(users=[member_user])
+        group.members.add(member_org)
+
+        response = self.call_view(
+            rf, staff_user, data={"action": "sync_wix"}, slug=group.slug
+        )
+
+        assert response.status_code == 302
+        calls = mock_sync.call_args_list
+        # Should sync both the group's own user and the member org's user,
+        # each associated with their own org
+        assert call(group.pk, wix_plan.pk, group_user.pk) in calls
+        assert call(member_org.pk, wix_plan.pk, member_user.pk) in calls
+
+    def test_sync_wix_cascades_to_child_orgs(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Syncing Wix on a parent should also sync users in its child orgs."""
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix_for_group_member.delay")
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        parent_user = user_factory()
+        parent = organization_factory(
+            collective_enabled=True,
+            share_resources=True,
+            plans=[wix_plan],
+            users=[parent_user],
+        )
+        child_user = user_factory()
+        child_org = organization_factory(users=[child_user], parent=parent)
+
+        response = self.call_view(
+            rf, staff_user, data={"action": "sync_wix"}, slug=parent.slug
+        )
+
+        assert response.status_code == 302
+        calls = mock_sync.call_args_list
+        assert call(parent.pk, wix_plan.pk, parent_user.pk) in calls
+        assert call(child_org.pk, wix_plan.pk, child_user.pk) in calls
+
+    def test_sync_wix_no_cascade_when_share_resources_false(
+        self, rf, organization_factory, plan_factory, user_factory, mocker
+    ):
+        """Syncing Wix should not cascade to member/child orgs when
+        share_resources is False."""
+        mock_sync = mocker.patch("squarelet.organizations.tasks.sync_wix.delay")
+        mocker.patch("squarelet.organizations.tasks.sync_wix_for_group_member.delay")
+        staff_user = user_factory(is_staff=True)
+        wix_plan = plan_factory(wix=True)
+        group_user = user_factory()
+        group = organization_factory(
+            collective_enabled=True,
+            share_resources=False,
+            plans=[wix_plan],
+            users=[group_user],
+        )
+        member_user = user_factory()
+        member_org = organization_factory(users=[member_user])
+        group.members.add(member_org)
+
+        response = self.call_view(
+            rf, staff_user, data={"action": "sync_wix"}, slug=group.slug
+        )
+
+        assert response.status_code == 302
+        # Should only sync the group's own user, not member org's user
+        mock_sync.assert_called_once_with(group.pk, wix_plan.pk, group_user.pk)
+
+
+@pytest.mark.django_db()
 class TestJoinRequestModal(ViewTestMixin):
     """Test the join request modal context on organization detail page"""
 
@@ -908,7 +1108,7 @@ class TestUpdateSubscription(ViewTestMixin):
         }
         response = self.call_view(rf, user, data, slug=organization.slug)
         assert response.status_code == 302
-        mocked.assert_called_with(
+        mocked.assert_called_once_with(
             token=data["stripe_token"],
             plan=organization.plan,
             max_users=data["max_users"],

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -119,6 +119,12 @@ class Detail(AdminLinkMixin, DetailView):
                 "has_email_domains": org.domains.exists(),
             }
 
+        # Wix sync context: True when org has a direct Wix plan or inherits one
+        # from a resource-sharing group/parent.  Used to show the staff toolbar button.
+        context["show_wix_sync"] = bool(
+            (org.plan and org.plan.wix) or org.get_wix_plans_from_groups()
+        )
+
         return context
 
     def handle_join(self, request):
@@ -268,14 +274,36 @@ class Detail(AdminLinkMixin, DetailView):
         messages.success(request, _("Auto-join has been disabled"))
         return None
 
+    def _sync_wix_for_org(self, org, plan):
+        """Queue a Wix sync for every user in *org* using *plan*."""
+        for wix_user in org.users.all():
+            sync_wix.delay(org.pk, plan.pk, wix_user.pk)
+
     def handle_sync_wix(self, request):
-        if self.request.user.is_staff and self.organization.plan.wix:
-            for wix_user in self.organization.users.all():
-                sync_wix.delay(
-                    self.organization.pk,
-                    self.organization.plan.pk,
-                    wix_user.pk,
-                )
+        if not self.request.user.is_staff:
+            return
+
+        org = self.organization
+        triggered = False
+
+        # Direct Wix plan on this org
+        if org.plan and org.plan.wix:
+            self._sync_wix_for_org(org, org.plan)
+            triggered = True
+
+            # Cascade to member orgs and child orgs when this org shares resources
+            if org.share_resources:
+                for member_org in org.members.all():
+                    self._sync_wix_for_org(member_org, org.plan)
+                for child_org in org.children.all():
+                    self._sync_wix_for_org(child_org, org.plan)
+
+        # Inherited Wix plans via resource-sharing groups / parent orgs
+        for _group, plan in org.get_wix_plans_from_groups():
+            self._sync_wix_for_org(org, plan)
+            triggered = True
+
+        if triggered:
             messages.success(request, _("Wix sync started"))
 
     def post(self, request, *args, **kwargs):

--- a/squarelet/templates/organizations/organization_detail.html
+++ b/squarelet/templates/organizations/organization_detail.html
@@ -24,7 +24,7 @@
         <a href="{% url 'organizations:merge' %}" class="btn ghost">
           {% trans "Merge organization" %}
         </a>
-        {% if organization.plan.wix %}
+        {% if show_wix_sync %}
           <form method="post" style="display: inline;">
             {% csrf_token %}
             <button class="btn caution" type="submit" name="action" value="sync_wix">


### PR DESCRIPTION
Closes #637

- Uses signals on org memberships/parent-child changes to trigger syncs, so it handles frontend and backend changes to organizations.
- Shows “Wix Sync” buttons on orgs if they belong to a resource-sharing group with a Wix subscription
- Syncs all child/member organizations when using the “Wix Sync” button on an org with a Wix subscription and resource-sharing enabled.