### PR TITLE
Hides admin emails for users with unverified emails

### DIFF
--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -114,8 +114,21 @@ test.describe("Organization Viewing", () => {
       await expect(page.locator("#members .user-list .user")).toHaveCount(1); // only admins
     });
 
-    test("sees admin emails", async ({ page }) => {
+    test("cannot see admin emails without a verified email", async ({ page }) => {
+      // Unverify e2e-regular's email so we can test the unverified case
+      runManageCommand(
+        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=False)"`,
+      );
+
       await page.goto("/organizations/e2e-public-org/");
+      await expect(page.locator(".user .info .caption")).toHaveCount(0);
+
+      // Re-verify the email and confirm admin emails now appear
+      runManageCommand(
+        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=True)"`,
+      );
+
+      await page.reload();
       await expect(page.locator(".user .info .caption").first()).toBeVisible();
     });
   });

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -1255,18 +1255,16 @@ class TestCreate(ViewTestMixin):
         assert user.email in organization.receipt_emails.values_list("email", flat=True)
 
     def test_get_unverified_email(self, rf, user_factory):
-        """User without verified email sees verification message"""
+        """User without verified email can still access the page"""
         user = user_factory(email_verified=False)
         response = self.call_view(rf, user)
         assert response.status_code == 200
-        assert response.context_data["has_verified_email"] is False
 
     def test_get_verified_email(self, rf, user_factory):
         """User with verified email sees the creation form"""
         user = user_factory(email_verified=True)
         response = self.call_view(rf, user)
         assert response.status_code == 200
-        assert response.context_data["has_verified_email"] is True
         assert "form" in response.context_data
 
     def test_post_creates_org_despite_matching_name(

--- a/squarelet/organizations/views/create.py
+++ b/squarelet/organizations/views/create.py
@@ -15,13 +15,6 @@ class Create(LoginRequiredMixin, CreateView):
     form_class = CreateForm
     template_name = "organizations/organization_create_form.html"
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["has_verified_email"] = self.request.user.emailaddress_set.filter(
-            verified=True
-        ).exists()
-        return context
-
     @transaction.atomic
     def form_valid(self, form):
         """The organization creator is automatically a member and admin"""

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -40,9 +40,6 @@ class Detail(AdminLinkMixin, DetailView):
         if user.is_authenticated:
             context["is_admin"] = org.has_admin(user)
             context["is_member"] = org.has_member(user)
-            context["has_verified_email"] = user.emailaddress_set.filter(
-                verified=True
-            ).exists()
 
             if user.has_perm("organizations.can_manage_members", org):
                 context["pending_requests"] = org.invitations.get_pending_requests()
@@ -364,7 +361,6 @@ class List(ListView):
             + context["pending_invitations"]
             + context["potential_orgs"]
         )
-        context["has_verified_email"] = bool(user.get_verified_emails())
         context["admin_orgs"] = list(
             user.organizations.filter(individual=False, memberships__admin=True)
         )

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -40,6 +40,9 @@ class Detail(AdminLinkMixin, DetailView):
         if user.is_authenticated:
             context["is_admin"] = org.has_admin(user)
             context["is_member"] = org.has_member(user)
+            context["has_verified_email"] = user.emailaddress_set.filter(
+                verified=True
+            ).exists()
 
             if user.has_perm("organizations.can_manage_members", org):
                 context["pending_requests"] = org.invitations.get_pending_requests()

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -246,9 +246,6 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["admin"] = self.request.user
-        context["has_verified_email"] = self.request.user.emailaddress_set.filter(
-            verified=True
-        ).exists()
         # Use member_users() for consistent sorting: current user, admins, then members
         users = self.object.member_users(self.request)
         context["members"] = [u.org_membership_list[0] for u in users]

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -246,6 +246,9 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["admin"] = self.request.user
+        context["has_verified_email"] = self.request.user.emailaddress_set.filter(
+            verified=True
+        ).exists()
         # Use member_users() for consistent sorting: current user, admins, then members
         users = self.object.member_users(self.request)
         context["members"] = [u.org_membership_list[0] for u in users]

--- a/squarelet/templates/organizations/organization_create_form.html
+++ b/squarelet/templates/organizations/organization_create_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static i18n django_vite crispy_forms_tags %}
+{% load static i18n django_vite crispy_forms_tags email_verification %}
 {% block title %}Create organization{% endblock %}
 
 {% block vite %}
@@ -9,8 +9,8 @@
 
 {% block content %}
 
-<div class="_cls-content create-organization {% if not has_verified_email %}unverified{% endif %}">
-  {% if not has_verified_email %}
+<div class="_cls-content create-organization {% if not request.user|has_verified_email %}unverified{% endif %}">
+  {% if not request.user|has_verified_email %}
     <h2>{% trans "Email verification required" %}</h2>
     <p>
       {% blocktrans %}

--- a/squarelet/templates/organizations/organization_list.html
+++ b/squarelet/templates/organizations/organization_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static i18n avatar django_vite %}
+{% load static i18n avatar django_vite email_verification %}
 
 {% block title %}Organizations{% endblock %}
 
@@ -102,7 +102,7 @@
     </section>
 
     <section class="invites">
-      {% if not has_verified_email %}
+      {% if not request.user|has_verified_email %}
       <div class="empty">
         <p>
           {% blocktrans %}

--- a/squarelet/templates/organizations/user_list_item.html
+++ b/squarelet/templates/organizations/user_list_item.html
@@ -26,7 +26,7 @@
             {% if can_manage_members and user.has_mfa_enabled and membership %}
             <span class="green badge">{% trans "2FA" %}</span>
             {% endif %}
-            {% if request.user.is_authenticated %}
+            {% if request.user.is_authenticated and has_verified_email %}
             <span class="caption">{{ user.email }}</span>
             {% endif %}
         </div>

--- a/squarelet/templates/organizations/user_list_item.html
+++ b/squarelet/templates/organizations/user_list_item.html
@@ -1,5 +1,5 @@
 {# required css: css/user_list_item.css #}
-{% load thumbnail i18n rules %}
+{% load thumbnail i18n rules email_verification %}
 {% has_perm "organizations.can_manage_members" request.user organization as can_manage_members %}
 {% with avatar=user.avatar %}
 <div class="user">
@@ -26,7 +26,7 @@
             {% if can_manage_members and user.has_mfa_enabled and membership %}
             <span class="green badge">{% trans "2FA" %}</span>
             {% endif %}
-            {% if request.user.is_authenticated and has_verified_email %}
+            {% if request.user|has_verified_email %}
             <span class="caption">{{ user.email }}</span>
             {% endif %}
         </div>

--- a/squarelet/users/templatetags/email_verification.py
+++ b/squarelet/users/templatetags/email_verification.py
@@ -1,0 +1,12 @@
+# Django
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def has_verified_email(user):
+    """Return True if the user has at least one verified email address."""
+    if not user or not user.is_authenticated:
+        return False
+    return user.emailaddress_set.filter(verified=True).exists()


### PR DESCRIPTION
Closes #652

Protects user privacy by only sharing the email addresses of org admins with users who have confirmed their email. This prevents fraudulent  users from accessing email address data.

Improves code quality by adding a template tag filter for `request.user|has_verified_email`, removing the need to get and insert this check into view context.