### PR TITLE
Restrict invitation actions to users with confirmed emails

### DIFF
--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -465,8 +465,9 @@ test.describe("Member Management", () => {
     const anonContext = await browser.newContext({ ignoreHTTPSErrors: true });
     const anonPage = await anonContext.newPage();
     await anonPage.goto(`https://dev.squarelet.com${invitationPath}`);
-    await expect(anonPage.locator("a:has-text('Sign Up')")).toBeVisible();
-    await expect(anonPage.locator("a:has-text('Log In')")).toBeVisible();
+    const controls = anonPage.locator(".control-group");
+    await expect(controls.locator("a:has-text('Sign Up')")).toBeVisible();
+    await expect(controls.locator("a:has-text('Log In')")).toBeVisible();
     await anonContext.close();
 
     // Verify the link invitation shows "Copy link" (not "Resend") on manage-members

--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -1074,4 +1074,71 @@ test.describe("Invitations for unverified users", () => {
     await expect(invitation).toBeVisible();
     await expect(invitation.locator('button[value="accept"]')).toBeVisible();
   });
+
+  // Look up the invitation-link landing page (/organizations/<uuid>/invitation/)
+  // for the pending invitation addressed to the given email.
+  function invitationPathFor(email: string): string {
+    const out = runManageCommand(
+      `shell -c "from squarelet.organizations.models.invitation import Invitation;` +
+        ` print(Invitation.objects.get_pending().filter(email='${email}',` +
+        ` organization__slug='e2e-public-org').latest('created_at').uuid)"`,
+    );
+    const match = out.match(/[0-9a-f-]{36}/);
+    if (!match) {
+      throw new Error(`No pending invitation found for ${email}: ${out}`);
+    }
+    return `/organizations/${match[0]}/invitation/`;
+  }
+
+  test("can accept a member invitation from the email-link page", async ({
+    page,
+  }) => {
+    await inviteUnverifiedMember(page);
+    const invitationPath = invitationPathFor("e2e-unverified@example.com");
+
+    await login(page, "e2e-unverified");
+    await page.goto(invitationPath);
+
+    // The shared accept-form partial renders working Accept/Reject controls
+    const controls = page.locator(".control-group");
+    await expect(controls.locator('button[value="accept"]')).toBeVisible();
+    await controls.locator('button[value="accept"]').click();
+    await expectFlashMessage(page, "success");
+
+    // The user is now a member of the organization
+    await login(page, "e2e-admin");
+    await page.goto("/organizations/e2e-public-org/manage-members/");
+    await expect(
+      page.locator(".membership", {
+        has: page.locator("h3", { hasText: "e2e-unverified" }),
+      }),
+    ).toBeVisible();
+  });
+
+  test("admin invitation email-link page shows the verification gate", async ({
+    page,
+  }) => {
+    // Admin sends an admin-role invitation to e2e-unverified
+    await login(page, "e2e-admin");
+    await clearPendingInvitations(page);
+    await page.locator("#user-select input").fill("e2e-unverified@example.com");
+    await expect(page.locator("button.creatable-row")).toBeEnabled({
+      timeout: 5_000,
+    });
+    await page.locator("button.creatable-row").click();
+    await page.locator("select[name='role']").selectOption("1");
+    await page.locator('button[value="addmember"]').click();
+    await expectFlashMessage(page, "success");
+
+    const invitationPath = invitationPathFor("e2e-unverified@example.com");
+
+    await login(page, "e2e-unverified");
+    await page.goto(invitationPath);
+
+    // The shared partial gates acceptance behind email confirmation, the same
+    // as every other accept surface — no accept button, a confirm-email link.
+    const controls = page.locator(".control-group");
+    await expect(controls.locator('button[value="accept"]')).toHaveCount(0);
+    await expect(controls.locator('a[href$="#accounts"]')).toBeVisible();
+  });
 });

--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   login,
   inviteByEmail,
@@ -931,5 +931,147 @@ test.describe("Auto-Join Domain Management", () => {
 
     // Verify auto-join is now disabled on the detail page
     await expect(page.locator('button[value="enable_autojoin"]')).toBeVisible();
+  });
+});
+
+test.describe("Invitations for unverified users", () => {
+  // e2e-unverified is seeded with an unconfirmed email and no team
+  // memberships.  clear_invitations also resets memberships back to the
+  // seeded state, removing anything accepted during a test.
+  test.afterEach(() => {
+    runManageCommand("seed_e2e_data --action clear_invitations");
+  });
+
+  // Revoke any stale pending invitations on manage-members before inviting.
+  async function clearPendingInvitations(page: Page) {
+    await page.goto("/organizations/e2e-public-org/manage-members/");
+    while (await page.locator('button[value="revokeinvite"]').count()) {
+      await page.locator('button[value="revokeinvite"]').first().click();
+      await page.goto("/organizations/e2e-public-org/manage-members/");
+    }
+  }
+
+  // Send a member-role invitation (the default role) to e2e-unverified —
+  // the shared setup for the render-surface tests below.
+  async function inviteUnverifiedMember(page: Page) {
+    await login(page, "e2e-admin");
+    await clearPendingInvitations(page);
+    await inviteByEmail(page, "e2e-unverified@example.com");
+    await expectFlashMessage(page, "success");
+  }
+
+  test("can see and accept a member invitation", async ({ page }) => {
+    await inviteUnverifiedMember(page);
+
+    // The unverified user logs in and views their account page
+    await login(page, "e2e-unverified");
+    await page.goto("/users/e2e-unverified/");
+
+    // The member invitation is visible and can be accepted
+    const invitation = page.locator(".invite", {
+      has: page.locator("text=e2e-public-org"),
+    });
+    await expect(invitation).toBeVisible();
+    await expect(invitation.locator('button[value="accept"]')).toBeVisible();
+
+    await invitation.locator('button[value="accept"]').click();
+    await expectFlashMessage(page, "success");
+
+    // The user is now a member of the organization
+    await login(page, "e2e-admin");
+    await page.goto("/organizations/e2e-public-org/manage-members/");
+    const membership = page.locator(".membership", {
+      has: page.locator("h3", { hasText: "e2e-unverified" }),
+    });
+    await expect(membership).toBeVisible();
+  });
+
+  test("sees an admin invitation but cannot accept it without verifying", async ({
+    page,
+  }) => {
+    // Admin sends an admin-role invitation to e2e-unverified
+    await login(page, "e2e-admin");
+    await clearPendingInvitations(page);
+    await page.locator("#user-select input").fill("e2e-unverified@example.com");
+    await expect(page.locator("button.creatable-row")).toBeEnabled({
+      timeout: 5_000,
+    });
+    await page.locator("button.creatable-row").click();
+    await page.locator("select[name='role']").selectOption("1");
+    await page.locator('button[value="addmember"]').click();
+    await expectFlashMessage(page, "success");
+
+    // The unverified user logs in and views their account page
+    await login(page, "e2e-unverified");
+    await page.goto("/users/e2e-unverified/");
+
+    // The admin invitation is visible...
+    const invitation = page.locator(".invite", {
+      has: page.locator("text=e2e-public-org"),
+    });
+    await expect(invitation).toBeVisible();
+
+    // ...but it offers an email-confirmation prompt instead of an accept button
+    await expect(invitation.locator('button[value="accept"]')).toHaveCount(0);
+    await expect(invitation.locator('a[href$="#accounts"]')).toBeVisible();
+  });
+
+  test("see a member invitation on the organizations list page", async ({
+    page,
+  }) => {
+    await inviteUnverifiedMember(page);
+
+    await login(page, "e2e-unverified");
+    await page.goto("/organizations/");
+
+    // The invitation appears in the pending-invitations section and is acceptable
+    const invitation = page.locator("#invitations .invite", {
+      has: page.locator("text=e2e-public-org"),
+    });
+    await expect(invitation).toBeVisible();
+    await expect(invitation.locator('button[value="accept"]')).toBeVisible();
+  });
+
+  test("see a member invitation in their invitation history", async ({
+    page,
+  }) => {
+    await inviteUnverifiedMember(page);
+
+    await login(page, "e2e-unverified");
+    await page.goto("/users/e2e-unverified/invitations/");
+
+    // The invitation is listed and can be accepted from the history page
+    await expect(
+      page.locator(".invitation-history-table tbody tr"),
+    ).toHaveCount(1);
+    await expect(
+      page.locator(".invitation-actions button[value='accept']"),
+    ).toBeVisible();
+  });
+
+  test("see a member invitation during onboarding", async ({ page }) => {
+    await inviteUnverifiedMember(page);
+
+    // Logging in redirects the unverified user into onboarding
+    await login(page, "e2e-unverified");
+
+    // The first onboarding step asks them to confirm their email — advance past it
+    const confirmStep = page.locator(
+      "input[name='step'][value='confirm_email']",
+    );
+    if (await confirmStep.count()) {
+      await page
+        .locator(
+          "form:has(input[name='step'][value='confirm_email']) button[type='submit']",
+        )
+        .click();
+    }
+
+    // The join-organization step surfaces the pending invitation
+    const invitation = page.locator(".invite", {
+      has: page.locator("text=e2e-public-org"),
+    });
+    await expect(invitation).toBeVisible();
+    await expect(invitation.locator('button[value="accept"]')).toBeVisible();
   });
 });

--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -465,8 +465,8 @@ test.describe("Member Management", () => {
     const anonContext = await browser.newContext({ ignoreHTTPSErrors: true });
     const anonPage = await anonContext.newPage();
     await anonPage.goto(`https://dev.squarelet.com${invitationPath}`);
-    await expect(anonPage.locator("form a:has-text('Sign Up')")).toBeVisible();
-    await expect(anonPage.locator("form a:has-text('Log In')")).toBeVisible();
+    await expect(anonPage.locator("a:has-text('Sign Up')")).toBeVisible();
+    await expect(anonPage.locator("a:has-text('Log In')")).toBeVisible();
     await anonContext.close();
 
     // Verify the link invitation shows "Copy link" (not "Resend") on manage-members

--- a/frontend/css/gps.css
+++ b/frontend/css/gps.css
@@ -442,6 +442,7 @@ strong {
 
 .empty {
   display: flex;
+  margin: 0 auto;
   width: 16.5rem;
   padding: 1.5rem;
   flex-direction: column;
@@ -453,12 +454,18 @@ strong {
   border: 1.282px solid var(--Gray-2, #d8dee2);
 }
 
+.empty--no-border {
+  border: none;
+}
+
 .empty p {
   align-self: stretch;
-  margin: 0;
-  color: var(--gray-4);
-  text-align: center;
   font-family: "Source Sans Pro";
+  line-height: 1.4;
+  color: var(--gray-4);
+  margin: 0 auto;
+  text-align: center;
+  max-width: 60ch;
 }
 
 .card {

--- a/squarelet/organizations/forms.py
+++ b/squarelet/organizations/forms.py
@@ -297,6 +297,51 @@ class AddMemberForm(forms.Form):
         return cleaned_data
 
 
+class InvitationAcceptForm(forms.Form):
+    """
+    Validates that a user can accept an invitation.
+    Admin-role invitations require the user to have a verified email address.
+    Exposes a class method to bind the class to an Invitation object.
+    """
+
+    template_name = "organizations/invitation_accept_form.html"
+
+    def __init__(self, *args, invitation, user, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.invitation = invitation
+        self.user = user
+
+    @property
+    def requires_email_verification(self):
+        return (
+            self.invitation.role == InvitationRole.admin
+            and not self.user.emailaddress_set.filter(verified=True).exists()
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if self.requires_email_verification:
+            raise forms.ValidationError(
+                _("You must verify your email address before accepting "
+                  "an admin invitation.")
+            )
+        return cleaned_data
+
+    def get_context(self):
+        context = super().get_context()
+        context["invitation"] = self.invitation
+        context["user"] = self.user
+        context["requires_email_verification"] = self.requires_email_verification
+        return context
+
+    @classmethod
+    def attach_to_invitations(cls, invitations, user):
+        """Attach an accept_form to each invitation in the list."""
+        for invitation in invitations:
+            invitation.accept_form = cls(invitation=invitation, user=user)
+        return invitations
+
+
 class MergeForm(forms.Form):
     """A form to merge two organizations"""
 

--- a/squarelet/organizations/forms.py
+++ b/squarelet/organizations/forms.py
@@ -2,6 +2,7 @@
 from django import forms
 from django.core.validators import validate_email
 from django.db.models.aggregates import Min
+from django.middleware.csrf import get_token
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -306,10 +307,11 @@ class InvitationAcceptForm(forms.Form):
 
     template_name = "organizations/invitation_accept_form.html"
 
-    def __init__(self, *args, invitation, user, **kwargs):
+    def __init__(self, *args, invitation, user, request=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.invitation = invitation
         self.user = user
+        self.request = request
 
     @property
     def requires_email_verification(self):
@@ -334,13 +336,17 @@ class InvitationAcceptForm(forms.Form):
         context["invitation"] = self.invitation
         context["user"] = self.user
         context["requires_email_verification"] = self.requires_email_verification
+        if self.request:
+            context["csrf_token"] = get_token(self.request)
         return context
 
     @classmethod
-    def attach_to_invitations(cls, invitations, user):
+    def attach_to_invitations(cls, invitations, user, request=None):
         """Attach an accept_form to each invitation in the list."""
         for invitation in invitations:
-            invitation.accept_form = cls(invitation=invitation, user=user)
+            invitation.accept_form = cls(
+                invitation=invitation, user=user, request=request
+            )
         return invitations
 
 

--- a/squarelet/organizations/forms.py
+++ b/squarelet/organizations/forms.py
@@ -322,8 +322,10 @@ class InvitationAcceptForm(forms.Form):
         cleaned_data = super().clean()
         if self.requires_email_verification:
             raise forms.ValidationError(
-                _("You must verify your email address before accepting "
-                  "an admin invitation.")
+                _(
+                    "You must verify your email address before accepting "
+                    "an admin invitation."
+                )
             )
         return cleaned_data
 

--- a/squarelet/organizations/models/invitation.py
+++ b/squarelet/organizations/models/invitation.py
@@ -103,6 +103,10 @@ class Invitation(models.Model):
     def __str__(self):
         return f"Invitation: {self.uuid}"
 
+    @property
+    def is_admin_role(self):
+        return self.role == InvitationRole.admin
+
     def send(self):
 
         if self.request:

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -245,11 +245,16 @@ class InvitationQuerySet(models.QuerySet):
         return self.exclude(rejected_at=None)
 
     def for_user(self, user):
-        """Filter invitations/requests for a user's verified emails or user field"""
-        verified_emails = user.get_verified_emails()
-        if not verified_emails:
-            return self.none()
-        return self.filter(Q(email__in=verified_emails) | Q(user=user))
+        """Filter invitations/requests for a user's emails or user field
+
+        Matches against all of the user's email addresses (verified or not) so
+        that users who haven't confirmed their email can still see their
+        invitations.  Accepting an admin-role invitation is separately gated
+        behind email verification (see
+        InvitationAcceptForm.requires_email_verification).
+        """
+        emails = user.get_emails()
+        return self.filter(Q(email__in=emails) | Q(user=user))
 
     def get_user_invitations(self, user):
         """Get all invitations (request=False) for a user"""

--- a/squarelet/organizations/tests/test_querysets_invitation.py
+++ b/squarelet/organizations/tests/test_querysets_invitation.py
@@ -146,16 +146,17 @@ class TestInvitationQuerySetStatus(TestCase):
         assert queryset.count() == 2
 
     @pytest.mark.django_db
-    def test_for_user_no_verified_emails(self):
-        """Test for_user() returns empty queryset when user has no verified emails"""
+    def test_for_user_unverified_email(self):
+        """for_user() matches invitations to a user's email even if unverified"""
         user = UserFactory(email="user@example.com", email_verified=False)
         org = OrganizationFactory()
 
-        # Create invitation that would match if email was verified
-        InvitationFactory(email="user@example.com", organization=org)
+        # Invitation to the user's email, which they have not yet verified
+        invitation = InvitationFactory(email="user@example.com", organization=org)
 
         queryset = Invitation.objects.for_user(user)
-        assert queryset.count() == 0
+        assert invitation in queryset
+        assert queryset.count() == 1
 
     @pytest.mark.django_db
     def test_for_user_multiple_verified_emails(self):
@@ -167,12 +168,10 @@ class TestInvitationQuerySetStatus(TestCase):
         invitation1 = InvitationFactory(email="primary@example.com", organization=org)
         InvitationFactory(email="secondary@example.com", organization=org)
 
-        # Mock get_verified_emails to return multiple emails
-        # In real code, this would involve creating EmailAddress records
-        # For now, we'll just test the primary email case
+        # The user only owns primary@example.com, so the invitation addressed
+        # to secondary@example.com (an email they don't have) is not matched.
         queryset = Invitation.objects.for_user(user)
         assert invitation1 in queryset
-        # invitation2 won't be included unless secondary email is verified
         assert queryset.count() == 1
 
     @pytest.mark.django_db
@@ -280,28 +279,30 @@ class TestInvitationQuerySetStatus(TestCase):
         assert queryset[2] == request1
 
     @pytest.mark.django_db
-    def test_get_user_invitations_no_verified_emails(self):
-        """Test get_user_invitations() returns empty when no verified emails"""
+    def test_get_user_invitations_unverified_email(self):
+        """get_user_invitations() matches a user's email even if unverified"""
         user = UserFactory(email="user@example.com", email_verified=False)
         org = OrganizationFactory()
 
-        # Create invitation that would match if verified
-        InvitationFactory(email="user@example.com", organization=org)
+        # Invitation to the user's email, which they have not yet verified
+        invitation = InvitationFactory(email="user@example.com", organization=org)
 
         queryset = Invitation.objects.get_user_invitations(user)
-        assert queryset.count() == 0
+        assert invitation in queryset
+        assert queryset.count() == 1
 
     @pytest.mark.django_db
-    def test_get_user_requests_no_verified_emails(self):
-        """Test get_user_requests() returns empty when no verified emails"""
+    def test_get_user_requests_unverified_email(self):
+        """get_user_requests() matches a user's requests even if unverified"""
         user = UserFactory(email="user@example.com", email_verified=False)
         org = OrganizationFactory()
 
-        # Create request that would match if verified
-        InvitationRequestFactory(user=user, organization=org)
+        # Request from the user, who has not yet verified their email
+        request = InvitationRequestFactory(user=user, organization=org)
 
         queryset = Invitation.objects.get_user_requests(user)
-        assert queryset.count() == 0
+        assert request in queryset
+        assert queryset.count() == 1
 
     @pytest.mark.django_db
     def test_get_org_invitations_filters_by_request_false(self):
@@ -467,16 +468,17 @@ class TestInvitationQuerySetForUser(TestCase):
         assert queryset.count() == 2
 
     @pytest.mark.django_db
-    def test_for_user_no_verified_emails(self):
-        """Test for_user() returns empty queryset when user has no verified emails"""
+    def test_for_user_unverified_email(self):
+        """for_user() matches invitations to a user's email even if unverified"""
         user = UserFactory(email="user@example.com", email_verified=False)
         org = OrganizationFactory()
 
-        # Create invitation that would match if email was verified
-        InvitationFactory(email="user@example.com", organization=org)
+        # Invitation to the user's email, which they have not yet verified
+        invitation = InvitationFactory(email="user@example.com", organization=org)
 
         queryset = Invitation.objects.for_user(user)
-        assert queryset.count() == 0
+        assert invitation in queryset
+        assert queryset.count() == 1
 
     @pytest.mark.django_db
     def test_for_user_multiple_verified_emails(self):
@@ -488,12 +490,10 @@ class TestInvitationQuerySetForUser(TestCase):
         invitation1 = InvitationFactory(email="primary@example.com", organization=org)
         InvitationFactory(email="secondary@example.com", organization=org)
 
-        # Mock get_verified_emails to return multiple emails
-        # In real code, this would involve creating EmailAddress records
-        # For now, we'll just test the primary email case
+        # The user only owns primary@example.com, so the invitation addressed
+        # to secondary@example.com (an email they don't have) is not matched.
         queryset = Invitation.objects.for_user(user)
         assert invitation1 in queryset
-        # invitation2 won't be included unless secondary email is verified
         assert queryset.count() == 1
 
 
@@ -605,25 +605,27 @@ class TestInvitationQuerySetUserInvitations(TestCase):
         assert queryset[2] == request1
 
     @pytest.mark.django_db
-    def test_get_user_invitations_no_verified_emails(self):
-        """Test get_user_invitations() returns empty when no verified emails"""
+    def test_get_user_invitations_unverified_email(self):
+        """get_user_invitations() matches a user's email even if unverified"""
         user = UserFactory(email="user@example.com", email_verified=False)
         org = OrganizationFactory()
 
-        # Create invitation that would match if verified
-        InvitationFactory(email="user@example.com", organization=org)
+        # Invitation to the user's email, which they have not yet verified
+        invitation = InvitationFactory(email="user@example.com", organization=org)
 
         queryset = Invitation.objects.get_user_invitations(user)
-        assert queryset.count() == 0
+        assert invitation in queryset
+        assert queryset.count() == 1
 
     @pytest.mark.django_db
-    def test_get_user_requests_no_verified_emails(self):
-        """Test get_user_requests() returns empty when no verified emails"""
+    def test_get_user_requests_unverified_email(self):
+        """get_user_requests() matches a user's requests even if unverified"""
         user = UserFactory(email="user@example.com", email_verified=False)
         org = OrganizationFactory()
 
-        # Create request that would match if verified
-        InvitationRequestFactory(user=user, organization=org)
+        # Request from the user, who has not yet verified their email
+        request = InvitationRequestFactory(user=user, organization=org)
 
         queryset = Invitation.objects.get_user_requests(user)
-        assert queryset.count() == 0
+        assert request in queryset
+        assert queryset.count() == 1

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -1672,9 +1672,40 @@ class TestInvitationAccept(ViewTestMixin):
     view = views.InvitationAccept
     url = "/organizations/{uuid}/invitation/"
 
+    def _create_verified_email(self, user):
+        EmailAddress.objects.update_or_create(
+            user=user,
+            email=user.email,
+            defaults={"verified": True, "primary": True},
+        )
+
     def test_accept(self, rf, invitation_factory, user_factory):
         invitation = invitation_factory()
         user = user_factory()
+        self.call_view(rf, user, {"action": "accept"}, uuid=invitation.uuid)
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is not None
+        assert invitation.organization.has_member(user)
+
+    def test_accept_admin_requires_verified_email(
+        self, rf, invitation_factory, user_factory
+    ):
+        """Users without a verified email cannot accept admin invitations"""
+        invitation = invitation_factory(role=InvitationRole.admin)
+        user = user_factory()
+        response = self.call_view(rf, user, {"action": "accept"}, uuid=invitation.uuid)
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is None
+        assert not invitation.organization.has_member(user)
+        assert response.status_code == 302
+
+    def test_accept_admin_with_verified_email(
+        self, rf, invitation_factory, user_factory
+    ):
+        """Users with a verified email can accept admin invitations"""
+        invitation = invitation_factory(role=InvitationRole.admin)
+        user = user_factory()
+        self._create_verified_email(user)
         self.call_view(rf, user, {"action": "accept"}, uuid=invitation.uuid)
         invitation.refresh_from_db()
         assert invitation.accepted_at is not None

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -18,6 +18,7 @@ from datetime import datetime
 # Squarelet
 from squarelet.core.mixins import AdminLinkMixin
 from squarelet.core.utils import get_redirect_url, is_rate_limited, new_action
+from squarelet.organizations.forms import InvitationAcceptForm
 from squarelet.organizations.models import Invitation, Membership, Organization, Plan
 from squarelet.organizations.payments.factory import get_payment_provider
 from squarelet.organizations.tasks import sync_wix
@@ -361,7 +362,9 @@ class List(ListView):
         context["potential_orgs"] = []
         if user.is_authenticated:
             context["pending_requests"] = list(user.get_pending_requests())
-            context["pending_invitations"] = list(user.get_pending_invitations())
+            context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
+                list(user.get_pending_invitations()), user
+            )
             context["potential_orgs"] = list(user.get_potential_organizations())
 
         context["has_pending"] = bool(
@@ -378,7 +381,9 @@ class List(ListView):
             ).get_viewable(self.request.user)
         )
         context["potential_organizations"] = list(user.get_potential_organizations())
-        context["pending_invitations"] = list(user.get_pending_invitations())
+        context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
+            list(user.get_pending_invitations()), user
+        )
 
         return context
 

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -363,7 +363,7 @@ class List(ListView):
         if user.is_authenticated:
             context["pending_requests"] = list(user.get_pending_requests())
             context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
-                list(user.get_pending_invitations()), user
+                list(user.get_pending_invitations()), user, request=self.request
             )
             context["potential_orgs"] = list(user.get_potential_organizations())
 
@@ -382,7 +382,7 @@ class List(ListView):
         )
         context["potential_organizations"] = list(user.get_potential_organizations())
         context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
-            list(user.get_pending_invitations()), user
+            list(user.get_pending_invitations()), user, request=self.request
         )
 
         return context

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -10,7 +10,7 @@ from django.views.generic import DetailView, ListView
 # Squarelet
 from squarelet.core.utils import get_redirect_url, new_action, pluralize
 from squarelet.organizations.choices import InvitationRole
-from squarelet.organizations.forms import AddMemberForm
+from squarelet.organizations.forms import AddMemberForm, InvitationAcceptForm
 from squarelet.organizations.mixins import OrganizationPermissionMixin
 from squarelet.organizations.models import Invitation, Membership, Organization
 from squarelet.users.models import User
@@ -283,6 +283,14 @@ class InvitationAccept(DetailView):
     slug_field = "uuid"
     slug_url_kwarg = "uuid"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if self.request.user.is_authenticated:
+            context["accept_form"] = InvitationAcceptForm(
+                invitation=self.object, user=self.request.user
+            )
+        return context
+
     def dispatch(self, request, *args, **kwargs):
         """
         If the user is not authenticated, store the invitation in the session,
@@ -313,15 +321,12 @@ class InvitationAccept(DetailView):
         return handler(request, invitation)
 
     def _accept(self, request, invitation):
-        if (
-            invitation.role == InvitationRole.admin
-            and not request.user.emailaddress_set.filter(verified=True).exists()
-        ):
-            messages.error(
-                request,
-                "You must verify your email address before accepting "
-                "an admin invitation.",
-            )
+        form = InvitationAcceptForm(
+            request.POST, invitation=invitation, user=request.user
+        )
+        if not form.is_valid():
+            for error in form.non_field_errors():
+                messages.error(request, error)
             return redirect("organizations:invitation", uuid=invitation.uuid)
         invitation.accept(request.user)
         messages.success(request, "Invitation accepted")

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -313,6 +313,16 @@ class InvitationAccept(DetailView):
         return handler(request, invitation)
 
     def _accept(self, request, invitation):
+        if (
+            invitation.role == InvitationRole.admin
+            and not request.user.emailaddress_set.filter(verified=True).exists()
+        ):
+            messages.error(
+                request,
+                "You must verify your email address before accepting "
+                "an admin invitation.",
+            )
+            return redirect("organizations:invitation", uuid=invitation.uuid)
         invitation.accept(request.user)
         messages.success(request, "Invitation accepted")
         return get_redirect_url(request, redirect(invitation.organization))

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -287,7 +287,9 @@ class InvitationAccept(DetailView):
         context = super().get_context_data(**kwargs)
         if self.request.user.is_authenticated:
             context["accept_form"] = InvitationAcceptForm(
-                invitation=self.object, user=self.request.user
+                invitation=self.object,
+                user=self.request.user,
+                request=self.request,
             )
         return context
 

--- a/squarelet/templates/account/onboarding/join_org.html
+++ b/squarelet/templates/account/onboarding/join_org.html
@@ -51,15 +51,7 @@
         <div class="invite">
           {% include "account/team_list_item.html" with organization=invite.organization %}
           
-          <form method="post" action="{% url "organizations:invitation" uuid=invite.uuid %}" class="actions">
-            {% csrf_token %}
-            <button class="btn primary ghost" type="submit" name="action" value="accept">
-              {% trans "Accept" %}
-            </button>
-            <button class="btn danger ghost" type="submit" name="action" value="reject">
-              {% trans "Reject" %}
-            </button>
-          </form>
+          {{ invite.accept_form }}
         </div>
         {% endfor %}
       </div>

--- a/squarelet/templates/organizations/invitation_accept_form.html
+++ b/squarelet/templates/organizations/invitation_accept_form.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% if requires_email_verification %}
+<form class="email-actions" action="{% url "account_email" %}" method="post">
+  {% csrf_token %}
+  <input type="hidden" name="email" value="{{ user.email }}" />
+  <button class="btn small primary" type="submit" name="action_send">
+    {% trans "Verify email to accept" %}
+  </button>
+</form>
+{% else %}
+<form method="post" action="{% url "organizations:invitation" uuid=invitation.uuid %}" class="actions">
+  {% csrf_token %}
+  <button class="btn small primary" type="submit" name="action" value="accept">
+    {% trans "Accept" %}
+  </button>
+  <button class="btn small danger ghost" type="submit" name="action" value="reject">
+    {% trans "Reject" %}
+  </button>
+</form>
+{% endif %}

--- a/squarelet/templates/organizations/invitation_accept_form.html
+++ b/squarelet/templates/organizations/invitation_accept_form.html
@@ -1,12 +1,8 @@
 {% load i18n %}
 {% if requires_email_verification %}
-<form class="email-actions" action="{% url "account_email" %}" method="post">
-  {% csrf_token %}
-  <input type="hidden" name="email" value="{{ user.email }}" />
-  <button class="btn small primary" type="submit" name="action_send">
-    {% trans "Verify email to accept" %}
-  </button>
-</form>
+<a class="btn small primary" href="{% url "users:redirect" %}#accounts">
+  {% trans "Confirm email to accept" %}
+</a>
 {% else %}
 <form method="post" action="{% url "organizations:invitation" uuid=invitation.uuid %}" class="actions">
   {% csrf_token %}

--- a/squarelet/templates/organizations/invitation_detail.html
+++ b/squarelet/templates/organizations/invitation_detail.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% load thumbnail %}
 {% load i18n %}
-{% load email_verification %}
 
 {% block title %}Organization: {{ invitation.organization.name }}{% endblock %}
 
@@ -53,7 +52,7 @@
           out and sign back in with the account you'd like to use.
         {% endblocktrans %}
       </p>
-      {% if invitation.is_admin_role and not request.user|has_verified_email %}
+      {% if accept_form.requires_email_verification %}
       <p>
         {% blocktrans %}
           You must verify your email address before you can accept an admin invitation.
@@ -83,7 +82,7 @@
       {% endif %}
 
       {% if request.user.is_authenticated %}
-        {% if invitation.is_admin_role and not request.user|has_verified_email %}
+        {% if accept_form.requires_email_verification %}
         <div class="control-group">
           <form class="email-actions" action="{% url "account_email" %}" method="post">
             {% csrf_token %}

--- a/squarelet/templates/organizations/invitation_detail.html
+++ b/squarelet/templates/organizations/invitation_detail.html
@@ -11,6 +11,10 @@
     .container {
       max-width: 32rem;
       margin: 3rem auto;
+      padding: 2rem;
+      background: var(--white);
+      border-radius: 8px;
+      border: 1px solid var(--gray-2);
     }
     h2 {
       font-weight: var(--font-semibold, 600);
@@ -21,6 +25,23 @@
       display: flex;
       gap: 1rem;
       align-items: center;
+    }
+
+    .control-group form {
+      display: contents;
+    }
+    .control-group .button {
+      flex-grow: 1;
+    }
+    .control-group .button.primary {
+      flex-grow: 2;
+    }
+
+    .user-data {
+      font-weight: 500;
+    }
+    .user-data a {
+      text-decoration: underline;
     }
   </style>
 {% endblock %}
@@ -35,86 +56,86 @@
       {% trans "on MuckRock" %}
     </h2>
 
-    <form method="post">
-      {% csrf_token %}
-      <p>
-        {% blocktrans with name=invitation.organization.name %}
-          You have been invited you to join {{ name }}, an organization
-          account on MuckRock. If you have questions or think this might malicious,
-          please reach out to the organization directly to confirm.
-        {% endblocktrans %}
-      </p>
-      {% if request.user.is_authenticated %}
-      <p>
-        {% blocktrans with name=request.user.name email=request.user.email %}
-          You're currently logged in as {{ name }} with {{ email }}. If you'd
-          like to associate this invitation with another account, please sign
-          out and sign back in with the account you'd like to use.
-        {% endblocktrans %}
-      </p>
-      {% if accept_form.requires_email_verification %}
-      <p>
-        {% blocktrans %}
-          You must verify your email address before you can accept an admin invitation.
-        {% endblocktrans %}
-      </p>
-      {% endif %}
-      {% else %}
-      <p>
-        {% blocktrans %}
-        MuckRock is a non-profit organization that builds transparency tools
-        for journalists, researchers and the public.
-        {% endblocktrans %}
-      </p>
-      <p>
-        {% blocktrans %}
-          Before you can accept this account, you need to either create a new
-          account or log in with the account you'd like to join.
-        {% endblocktrans %}
-      </p>
-      <p>
-        {% blocktrans %}
-          Your MuckRock account will give you access to MuckRock,
-          DocumentCloud, FOIA Machine and Big Local News, as well as make it
-          easier to collaborate with your colleagues there.
-        {% endblocktrans %}
-      </p>
-      {% endif %}
+    <p>
+      {% blocktrans with name=invitation.organization.name %}
+        You have been invited you to join {{ name }}, an organization
+        account on MuckRock. If you have questions or think this might malicious,
+        please reach out to the organization directly to confirm.
+      {% endblocktrans %}
+    </p>
+    {% if request.user.is_authenticated %}
+    <p>
+      {% url 'users:redirect' as user_url %}
+      {% blocktrans with name=request.user.name email=request.user.email %}
+        You're currently logged in as <a class="user-data" href="{{ user_url }}">{{ name }}</a> with <span class="user-data">{{ email }}</span>.
+      {% endblocktrans %}
+    </p>
+    <p>
+      {% blocktrans %}
+       If you'd like to associate this invitation with another account,
+       please sign out and sign back in with the account you'd like to use.
+      {% endblocktrans %}
+    {% if accept_form.requires_email_verification %}
+    <p>
+      {% blocktrans %}
+        You must verify your email address before you can accept an admin invitation.
+      {% endblocktrans %}
+    </p>
+    {% endif %}
+    {% else %}
+    <p>
+      <strong>
+      {% blocktrans %}
+        Before you can accept this account, you need to either create a new
+        account or log in with the account you'd like to join.
+      {% endblocktrans %}
+      </strong>
+    </p>
+    <p>
+      {% blocktrans %}
+      MuckRock is a non-profit organization that builds transparency tools
+      for journalists, researchers and the public.
+      {% endblocktrans %}
+    </p>
+    <p>
+      {% blocktrans %}
+        Your MuckRock account will give you access to MuckRock,
+        DocumentCloud, FOIA Machine and Big Local News, as well as make it
+        easier to collaborate with your colleagues there.
+      {% endblocktrans %}
+    </p>
+    {% endif %}
 
-      {% if request.user.is_authenticated %}
-        {% if accept_form.requires_email_verification %}
-        <div class="control-group">
-          <form class="email-actions" action="{% url "account_email" %}" method="post">
-            {% csrf_token %}
-            <input type="hidden" name="email" value="{{request.user.email}}" />
-            <button class="button primary" type="submit" name="action_send">
-              {% trans "Verify your email address" %}
-            </button>
-          </form>
-        </div>
-        {% else %}
-        <div class="control-group">
-            <button class="button primary" type="submit" name="action" value="accept">
-              {% trans "Accept" %}
-            </button>
-            <button class="button caution" type="submit" name="action" value="reject">
-              {% trans "Reject" %}
-            </button>
-          </div>
-        </div>
-        {% endif %}
+    <div class="control-group">
+    {% if request.user.is_authenticated %}
+      {% if accept_form.requires_email_verification %}
+        <form class="email-actions" action="{% url "account_email" %}" method="post">
+          {% csrf_token %}
+          <input type="hidden" name="email" value="{{request.user.email}}" />
+          <button class="button primary" type="submit" name="action_send">
+            {% trans "Verify your email address" %}
+          </button>
+        </form>
       {% else %}
-        <div class="control-group">
-            <a href="{% url "account_signup" %}?next={{request.path}}" class="button primary">
-              {% trans "Sign Up" %}
-            </a>
-            <a href="{% url "account_login" %}?next={{request.path}}" class="button primary ghost">
-              {% trans "Log In" %}
-            </a>
-          </div>
-        </div>
+        <form method="post">
+          {% csrf_token %}
+          <button class="button caution" type="submit" name="action" value="reject">
+            {% trans "Reject" %}
+          </button>
+          <button class="button primary" type="submit" name="action" value="accept">
+            {% trans "Accept Invitation" %}
+          </button>
+        </form>
       {% endif %}
-    </form>
+    {% else %}
+      <a href="{% url "account_signup" %}?next={{request.path}}" class="button primary">
+        {% trans "Sign Up" %}
+      </a>
+      <a href="{% url "account_login" %}?next={{request.path}}" class="button primary ghost">
+        {% trans "Log In" %}
+      </a>
+    {% endif %}
+    </div>
 
   </div>
 {% endblock content %}

--- a/squarelet/templates/organizations/invitation_detail.html
+++ b/squarelet/templates/organizations/invitation_detail.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load thumbnail %}
 {% load i18n %}
+{% load email_verification %}
 
 {% block title %}Organization: {{ invitation.organization.name }}{% endblock %}
 
@@ -52,6 +53,13 @@
           out and sign back in with the account you'd like to use.
         {% endblocktrans %}
       </p>
+      {% if invitation.is_admin_role and not request.user|has_verified_email %}
+      <p>
+        {% blocktrans %}
+          You must verify your email address before you can accept an admin invitation.
+        {% endblocktrans %}
+      </p>
+      {% endif %}
       {% else %}
       <p>
         {% blocktrans %}
@@ -75,6 +83,17 @@
       {% endif %}
 
       {% if request.user.is_authenticated %}
+        {% if invitation.is_admin_role and not request.user|has_verified_email %}
+        <div class="control-group">
+          <form class="email-actions" action="{% url "account_email" %}" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="email" value="{{request.user.email}}" />
+            <button class="button primary" type="submit" name="action_send">
+              {% trans "Verify your email address" %}
+            </button>
+          </form>
+        </div>
+        {% else %}
         <div class="control-group">
             <button class="button primary" type="submit" name="action" value="accept">
               {% trans "Accept" %}
@@ -84,6 +103,7 @@
             </button>
           </div>
         </div>
+        {% endif %}
       {% else %}
         <div class="control-group">
             <a href="{% url "account_signup" %}?next={{request.path}}" class="button primary">

--- a/squarelet/templates/organizations/invitation_detail.html
+++ b/squarelet/templates/organizations/invitation_detail.html
@@ -109,13 +109,9 @@
     <div class="control-group">
     {% if request.user.is_authenticated %}
       {% if accept_form.requires_email_verification %}
-        <form class="email-actions" action="{% url "account_email" %}" method="post">
-          {% csrf_token %}
-          <input type="hidden" name="email" value="{{request.user.email}}" />
-          <button class="button primary" type="submit" name="action_send">
-            {% trans "Verify your email address" %}
-          </button>
-        </form>
+        <a class="button primary" href="{% url "users:redirect" %}#accounts">
+          {% trans "Confirm your email address" %}
+        </a>
       {% else %}
         <form method="post">
           {% csrf_token %}

--- a/squarelet/templates/organizations/invitation_detail.html
+++ b/squarelet/templates/organizations/invitation_detail.html
@@ -109,21 +109,7 @@
 
     <div class="control-group">
     {% if request.user.is_authenticated %}
-      {% if accept_form.requires_email_verification %}
-        <a class="button primary" href="{% url "users:redirect" %}#accounts">
-          {% trans "Confirm your email address" %}
-        </a>
-      {% else %}
-        <form method="post">
-          {% csrf_token %}
-          <button class="button caution" type="submit" name="action" value="reject">
-            {% trans "Reject" %}
-          </button>
-          <button class="button primary" type="submit" name="action" value="accept">
-            {% trans "Accept Invitation" %}
-          </button>
-        </form>
-      {% endif %}
+      {{ accept_form }}
     {% else %}
       <a href="{% url "account_signup" %}?next={{request.path}}" class="button primary">
         {% trans "Sign Up" %}

--- a/squarelet/templates/organizations/invitation_detail.html
+++ b/squarelet/templates/organizations/invitation_detail.html
@@ -75,6 +75,7 @@
        If you'd like to associate this invitation with another account,
        please sign out and sign back in with the account you'd like to use.
       {% endblocktrans %}
+    </p>
     {% if accept_form.requires_email_verification %}
     <p>
       {% blocktrans %}

--- a/squarelet/templates/organizations/organization_list.html
+++ b/squarelet/templates/organizations/organization_list.html
@@ -146,15 +146,7 @@
             <div class="invite">
               {% include "account/team_list_item.html" with organization=invite.organization %}
 
-              <form method="post" action="{% url "organizations:invitation" uuid=invite.uuid %}" class="actions">
-                {% csrf_token %}
-                <button class="btn small primary" type="submit" name="action" value="accept">
-                  {% trans "Accept" %}
-                </button>
-                <button class="btn small danger ghost" type="submit" name="action" value="reject">
-                  {% trans "Reject" %}
-                </button>
-              </form>
+              {{ invite.accept_form }}
             </div>
             {% endfor %}
           </div>

--- a/squarelet/templates/organizations/organization_list.html
+++ b/squarelet/templates/organizations/organization_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static i18n avatar django_vite email_verification icon %}
+{% load static i18n avatar django_vite icon %}
 
 {% block title %}Organizations{% endblock %}
 
@@ -102,23 +102,6 @@
     </section>
 
     <section class="invites">
-      {% if not request.user|has_verified_email %}
-      <div class="empty">
-        <p>
-          {% blocktrans %}
-          You must verify your email address before you can send requests
-          or receive invitations to join an organization.
-          {% endblocktrans %}
-        </p>
-        <form class="email-actions" action="{% url "account_email" %}" method="post">
-          {% csrf_token %}
-          <input type="hidden" name="email" value="{{user.email}}" />
-          <button class="btn primary small" type="submit" name="action_send">
-            {% trans "Confirm your email address" %}
-          </button>
-        </form>
-      </div>
-      {% else %}
         {% if potential_orgs %}
         <div id="pre-approved" class="pre-approved">
           <header>
@@ -213,7 +196,6 @@
           </div>
           {% endif %}
         </div>
-      {% endif %}
     </section>
   </main>
 </article>

--- a/squarelet/templates/organizations/organization_managemembers.html
+++ b/squarelet/templates/organizations/organization_managemembers.html
@@ -142,8 +142,8 @@
         </form>
       </div>
       {% empty %}
-      <div class="empty">
-        <h3>No pending requests</h3>
+      <div class="empty empty--no-border">
+        <p>No pending requests</p>
       </div>
       {% endfor %}
     </div>
@@ -201,8 +201,8 @@
           </div>
         </div>
       {% empty %}
-        <div class="empty">
-          <h3>No pending invitations</h3>
+        <div class="empty empty--no-border">
+          <p>No pending invitations</p>
         </div>
       {% endfor %}
       </div>

--- a/squarelet/templates/organizations/your_organizations.html
+++ b/squarelet/templates/organizations/your_organizations.html
@@ -31,15 +31,7 @@
   {% for invite in pending_invitations %}
     <div class="invite">
       {% include "account/team_list_item.html" with organization=invite.organization %}
-      <form method="post" action="{% url "organizations:invitation" uuid=invite.uuid %}" class="actions actions-nowrap">
-        {% csrf_token %}
-        <button class="small btn primary" type="submit" name="action" value="accept">
-          {% trans "Accept" %}
-        </button>
-        <button class="small btn danger ghost" type="submit" name="action" value="reject">
-          {% trans "Reject" %}
-        </button>
-      </form>
+      {{ invite.accept_form }}
     </div>
   {% endfor %}
 </div>

--- a/squarelet/templates/users/user_invitations.html
+++ b/squarelet/templates/users/user_invitations.html
@@ -54,15 +54,7 @@
         {% if is_own_page %}
         <td class="invitation-actions">
           {% if not invitation.accepted_at and not invitation.rejected_at and not invitation.withdrawn_at %}
-            <form method="post" action="{% url "organizations:invitation" uuid=invitation.uuid %}">
-              {% csrf_token %}
-              <button class="btn small primary" type="submit" name="action" value="accept">
-                {% trans "Accept" %}
-              </button>
-              <button class="btn small danger ghost" type="submit" name="action" value="reject">
-                {% trans "Reject" %}
-              </button>
-            </form>
+            {{ invitation.accept_form }}
           {% elif invitation.rejected_at %}
             <form method="post" action="{% url "users:invitations" username=target_user.username %}">
               {% csrf_token %}

--- a/squarelet/users/models.py
+++ b/squarelet/users/models.py
@@ -243,10 +243,12 @@ class User(AvatarMixin, AbstractBaseUser, PermissionsMixin):
     def verified_journalist(self):
         return self.organizations.filter(verified_journalist=True).exists()
 
-    def get_verified_emails(self):
-        """Returns a list of all verified emails"""
-        verified_email_qs = self.emailaddress_set.filter(verified=True)
-        return list(verified_email_qs.values_list("email", flat=True))
+    def get_emails(self, verified=False):
+        """Returns a list of the user's emails."""
+        emails = self.emailaddress_set.all()
+        if verified:
+            emails = emails.filter(verified=True)
+        return list(emails.values_list("email", flat=True))
 
     # TODO: remove after retiring Election Hub (#229)
     def is_hub_eligible(self):
@@ -286,17 +288,17 @@ class User(AvatarMixin, AbstractBaseUser, PermissionsMixin):
         )
 
     def get_pending_requests(self):
-        verified_emails = self.get_verified_emails()
+        # Match against all emails (verified or not) and the user field so that
+        # users who haven't confirmed their email can still see their requests.
+        # Accepting an admin-role invitation is separately gated behind email
+        # verification (see InvitationAcceptForm.requires_email_verification).
+        emails = self.get_emails()
 
-        if not verified_emails:
-            # If the user has no verified emails, they cannot have pending invites
-            return Invitation.objects.none()
-
-        # Query for request Invitations matching any verified email
+        # Query for request Invitations matching any of the user's emails
         # that are not accepted or rejected
         pending_requests = (
             Invitation.objects.filter(
-                email__in=verified_emails,
+                Q(email__in=emails) | Q(user=self),
                 request=True,
                 accepted_at__isnull=True,
                 rejected_at__isnull=True,
@@ -308,17 +310,18 @@ class User(AvatarMixin, AbstractBaseUser, PermissionsMixin):
         return pending_requests
 
     def get_pending_invitations(self):
-        verified_emails = self.get_verified_emails()
+        # Match against all emails (verified or not) and the user field so that
+        # users who haven't confirmed their email can still see their
+        # invitations.  Accepting an admin-role invitation is separately gated
+        # behind email verification (see
+        # InvitationAcceptForm.requires_email_verification).
+        emails = self.get_emails()
 
-        if not verified_emails:
-            # If the user has no verified emails, they cannot have pending invites
-            return Invitation.objects.none()
-
-        # Query for non-request Invitations matching any verified email
+        # Query for non-request Invitations matching any of the user's emails
         # that are not accepted or rejected
         pending_invites = (
             Invitation.objects.filter(
-                email__in=verified_emails,
+                Q(email__in=emails) | Q(user=self),
                 request=False,
                 accepted_at__isnull=True,
                 rejected_at__isnull=True,

--- a/squarelet/users/onboarding.py
+++ b/squarelet/users/onboarding.py
@@ -163,7 +163,7 @@ class OrganizationJoinStep(OnboardingStep):
     def get_context_data(self, request):
         user = request.user
         invitations, potential_orgs = self._get_joinable_orgs(user)
-        InvitationAcceptForm.attach_to_invitations(invitations, user)
+        InvitationAcceptForm.attach_to_invitations(invitations, user, request=request)
         return {
             "invitations": invitations,
             "potential_orgs": potential_orgs,

--- a/squarelet/users/onboarding.py
+++ b/squarelet/users/onboarding.py
@@ -16,6 +16,7 @@ from allauth.mfa.totp.forms import ActivateTOTPForm
 from allauth.mfa.totp.internal.flows import activate_totp
 
 # Squarelet
+from squarelet.organizations.forms import InvitationAcceptForm
 from squarelet.organizations.models.payment import Plan
 from squarelet.organizations.payments.base import PaymentActionRequired
 from squarelet.users.forms import PremiumSubscriptionForm
@@ -162,6 +163,7 @@ class OrganizationJoinStep(OnboardingStep):
     def get_context_data(self, request):
         user = request.user
         invitations, potential_orgs = self._get_joinable_orgs(user)
+        InvitationAcceptForm.attach_to_invitations(invitations, user)
         return {
             "invitations": invitations,
             "potential_orgs": potential_orgs,

--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -2368,32 +2368,25 @@ class TestUserInvitationsView(ViewTestMixin):
         # Only invitations should appear, not requests
         assert len(response.context_data["invitations"]) == 2
 
-    def test_get_invitations_filters_by_verified_email(
-        self, rf, user_factory, organization_factory, invitation_factory, mocker
+    def test_get_invitations_excludes_other_emails(
+        self, rf, user_factory, organization_factory, invitation_factory
     ):
-        """View only shows invitations for verified emails"""
-        user = user_factory(email="verified@example.com", email_verified=True)
+        """View only shows invitations addressed to the user's own emails"""
+        user = user_factory(email="user@example.com", email_verified=True)
         org = organization_factory()
 
-        # Mock get_verified_emails to return only verified email
-        mocker.patch.object(
-            user, "get_verified_emails", return_value=["verified@example.com"]
-        )
-
-        # Create invitation for verified email (should appear)
+        # Invitation to the user's email (should appear)
+        invitation_factory(email="user@example.com", organization=org, request=False)
+        # Invitation to an email the user doesn't own (should NOT appear)
         invitation_factory(
-            email="verified@example.com", organization=org, request=False
-        )
-        # Create invitation for unverified email (should NOT appear)
-        invitation_factory(
-            email="unverified@example.com", organization=org, request=False
+            email="someone-else@example.com", organization=org, request=False
         )
 
         response = self.call_view(rf, user, username=user.username)
 
         assert response.status_code == 200
         assert len(response.context_data["invitations"]) == 1
-        assert response.context_data["invitations"][0].email == "verified@example.com"
+        assert response.context_data["invitations"][0].email == "user@example.com"
 
     def test_get_invitations_includes_user_field_invitations(
         self, rf, user_factory, organization_factory, invitation_factory
@@ -2447,17 +2440,19 @@ class TestUserInvitationsView(ViewTestMixin):
         assert response.context_data["is_paginated"] is True
         assert len(response.context_data["invitations"]) == 20
 
-    def test_get_invitations_no_verified_emails(self, rf, user_factory, mocker):
-        """User with no verified emails should see empty list"""
+    def test_get_invitations_unverified_email(
+        self, rf, user_factory, organization_factory, invitation_factory
+    ):
+        """Invitations to an unverified email are still shown to the user"""
         user = user_factory(email_verified=False)
+        org = organization_factory()
 
-        # Mock no verified emails
-        mocker.patch.object(user, "get_verified_emails", return_value=[])
+        invitation_factory(email=user.email, organization=org, request=False)
 
         response = self.call_view(rf, user, username=user.username)
 
         assert response.status_code == 200
-        assert len(response.context_data["invitations"]) == 0
+        assert len(response.context_data["invitations"]) == 1
 
     def test_staff_can_view_other_users_invitations(
         self, rf, user_factory, organization_factory, invitation_factory
@@ -2628,30 +2623,25 @@ class TestUserRequestsView(ViewTestMixin):
         # Only requests should appear, not invitations
         assert len(response.context_data["requests"]) == 3
 
-    def test_get_requests_filters_by_verified_email(
-        self, rf, user_factory, organization_factory, invitation_factory, mocker
+    def test_get_requests_excludes_other_emails(
+        self, rf, user_factory, organization_factory, invitation_factory
     ):
-        """View only shows requests for verified emails"""
-        user = user_factory(email="verified@example.com", email_verified=True)
+        """View only shows requests addressed to the user's own emails"""
+        user = user_factory(email="user@example.com", email_verified=True)
         org = organization_factory()
 
-        # Mock get_verified_emails to return only verified email
-        mocker.patch.object(
-            user, "get_verified_emails", return_value=["verified@example.com"]
-        )
-
-        # Create request for verified email (should appear)
-        invitation_factory(email="verified@example.com", organization=org, request=True)
-        # Create request for unverified email (should NOT appear)
+        # Request to the user's email (should appear)
+        invitation_factory(email="user@example.com", organization=org, request=True)
+        # Request to an email the user doesn't own (should NOT appear)
         invitation_factory(
-            email="unverified@example.com", organization=org, request=True
+            email="someone-else@example.com", organization=org, request=True
         )
 
         response = self.call_view(rf, user, username=user.username)
 
         assert response.status_code == 200
         assert len(response.context_data["requests"]) == 1
-        assert response.context_data["requests"][0].email == "verified@example.com"
+        assert response.context_data["requests"][0].email == "user@example.com"
 
     def test_get_requests_includes_user_field_requests(
         self, rf, user_factory, organization_factory, invitation_factory
@@ -2705,17 +2695,19 @@ class TestUserRequestsView(ViewTestMixin):
         assert response.context_data["is_paginated"] is True
         assert len(response.context_data["requests"]) == 20
 
-    def test_get_requests_no_verified_emails(self, rf, user_factory, mocker):
-        """User with no verified emails should see empty list"""
+    def test_get_requests_unverified_email(
+        self, rf, user_factory, organization_factory, invitation_factory
+    ):
+        """Requests from an unverified user are still shown to them"""
         user = user_factory(email_verified=False)
+        org = organization_factory()
 
-        # Mock no verified emails
-        mocker.patch.object(user, "get_verified_emails", return_value=[])
+        invitation_factory(email=user.email, organization=org, request=True)
 
         response = self.call_view(rf, user, username=user.username)
 
         assert response.status_code == 200
-        assert len(response.context_data["requests"]) == 0
+        assert len(response.context_data["requests"]) == 1
 
     def test_staff_can_view_other_users_requests(
         self, rf, user_factory, organization_factory, invitation_factory

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -48,6 +48,7 @@ from allauth.socialaccount.views import ConnectionsView
 # Squarelet
 from squarelet.core.mixins import AdminLinkMixin
 from squarelet.core.utils import new_action
+from squarelet.organizations.forms import InvitationAcceptForm
 from squarelet.organizations.models import Invitation, ReceiptEmail
 from squarelet.organizations.models.payment import Plan
 from squarelet.organizations.payments.factory import get_payment_provider
@@ -139,7 +140,9 @@ class UserDetailView(LoginRequiredMixin, StaffAccessMixin, AdminLinkMixin, Detai
         )
         context["is_own_page"] = user == self.request.user
         context["potential_organizations"] = list(user.get_potential_organizations())
-        context["pending_invitations"] = list(user.get_pending_invitations())
+        context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
+            list(user.get_pending_invitations()), user
+        )
         context["pending_requests"] = list(user.get_pending_requests())
         context["verified"] = user.verified_journalist()
         context["verified_organizations"] = list(
@@ -652,6 +655,13 @@ class UserInvitationsView(BaseUserInvitationRequestView):
     context_object_name = "invitations"
     is_request_view = False
     redirect_url_name = "users:invitations"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        InvitationAcceptForm.attach_to_invitations(
+            context["invitations"], self.request.user
+        )
+        return context
 
 
 class UserRequestsView(BaseUserInvitationRequestView):

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -141,7 +141,7 @@ class UserDetailView(LoginRequiredMixin, StaffAccessMixin, AdminLinkMixin, Detai
         context["is_own_page"] = user == self.request.user
         context["potential_organizations"] = list(user.get_potential_organizations())
         context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
-            list(user.get_pending_invitations()), user
+            list(user.get_pending_invitations()), user, request=self.request
         )
         context["pending_requests"] = list(user.get_pending_requests())
         context["verified"] = user.verified_journalist()
@@ -659,7 +659,7 @@ class UserInvitationsView(BaseUserInvitationRequestView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         InvitationAcceptForm.attach_to_invitations(
-            context["invitations"], self.request.user
+            context["invitations"], self.request.user, request=self.request
         )
         return context
 


### PR DESCRIPTION
Resolves #619

Users must have confirmed their email addresses before they can accept an invitation to join an org **as an admin**.

This also relaxes the restriction allowing uses to see invitations and send requests if they have an unverified email address for a consistent user experience. It's acceptable for users without confirmed emails to be able to accept or request org membership, given our other guardrails to prevent abuse. This results in a smoother first-run experience for users.

Improves code quality by rendering all invitation mutation UI from a  `InvitationAcceptForm` that also validates the POST data. Forms are bound to invitations during context generation, so we render a unique form for each invitation in the template.