### PR TITLE
Only show org admin list to authenticated users

### DIFF
--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -64,10 +64,10 @@ test.describe("Organization Viewing", () => {
       expect(response?.status()).toBe(404);
     });
 
-    test("sees only admins in member list", async ({ page }) => {
+    test("cannot see the org's member list", async ({ page }) => {
       await page.goto("/organizations/e2e-public-org/");
-      await expect(page.locator("#members .user-list")).toBeVisible();
-      await expect(page.locator("#members .user-list .user")).toHaveCount(1); // only admins
+      await expect(page.locator("#members .user-list")).not.toBeVisible();
+      await expect(page.locator("#members .user-list .user")).not.toBeVisible();
     });
 
     test("sees org verification status", async ({ page }) => {

--- a/squarelet/core/management/commands/seed_e2e_data.py
+++ b/squarelet/core/management/commands/seed_e2e_data.py
@@ -109,6 +109,20 @@ class Command(BaseCommand):
             },
         )
 
+        # Create the professional plan (referenced by the user detail view
+        # as the individual upgrade option)
+        Plan.objects.get_or_create(
+            slug="professional",
+            defaults={
+                "name": "Professional",
+                "minimum_users": 1,
+                "base_price": 20,
+                "price_per_user": 5,
+                "for_individuals": True,
+                "for_groups": False,
+            },
+        )
+
         # Create users
         created_users = {}
         for user_spec in USERS:

--- a/squarelet/templates/organizations/organization_detail.html
+++ b/squarelet/templates/organizations/organization_detail.html
@@ -55,6 +55,7 @@
       </a>
     </li>
     {% endif %}
+    {% if user.is_authenticated %}
     <li>
       <a href="#members" class="nav-item">
         {% include "core/icons/people.svg" %}
@@ -65,6 +66,7 @@
         {% endif %}
       </a>
     </li>
+    {% endif %}
     <li>
       <a href="#verification" class="nav-item">
         {% if organization.verified_journalist %}
@@ -232,6 +234,7 @@
     </section>
     {% endif %}
 
+    {% if user.is_authenticated %}
     <section id="members">
       <header>
         <h2>
@@ -273,7 +276,7 @@
             <p>{% trans 'You have requested an invite.' %}</p>
           {% elif rejected_invite %}
             <p>{% trans 'Your request to join this organization was rejected. Please contact an admin if this is a mistake and you need to be added to this organization.' %}</p>
-          {% elif user.is_authenticated and not is_member %}
+          {% elif not is_member %}
             <form method="post">
               {% csrf_token %}
               <button class="btn primary" name="action" value="join" id="join-org-button">
@@ -343,6 +346,7 @@
         {% endif %}
       </main>
     </section>
+    {% endif %}
 
     <section id="verification">
       <header>

--- a/squarelet/templates/organizations/user_list_item.html
+++ b/squarelet/templates/organizations/user_list_item.html
@@ -1,5 +1,6 @@
 {# required css: css/user_list_item.css #}
-{% load thumbnail i18n %}
+{% load thumbnail i18n rules %}
+{% has_perm "organizations.can_manage_members" request.user organization as can_manage_members %}
 {% with avatar=user.avatar %}
 <div class="user">
     {% if avatar %}
@@ -22,7 +23,7 @@
             {% if membership.admin %}
             <span class="orange badge">{% trans "Admin" %}</span>
             {% endif %}
-            {% if user.has_mfa_enabled %}
+            {% if can_manage_members and user.has_mfa_enabled and membership %}
             <span class="green badge">{% trans "2FA" %}</span>
             {% endif %}
             {% if request.user.is_authenticated %}

--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -38,10 +38,11 @@ class TestUserDetailView(ViewTestMixin):
             user.organizations.filter(individual=False)
         )
 
-    def test_get_without_professional_plan(self, rf, user_factory):
+    def test_get_without_professional_plan(self, rf, user_factory, mocker):
         """View should render even if the 'professional' upgrade plan is missing."""
         user = user_factory()
-        assert not Plan.objects.filter(slug="professional").exists()
+        mocker.patch("squarelet.organizations.models.payment.Plan.delete_stripe_plan")
+        Plan.objects.filter(slug="professional").delete()
         response = self.call_view(rf, user, username=user.username)
         assert response.status_code == 200
         assert response.context_data["upgrade_plan"] is None

--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -38,6 +38,14 @@ class TestUserDetailView(ViewTestMixin):
             user.organizations.filter(individual=False)
         )
 
+    def test_get_without_professional_plan(self, rf, user_factory):
+        """View should render even if the 'professional' upgrade plan is missing."""
+        user = user_factory()
+        assert not Plan.objects.filter(slug="professional").exists()
+        response = self.call_view(rf, user, username=user.username)
+        assert response.status_code == 200
+        assert response.context_data["upgrade_plan"] is None
+
     def test_get_bad(self, rf, user_factory):
         user = user_factory()
         other_user = user_factory()

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -155,7 +155,7 @@ class UserDetailView(LoginRequiredMixin, StaffAccessMixin, AdminLinkMixin, Detai
         # Get the current plan and subscription, if any
         individual_org = user.individual_organization
         current_plan = None
-        upgrade_plan = Plan.objects.get(slug="professional")
+        upgrade_plan = Plan.objects.filter(slug="professional").first()
         subscription = None
         if hasattr(individual_org, "subscriptions"):
             subscription = individual_org.subscriptions.first()


### PR DESCRIPTION
This makes it harder for bad actors to identify organization admins for targeting in social engineering attacks.