### PR TITLE
Fix manual invoicing bugs

### DIFF
--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -588,44 +588,51 @@ class Organization(AvatarMixin, models.Model):
             to_max_users=self.max_users,
         )
 
-    def subscription_cancelled(self):
-        """The subscription was cancelled due to payment failure"""
+    def subscription_cancelled(self, subscription=None):
+        """The subscription was cancelled due to payment failure
+
+        Args:
+            subscription: The specific subscription to cancel. If None,
+                cancels self.subscription (the org's current subscription).
+        """
+        subscription = subscription or self.subscription
+
         # Create change log entry
         self.change_logs.create(
             reason=ChangeLogReason.failed,
-            from_plan=self.plan,
+            from_plan=subscription.plan if subscription else self.plan,
             from_max_users=self.max_users,
             to_max_users=self.max_users,
         )
 
         # Cancel subscription in Stripe if it exists
-        if self.subscription and self.subscription.subscription_id:
+        if subscription and subscription.subscription_id:
             try:
-                stripe_sub = self.subscription.stripe_subscription
+                stripe_sub = subscription.stripe_subscription
                 if stripe_sub:
                     stripe_sub.delete()
                     logger.info(
                         "Cancelled Stripe subscription %s for organization %s",
-                        self.subscription.subscription_id,
+                        subscription.subscription_id,
                         self.uuid,
                     )
                 else:
                     logger.warning(
                         "Stripe subscription %s not found for organization %s",
-                        self.subscription.subscription_id,
+                        subscription.subscription_id,
                         self.uuid,
                     )
             except stripe.error.StripeError as exc:
                 logger.error(
                     "Failed to cancel Stripe subscription %s for organization %s: %s",
-                    self.subscription.subscription_id,
+                    subscription.subscription_id,
                     self.uuid,
                     exc,
                     exc_info=sys.exc_info(),
                 )
 
         # Delete local subscription record
-        self.subscription.delete()
+        subscription.delete()
 
     def has_active_subscription(self):
         """Check if the organization has an active subscription"""

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -591,9 +591,8 @@ class Organization(AvatarMixin, models.Model):
     def subscription_cancelled(self, subscription=None):
         """The subscription was cancelled due to payment failure
 
-        Args:
-            subscription: The specific subscription to cancel. If None,
-                cancels self.subscription (the org's current subscription).
+        Takes an arg for the specific subscription to cancel.
+        If None, cancels the org's current subscription.
         """
         subscription = subscription or self.subscription
 

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -181,7 +181,7 @@ def handle_invoice_created(invoice_data):
         )
         return
 
-    # Get the subscription if available from the parent object
+    # Get the subscription from the parent object — only track subscription invoices
     subscription = None
     parent = invoice_data.get("parent")
     if parent and parent.get("type") == "subscription_details":
@@ -193,11 +193,22 @@ def handle_invoice_created(invoice_data):
                 invoice_id = invoice_data["id"]
                 stripe_link = get_stripe_dashboard_url("invoices", invoice_id)
                 logger.warning(
-                    "[STRIPE-WEBHOOK-INVOICE] Invoice references missing subscription: "
-                    "%s (%s)",
+                    "[STRIPE-WEBHOOK-INVOICE] Invoice references missing subscription, "
+                    "skipping: %s (%s)",
                     invoice_id,
                     stripe_link,
                 )
+                return
+
+    if subscription is None:
+        invoice_id = invoice_data["id"]
+        stripe_link = get_stripe_dashboard_url("invoices", invoice_id)
+        logger.info(
+            "[STRIPE-WEBHOOK-INVOICE] Skipping invoice with no subscription: %s (%s)",
+            invoice_id,
+            stripe_link,
+        )
+        return
 
     # Create or update the invoice
     # Note: Invoice may already exist if created synchronously during subscription start

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -226,6 +226,31 @@ def handle_invoice_created(invoice_data):
     )
 
 
+@shared_task(name="squarelet.organizations.tasks.handle_invoice_updated")
+def handle_invoice_updated(invoice_data):
+    """Handle receiving an invoice.updated event from the Stripe webhook"""
+    invoice_id = invoice_data["id"]
+    try:
+        invoice = Invoice.objects.get(invoice_id=invoice_id)
+    except Invoice.DoesNotExist:
+        stripe_link = get_stripe_dashboard_url("invoices", invoice_id)
+        logger.info(
+            "[STRIPE-WEBHOOK-INVOICE] Received update event for invoice not tracked "
+            "in our system: %s (%s)",
+            invoice_id,
+            stripe_link,
+        )
+        return
+
+    Invoice.create_or_update_from_stripe(
+        invoice_data, invoice.organization, invoice.subscription
+    )
+    stripe_link = get_stripe_dashboard_url("invoices", invoice_id)
+    logger.info(
+        "[STRIPE-WEBHOOK-INVOICE] Invoice updated: %s (%s)", invoice_id, stripe_link
+    )
+
+
 @shared_task(name="squarelet.organizations.tasks.handle_invoice_finalized")
 def handle_invoice_finalized(invoice_data):
     """Handle receiving an invoice.finalized event from the Stripe webhook"""
@@ -243,12 +268,9 @@ def handle_invoice_finalized(invoice_data):
         )
         return
 
-    invoice.status = invoice_data["status"]
-    if invoice_data.get("due_date"):
-        invoice.due_date = datetime.fromtimestamp(
-            invoice_data["due_date"], tz=get_current_timezone()
-        ).date()
-    invoice.save()
+    Invoice.create_or_update_from_stripe(
+        invoice_data, invoice.organization, invoice.subscription
+    )
     stripe_link = get_stripe_dashboard_url("invoices", invoice_id)
     logger.info(
         "[STRIPE-WEBHOOK-INVOICE] Invoice finalized: %s (%s)", invoice_id, stripe_link
@@ -272,8 +294,9 @@ def handle_invoice_paid(invoice_data):
         )
         return
 
-    invoice.status = "paid"
-    invoice.save()
+    Invoice.create_or_update_from_stripe(
+        invoice_data, invoice.organization, invoice.subscription
+    )
 
     # Clear payment_failed flag on the organization
     organization = invoice.organization

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -422,9 +422,9 @@ def process_overdue_invoice(invoice_id):
             invoice.invoice_id,
         )
 
-        # Cancel subscription (same as credit card failures)
-        if organization.subscription:
-            organization.subscription_cancelled()
+        # Cancel the subscription linked to this invoice (not the org's current one)
+        if invoice.subscription:
+            organization.subscription_cancelled(invoice.subscription)
             # Clear subscription reference since it was deleted
             invoice.subscription = None
 

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -393,6 +393,14 @@ def process_overdue_invoice(invoice_id):
         )
         return
 
+    # Skip $0 invoices — no payment is owed
+    if invoice.amount == 0:
+        logger.info(
+            "[STRIPE-PROCESS-OVERDUE-INVOICE] Skipping $0 invoice %s",
+            invoice.invoice_id,
+        )
+        return
+
     organization = invoice.organization
     grace_period_days = settings.OVERDUE_INVOICE_GRACE_PERIOD_DAYS
     days_overdue = (date.today() - invoice.due_date).days
@@ -508,9 +516,9 @@ def process_overdue_invoice(invoice_id):
 @shared_task(name="squarelet.organizations.tasks.check_overdue_invoices")
 def check_overdue_invoices():
     """Find all overdue invoices and dispatch tasks to process them"""
-    # Get all open invoices that are past due (any amount)
+    # Get all open invoices that are past due with a non-zero amount
     all_overdue_invoices = Invoice.objects.filter(
-        status="open", due_date__lt=date.today()
+        status="open", due_date__lt=date.today(), amount__gt=0
     )
 
     invoice_count = all_overdue_invoices.count()

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -392,6 +392,7 @@ class TestOrganization:
             "squarelet.organizations.models.Organization.subscription"
         )
         mocked_subscription.subscription_id = "sub_test123"
+        mocked_subscription.plan = plan
         # Mock the stripe_subscription property to return a mock Stripe subscription
         mock_stripe_sub = mocker.MagicMock()
         type(mocked_subscription).stripe_subscription = mocker.PropertyMock(

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -585,6 +585,72 @@ class TestHandleInvoiceCreated:
         assert not Invoice.objects.filter(invoice_id="in_warn").exists()
 
 
+class TestHandleInvoiceUpdated:
+    """Unit tests for the handle_invoice_updated task"""
+
+    @pytest.mark.django_db
+    def test_updates_invoice_amount(self, invoice_factory):
+        """Amount changes on an existing invoice should be captured"""
+        invoice = invoice_factory(
+            invoice_id="in_123", amount=0, status="draft"
+        )
+
+        invoice_data = {
+            "id": "in_123",
+            "amount_due": 1300000,
+            "status": "draft",
+            "due_date": None,
+            "created": int(invoice.created_at.timestamp()),
+        }
+
+        tasks.handle_invoice_updated(invoice_data)
+
+        invoice.refresh_from_db()
+        assert invoice.amount == 1300000
+
+    @pytest.mark.django_db
+    def test_updates_invoice_status(self, invoice_factory):
+        """Status changes should be captured"""
+        invoice = invoice_factory(
+            invoice_id="in_123", status="draft"
+        )
+
+        invoice_data = {
+            "id": "in_123",
+            "amount_due": invoice.amount,
+            "status": "open",
+            "due_date": None,
+            "created": int(invoice.created_at.timestamp()),
+        }
+
+        tasks.handle_invoice_updated(invoice_data)
+
+        invoice.refresh_from_db()
+        assert invoice.status == "open"
+
+    @pytest.mark.django_db
+    def test_invoice_not_found(self, mocker):
+        """Should log warning and return for invoices not in our DB"""
+        invoice_data = {
+            "id": "in_nonexistent",
+            "amount_due": 10000,
+            "status": "open",
+            "due_date": None,
+            "created": int(timezone.now().timestamp()),
+        }
+
+        mock_logger = mocker.patch("squarelet.organizations.tasks.logger")
+
+        tasks.handle_invoice_updated(invoice_data)
+
+        mock_logger.info.assert_called()
+        log_messages = [call[0][0] for call in mock_logger.info.call_args_list]
+        assert any("not tracked" in msg for msg in log_messages)
+
+        # Should not create an invoice
+        assert not Invoice.objects.filter(invoice_id="in_nonexistent").exists()
+
+
 class TestHandleInvoiceFinalized:
     """Unit tests for the handle_invoice_finalized task"""
 
@@ -597,8 +663,10 @@ class TestHandleInvoiceFinalized:
 
         invoice_data = {
             "id": "in_123",
+            "amount_due": invoice.amount,
             "status": "open",
             "due_date": int(due_timestamp.timestamp()),
+            "created": int(timestamp.timestamp()),
         }
 
         tasks.handle_invoice_finalized(invoice_data)
@@ -606,6 +674,30 @@ class TestHandleInvoiceFinalized:
         invoice.refresh_from_db()
         assert invoice.status == "open"
         assert invoice.due_date == due_timestamp.date()
+
+    @pytest.mark.django_db
+    @freeze_time("2025-01-15 12:00:00")
+    def test_updates_invoice_amount(self, invoice_factory):
+        """Finalization should update the invoice amount"""
+        timestamp = timezone.now().replace(microsecond=0)
+        due_timestamp = (timestamp + timedelta(days=30)).replace(microsecond=0)
+        invoice = invoice_factory(
+            invoice_id="in_123", status="draft", amount=5000, due_date=None
+        )
+
+        invoice_data = {
+            "id": "in_123",
+            "customer": invoice.organization.customers.first().customer_id,
+            "amount_due": 10000,
+            "status": "open",
+            "due_date": int(due_timestamp.timestamp()),
+            "created": int(timestamp.timestamp()),
+        }
+
+        tasks.handle_invoice_finalized(invoice_data)
+
+        invoice.refresh_from_db()
+        assert invoice.amount == 10000
 
     @pytest.mark.django_db()
     def test_invoice_not_found(self, mocker):
@@ -633,7 +725,21 @@ class TestHandleInvoicePaymentSucceeded:
     def test_marks_invoice_paid(self, invoice_factory):
         invoice = invoice_factory(invoice_id="in_123", status="open")
 
-        invoice_data = {"id": "in_123"}
+        invoice_data = {
+            "id": "in_123",
+            "amount_due": invoice.amount,
+            "status": "paid",
+            "due_date": (
+                int(
+                    timezone.datetime.combine(
+                        invoice.due_date, timezone.datetime.min.time()
+                    ).timestamp()
+                )
+                if invoice.due_date
+                else None
+            ),
+            "created": int(invoice.created_at.timestamp()),
+        }
 
         tasks.handle_invoice_paid(invoice_data)
 
@@ -641,11 +747,45 @@ class TestHandleInvoicePaymentSucceeded:
         assert invoice.status == "paid"
 
     @pytest.mark.django_db
+    def test_updates_invoice_amount(self, invoice_factory):
+        """Payment handler should update the invoice amount"""
+        invoice = invoice_factory(invoice_id="in_123", status="open", amount=0)
+
+        invoice_data = {
+            "id": "in_123",
+            "amount_due": 1300000,
+            "status": "paid",
+            "due_date": (
+                int(
+                    timezone.datetime.combine(
+                        invoice.due_date, timezone.datetime.min.time()
+                    ).timestamp()
+                )
+                if invoice.due_date
+                else None
+            ),
+            "created": int(invoice.created_at.timestamp()),
+        }
+
+        tasks.handle_invoice_paid(invoice_data)
+
+        invoice.refresh_from_db()
+        assert invoice.amount == 1300000
+
+    @pytest.mark.django_db
     def test_clears_payment_failed_flag(self, organization_factory, invoice_factory):
         organization = organization_factory(payment_failed=True)
-        invoice_factory(invoice_id="in_123", organization=organization, status="open")
+        invoice = invoice_factory(
+            invoice_id="in_123", organization=organization, status="open"
+        )
 
-        invoice_data = {"id": "in_123"}
+        invoice_data = {
+            "id": "in_123",
+            "amount_due": invoice.amount,
+            "status": "paid",
+            "due_date": None,
+            "created": int(invoice.created_at.timestamp()),
+        }
 
         tasks.handle_invoice_paid(invoice_data)
 
@@ -657,9 +797,17 @@ class TestHandleInvoicePaymentSucceeded:
         self, organization_factory, invoice_factory
     ):
         organization = organization_factory(payment_failed=False)
-        invoice_factory(invoice_id="in_123", organization=organization, status="open")
+        invoice = invoice_factory(
+            invoice_id="in_123", organization=organization, status="open"
+        )
 
-        invoice_data = {"id": "in_123"}
+        invoice_data = {
+            "id": "in_123",
+            "amount_due": invoice.amount,
+            "status": "paid",
+            "due_date": None,
+            "created": int(invoice.created_at.timestamp()),
+        }
 
         tasks.handle_invoice_paid(invoice_data)
 

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -1250,6 +1250,29 @@ class TestCheckOverdueInvoices:
             == "https://invoice.stripe.com/i/test"
         )
 
+    @pytest.mark.django_db
+    @override_settings(OVERDUE_INVOICE_GRACE_PERIOD_DAYS=30)
+    def test_skips_zero_amount_invoice(
+        self, invoice_factory, organization_factory, mocker
+    ):
+        """$0 invoices should not trigger overdue processing"""
+        org = organization_factory()
+        invoice = invoice_factory(
+            organization=org,
+            status="open",
+            amount=0,
+            due_date=date.today() - timedelta(days=20),
+        )
+
+        mock_send_mail = mocker.patch("squarelet.organizations.tasks.send_mail")
+
+        tasks.process_overdue_invoice(invoice.id)
+
+        # Should NOT send email or set payment_failed
+        mock_send_mail.assert_not_called()
+        org.refresh_from_db()
+        assert not org.payment_failed
+
 
 class TestCheckOverdueInvoicesDispatcher:
     """Unit tests for the check_overdue_invoices dispatcher task"""
@@ -1341,6 +1364,36 @@ class TestCheckOverdueInvoicesDispatcher:
 
         # Should not dispatch any tasks
         mock_process.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_does_not_dispatch_for_zero_amount_invoices(
+        self, invoice_factory, organization_factory, mocker
+    ):
+        """Should not dispatch tasks for $0 invoices"""
+        org = organization_factory()
+        # $0 invoice - should be skipped
+        invoice_factory(
+            organization=org,
+            status="open",
+            amount=0,
+            due_date=date.today() - timedelta(days=10),
+        )
+        # $100 invoice - should be dispatched
+        invoice_with_amount = invoice_factory(
+            organization=org,
+            status="open",
+            amount=10000,
+            due_date=date.today() - timedelta(days=10),
+        )
+
+        mock_process = mocker.patch(
+            "squarelet.organizations.tasks.process_overdue_invoice.delay"
+        )
+
+        tasks.check_overdue_invoices()
+
+        # Should only dispatch for the non-zero invoice
+        mock_process.assert_called_once_with(invoice_with_amount.id)
 
 
 class TestSyncWix:

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -496,9 +496,7 @@ class TestHandleInvoiceCreated:
         assert not Invoice.objects.filter(invoice_id="in_quote").exists()
 
     @pytest.mark.django_db(transaction=True)
-    def test_updates_existing_invoice(
-        self, organization_factory, subscription_factory
-    ):
+    def test_updates_existing_invoice(self, organization_factory, subscription_factory):
         timestamp = timezone.now().replace(microsecond=0)
         organization = organization_factory(customer__customer_id="cus_123")
         subscription = subscription_factory(
@@ -591,9 +589,7 @@ class TestHandleInvoiceUpdated:
     @pytest.mark.django_db
     def test_updates_invoice_amount(self, invoice_factory):
         """Amount changes on an existing invoice should be captured"""
-        invoice = invoice_factory(
-            invoice_id="in_123", amount=0, status="draft"
-        )
+        invoice = invoice_factory(invoice_id="in_123", amount=0, status="draft")
 
         invoice_data = {
             "id": "in_123",
@@ -611,9 +607,7 @@ class TestHandleInvoiceUpdated:
     @pytest.mark.django_db
     def test_updates_invoice_status(self, invoice_factory):
         """Status changes should be captured"""
-        invoice = invoice_factory(
-            invoice_id="in_123", status="draft"
-        )
+        invoice = invoice_factory(invoice_id="in_123", status="draft")
 
         invoice_data = {
             "id": "in_123",

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -430,7 +430,8 @@ class TestHandleInvoiceCreated:
         assert invoice.status == "draft"
 
     @pytest.mark.django_db(transaction=True)
-    def test_handles_missing_subscription(self, organization_factory):
+    def test_skips_invoice_with_missing_subscription(self, organization_factory):
+        """Invoices referencing a non-existent subscription should not be created"""
         timestamp = timezone.now().replace(microsecond=0)
         organization_factory(customer__customer_id="cus_123")
 
@@ -449,22 +450,74 @@ class TestHandleInvoiceCreated:
 
         tasks.handle_invoice_created(invoice_data)
 
-        # Refresh from database to ensure we have the committed state
-        invoice = Invoice.objects.get(invoice_id="in_123")
-        assert invoice.subscription is None
+        assert not Invoice.objects.filter(invoice_id="in_123").exists()
 
     @pytest.mark.django_db(transaction=True)
-    def test_updates_existing_invoice(self, organization_factory):
+    def test_skips_invoice_without_subscription_parent(self, organization_factory):
+        """Manually-created invoices with no parent should not be tracked"""
+        timestamp = timezone.now().replace(microsecond=0)
+        organization_factory(customer__customer_id="cus_123")
+
+        invoice_data = {
+            "id": "in_manual",
+            "customer": "cus_123",
+            "parent": None,
+            "amount_due": 10000,
+            "due_date": None,
+            "status": "draft",
+            "created": int(timestamp.timestamp()),
+        }
+
+        tasks.handle_invoice_created(invoice_data)
+
+        assert not Invoice.objects.filter(invoice_id="in_manual").exists()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_skips_invoice_with_non_subscription_parent(self, organization_factory):
+        """Invoices with a non-subscription parent type should not be tracked"""
+        timestamp = timezone.now().replace(microsecond=0)
+        organization_factory(customer__customer_id="cus_123")
+
+        invoice_data = {
+            "id": "in_quote",
+            "customer": "cus_123",
+            "parent": {
+                "type": "quote_details",
+                "quote_details": {"quote": "qt_123"},
+            },
+            "amount_due": 10000,
+            "due_date": None,
+            "status": "draft",
+            "created": int(timestamp.timestamp()),
+        }
+
+        tasks.handle_invoice_created(invoice_data)
+
+        assert not Invoice.objects.filter(invoice_id="in_quote").exists()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_updates_existing_invoice(
+        self, organization_factory, subscription_factory
+    ):
         timestamp = timezone.now().replace(microsecond=0)
         organization = organization_factory(customer__customer_id="cus_123")
+        subscription = subscription_factory(
+            organization=organization, subscription_id="sub_123"
+        )
         existing_invoice = InvoiceFactory(
-            invoice_id="in_123", organization=organization, amount=5000
+            invoice_id="in_123",
+            organization=organization,
+            subscription=subscription,
+            amount=5000,
         )
 
         invoice_data = {
             "id": "in_123",
             "customer": "cus_123",
-            "subscription": None,
+            "parent": {
+                "type": "subscription_details",
+                "subscription_details": {"subscription": "sub_123"},
+            },
             "amount_due": 10000,
             "due_date": None,
             "status": "open",
@@ -500,8 +553,10 @@ class TestHandleInvoiceCreated:
         assert "no matching organization" in mock_logger.error.call_args[0][0]
 
     @pytest.mark.django_db(transaction=True)
-    def test_missing_subscription_logs_warning(self, organization_factory, mocker):
-        """Test that missing subscription logs a warning but continues"""
+    def test_missing_subscription_logs_warning_and_skips(
+        self, organization_factory, mocker
+    ):
+        """Missing subscription should log a warning and not create an invoice"""
         organization_factory(customer__customer_id="cus_123")
 
         mock_logger = mocker.patch("squarelet.organizations.tasks.logger")
@@ -526,9 +581,8 @@ class TestHandleInvoiceCreated:
         assert "STRIPE-WEBHOOK-INVOICE" in mock_logger.warning.call_args[0][0]
         assert "missing subscription" in mock_logger.warning.call_args[0][0]
 
-        # Verify invoice was still created
-        invoice = Invoice.objects.get(invoice_id="in_warn")
-        assert invoice.subscription is None
+        # Verify invoice was NOT created
+        assert not Invoice.objects.filter(invoice_id="in_warn").exists()
 
 
 class TestHandleInvoiceFinalized:

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -1053,6 +1053,74 @@ class TestCheckOverdueInvoices:
         mock_mark_uncollectible.assert_called_once()
         mock_send_mail.assert_called_once()
 
+    @pytest.mark.django_db(transaction=True)
+    @override_settings(OVERDUE_INVOICE_GRACE_PERIOD_DAYS=30)
+    def test_does_not_cancel_org_subscription_when_invoice_has_none(
+        self, invoice_factory, organization_factory, subscription_factory, mocker
+    ):
+        """Invoice with no subscription should not cancel the org's subscription"""
+        org = organization_factory()
+        org_subscription = subscription_factory(organization=org)
+        invoice = invoice_factory(
+            organization=org,
+            subscription=None,
+            status="open",
+            due_date=date.today() - timedelta(days=35),
+        )
+
+        mocker.patch("squarelet.organizations.tasks.send_mail")
+        mocker.patch(
+            "squarelet.organizations.models.invoice.Invoice."
+            "mark_uncollectible_in_stripe"
+        )
+        mock_subscription_cancelled = mocker.patch(
+            "squarelet.organizations.models.Organization.subscription_cancelled"
+        )
+
+        tasks.process_overdue_invoice(invoice.id)
+
+        # Should NOT cancel the org's unrelated subscription
+        mock_subscription_cancelled.assert_not_called()
+
+        # Org's subscription should still exist
+        assert Subscription.objects.filter(pk=org_subscription.pk).exists()
+
+    @pytest.mark.django_db(transaction=True)
+    @override_settings(OVERDUE_INVOICE_GRACE_PERIOD_DAYS=30)
+    def test_cancels_invoice_subscription_not_org_subscription(
+        self, invoice_factory, organization_factory, subscription_factory, mocker
+    ):
+        """Should cancel the invoice's subscription, not the org's current one"""
+        org = organization_factory()
+        org_subscription = subscription_factory(organization=org)
+        invoice_subscription = subscription_factory(organization=org)
+        invoice = invoice_factory(
+            organization=org,
+            subscription=invoice_subscription,
+            status="open",
+            due_date=date.today() - timedelta(days=35),
+        )
+
+        mocker.patch("squarelet.organizations.tasks.send_mail")
+        mocker.patch(
+            "squarelet.organizations.models.invoice.Invoice."
+            "mark_uncollectible_in_stripe"
+        )
+        # Mock Stripe deletion since subscription_cancelled tries to delete in Stripe
+        mocker.patch(
+            "squarelet.organizations.models.payment.Subscription.stripe_subscription",
+            new_callable=mocker.PropertyMock,
+            return_value=None,
+        )
+
+        tasks.process_overdue_invoice(invoice.id)
+
+        # The invoice's subscription should be deleted
+        assert not Subscription.objects.filter(pk=invoice_subscription.pk).exists()
+
+        # The org's other subscription should still exist
+        assert Subscription.objects.filter(pk=org_subscription.pk).exists()
+
     @pytest.mark.django_db
     @override_settings(OVERDUE_INVOICE_GRACE_PERIOD_DAYS=45)
     def test_respects_custom_grace_period(

--- a/squarelet/organizations/views/subscription.py
+++ b/squarelet/organizations/views/subscription.py
@@ -39,6 +39,7 @@ from squarelet.organizations.tasks import (
     handle_invoice_finalized,
     handle_invoice_marked_uncollectible,
     handle_invoice_paid,
+    handle_invoice_updated,
     handle_invoice_voided,
 )
 
@@ -210,6 +211,8 @@ def stripe_webhook(request):  # pylint: disable=too-many-branches
         handle_invoice_failed.delay(event["data"]["object"])
     elif event_type == "invoice.created":
         handle_invoice_created.delay(event["data"]["object"])
+    elif event_type == "invoice.updated":
+        handle_invoice_updated.delay(event["data"]["object"])
     elif event_type == "invoice.finalized":
         handle_invoice_finalized.delay(event["data"]["object"])
     elif event_type == "invoice.paid":


### PR DESCRIPTION
## Summary

Fixes a chain of bugs that caused a customer to receive an erroneous subscription cancellation email. A manually-created Stripe invoice was saved with `amount=0` (captured before line items were added), subsequent updates were never synced to our system, and overdue processing could (in theory) cancel the customer's unrelated subscription.

- **Don't track invoices without a subscription** — `handle_invoice_created` now skips invoices that can't be linked to a subscription record (manual invoices, quote-based invoices). Closes #670
- **Keep invoice state in sync across all webhook events** — Add `invoice.updated` webhook handler, refactor `handle_invoice_finalized` and `handle_invoice_paid` to use `Invoice.create_or_update_from_stripe()` so amount/status/due_date changes are always captured. Closes #669
- **Skip $0 invoices in overdue processing** — `check_overdue_invoices` filters out zero-amount invoices, with a defense-in-depth early return in `process_overdue_invoice`. Closes #671
- **Cancel the invoice's subscription, not the org's** — `process_overdue_invoice` now cancels `invoice.subscription` instead of `organization.subscription`, preventing unrelated subscriptions from being cancelled. Closes #672

Co-authored with Claude Opus 4.6