### PR TITLE
Google connect redirect fix

### DIFF
--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -236,7 +236,8 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return reverse("users:detail", kwargs={"username": request.user.username})
         messages.warning(
             request,
-            "Your session expired. Please sign in again to connect your Google account.",
+            "Your session expired. Please sign in again"
+            "to connect your Google account.",
         )
         return reverse("account_login")
 

--- a/squarelet/users/adapters.py
+++ b/squarelet/users/adapters.py
@@ -232,7 +232,13 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         """
         Redirect to the user detail page after connecting a social account.
         """
-        return reverse("users:detail", kwargs={"username": request.user.username})
+        if request.user.is_authenticated and request.user.username:
+            return reverse("users:detail", kwargs={"username": request.user.username})
+        messages.warning(
+            request,
+            "Your session expired. Please sign in again to connect your Google account.",
+        )
+        return reverse("account_login")
 
 
 class MfaAdapter(DefaultMFAAdapter):


### PR DESCRIPTION
Should fix #521 

Testing steps: 

- Log in 
- Click "Connect Google Account" from user page. Keep the profile page open in one tab. 
- Start Google oAuth setup
- In another logged in tab, log out. 
- Finish connecting Google account. You should be redirected to log back in with a warning about what happened. 
- Ensure no error is logged in Sentry. 

