### PR TITLE
add an endpoint to exchange an oidc token for a jwt token

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -30,6 +30,7 @@ from squarelet.users.views import (
     UserOnboardingView,
 )
 from squarelet.users.viewsets import (
+    OIDCTokenExchangeView,
     RefreshTokenViewSet,
     UrlAuthTokenViewSet,
     UserViewSet,
@@ -89,6 +90,7 @@ urlpatterns = [
     path("api/", include(router.urls)),
     path("fe_api/", include((fe_api_router.urls, "fe_api"), namespace="fe_api")),
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/jwt/", OIDCTokenExchangeView.as_view(), name="token_oidc_exchange"),
     path("api/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("openid/", include("oidc_provider.urls", namespace="oidc_provider")),
     path("openid/jwt", token_view, name="oidc_jwt"),

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -180,9 +180,7 @@ class TestOIDCTokenExchangeView:
 
     def test_valid_token_returns_jwt(self, user_factory, client):
         user = user_factory()
-        self._make_token(
-            user, client, expires_at=timezone.now() + timedelta(hours=1)
-        )
+        self._make_token(user, client, expires_at=timezone.now() + timedelta(hours=1))
         api_client = APIClient()
         response = api_client.post(
             "/api/jwt/", {"oidc_token": "test-oidc-access-token"}
@@ -206,9 +204,7 @@ class TestOIDCTokenExchangeView:
 
     def test_expired_token_returns_400(self, user_factory, client):
         user = user_factory()
-        self._make_token(
-            user, client, expires_at=timezone.now() - timedelta(hours=1)
-        )
+        self._make_token(user, client, expires_at=timezone.now() - timedelta(hours=1))
         api_client = APIClient()
         response = api_client.post(
             "/api/jwt/", {"oidc_token": "test-oidc-access-token"}

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock
 import pytest
 from allauth.account.models import EmailAddress
 from oidc_provider.lib.utils.token import create_token
-from oidc_provider.models import UserConsent
+from oidc_provider.models import Token, UserConsent
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -164,3 +164,54 @@ class TestUserAPI:
         # the `uuid` AliasField fails only in tests for some reason
         response = api_client.get(f"/api/users/{user.individual_organization_id}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db()
+class TestOIDCTokenExchangeView:
+    def _make_token(self, user, client, expires_at):
+        return Token.objects.create(
+            user=user,
+            client=client,
+            access_token="test-oidc-access-token",
+            refresh_token="test-oidc-refresh-token",
+            expires_at=expires_at,
+            _id_token="",
+        )
+
+    def test_valid_token_returns_jwt(self, user_factory, client):
+        user = user_factory()
+        self._make_token(
+            user, client, expires_at=timezone.now() + timedelta(hours=1)
+        )
+        api_client = APIClient()
+        response = api_client.post(
+            "/api/jwt/", {"oidc_token": "test-oidc-access-token"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+
+    def test_invalid_token_returns_400(self):
+        api_client = APIClient()
+        response = api_client.post("/api/jwt/", {"oidc_token": "nonexistent-token"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"error": "invalid token"}
+
+    def test_missing_token_returns_400(self):
+        api_client = APIClient()
+        response = api_client.post("/api/jwt/", {})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"error": "invalid token"}
+
+    def test_expired_token_returns_400(self, user_factory, client):
+        user = user_factory()
+        self._make_token(
+            user, client, expires_at=timezone.now() - timedelta(hours=1)
+        )
+        api_client = APIClient()
+        response = api_client.post(
+            "/api/jwt/", {"oidc_token": "test-oidc-access-token"}
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"error": "token expired"}

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -11,9 +11,11 @@ from django.utils.translation import gettext_lazy as _
 import sesame.utils
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from allauth.account.utils import setup_user_email
+from oidc_provider.models import Token
 from rest_framework import status, viewsets
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 
 # Squarelet
@@ -113,4 +115,27 @@ class RefreshTokenViewSet(viewsets.ViewSet):
         ).split(" ")
         return Response(
             {"refresh_token": str(token), "access_token": str(token.access_token)}
+        )
+
+
+class OIDCTokenExchangeView(APIView):
+
+    def post(self, request):
+        oidc_token = request.data.get("oidc_token")
+        # Validate against django-oidc-provider's token model
+
+        try:
+            token = Token.objects.get(access_token=oidc_token)
+        except Token.DoesNotExist:
+            return Response({"error": "invalid token"}, status=400)
+
+        if token.has_expired():
+            return Response({"error": "token expired"}, status=400)
+
+        refresh = RefreshToken.for_user(token.user)
+        return Response(
+            {
+                "access_token": str(refresh.access_token),
+                "refresh_token": str(refresh),
+            }
         )


### PR DESCRIPTION
Looking into how the oAuth flow works, a new endpoint was needed.  I have added an endpoint that allows you to exchange an OIDC access token (gotten from /openid/token) for a JWT access and refresh token, which can be used on the DocumentCloud API.

Use the access token from `/openid/token`.  Make a `POST` request to `/api/jwt/` with the token in the body parameter `oidc_token`.  It will return a JSON object with an `access_token` and a `refresh_token`.