### PR TITLE
optimize sql

### DIFF
--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -172,11 +172,8 @@ class EntitlementQuerySet(models.QuerySet):
         # Squarelet
         from squarelet.organizations.models.payment import EntitlementGrant
 
-        plan_q = Q(plans__organizations=org)
-        grant_pks = [g.pk for g in EntitlementGrant.objects.matching(org)]
-        grant_q = Q(grants__in=grant_pks)
-
-        qs = self.filter(plan_q | grant_q)
+        matching_grants = EntitlementGrant.objects.for_org(org)
+        qs = self.filter(Q(plans__organizations=org) | Q(grants__in=matching_grants))
         if client is not None:
             qs = qs.filter(client=client)
         return qs.distinct()
@@ -192,21 +189,34 @@ class EntitlementGrantQuerySet(models.QuerySet):
             on_date = timezone.now().date()
         return self.filter(update_on__lte=on_date)
 
-    def matching(self, org):
-        """Return active grants applying to `org`, as a list.
+    def for_org(self, org):
+        """Active grants that apply to `org`. Pure SQL — no Python-level loop.
 
-        Prefetches `organizations` and `entitlements` so callers can iterate
-        related rows without further queries.
+        A grant matches when the org type is compatible AND either:
+        - the org is explicitly listed in `organizations`, OR
+        - the grant has at least one rule flag set and every active rule is
+          satisfied by this org's attributes.
         """
-        org_type_filter = (
+        org_type_q = (
             Q(for_individuals=True) if org.individual else Q(for_groups=True)
         )
-        candidates = (
-            self.active()
-            .filter(org_type_filter)
-            .prefetch_related("organizations", "entitlements")
+        explicit_q = org_type_q & Q(organizations=org)
+
+        at_least_one_rule = (
+            Q(require_verified=True) | Q(require_active_subscription=True)
         )
-        return [g for g in candidates if g.matches(org)]
+        # If the org fails a requirement, exclude grants that set that flag.
+        verified_ok = (
+            Q() if org.verified_journalist else Q(require_verified=False)
+        )
+        sub_ok = (
+            Q()
+            if org.has_active_subscription()
+            else Q(require_active_subscription=False)
+        )
+        rule_q = org_type_q & at_least_one_rule & verified_ok & sub_ok
+
+        return self.active().filter(explicit_q | rule_q).distinct()
 
 
 class InvitationQuerySet(models.QuerySet):

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -190,25 +190,21 @@ class EntitlementGrantQuerySet(models.QuerySet):
         return self.filter(update_on__lte=on_date)
 
     def for_org(self, org):
-        """Active grants that apply to `org`. Pure SQL — no Python-level loop.
+        """Active grants that apply to `org`.
 
         A grant matches when the org type is compatible AND either:
         - the org is explicitly listed in `organizations`, OR
         - the grant has at least one rule flag set and every active rule is
           satisfied by this org's attributes.
         """
-        org_type_q = (
-            Q(for_individuals=True) if org.individual else Q(for_groups=True)
-        )
+        org_type_q = Q(for_individuals=True) if org.individual else Q(for_groups=True)
         explicit_q = org_type_q & Q(organizations=org)
 
-        at_least_one_rule = (
-            Q(require_verified=True) | Q(require_active_subscription=True)
+        at_least_one_rule = Q(require_verified=True) | Q(
+            require_active_subscription=True
         )
         # If the org fails a requirement, exclude grants that set that flag.
-        verified_ok = (
-            Q() if org.verified_journalist else Q(require_verified=False)
-        )
+        verified_ok = Q() if org.verified_journalist else Q(require_verified=False)
         sub_ok = (
             Q()
             if org.has_active_subscription()

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -1,6 +1,8 @@
+# Django
+from django.db.models import Q
+
 # Third Party
 import stripe
-from django.db.models import Q
 from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
 

--- a/squarelet/organizations/serializers.py
+++ b/squarelet/organizations/serializers.py
@@ -1,5 +1,6 @@
 # Third Party
 import stripe
+from django.db.models import Q
 from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
 
@@ -93,11 +94,18 @@ class OrganizationDetailSerializer(OrganizationSerializer):
         if not client:
             return []
 
-        # With a client, get entitlements for the org
+        # Compute matching grants once; reused for both the entitlement query
+        # and the grant_update_on map below (avoids a second DB round-trip).
+        matching_grants = EntitlementGrant.objects.for_org(obj).prefetch_related(
+            "entitlements"
+        )
         entitlements = list(
-            Entitlement.objects.for_organization(obj, client=client).values(
-                "pk", "name", "slug", "description", "resources"
+            Entitlement.objects.filter(
+                Q(plans__organizations=obj) | Q(grants__in=matching_grants),
+                client=client,
             )
+            .distinct()
+            .values("pk", "name", "slug", "description", "resources")
         )
 
         sub = obj.subscription
@@ -107,7 +115,7 @@ class OrganizationDetailSerializer(OrganizationSerializer):
         # matching grant's update_on per entitlement.
         grant_update_on = {}
         if sub_update_on is None:
-            for grant in EntitlementGrant.objects.matching(obj):
+            for grant in matching_grants:
                 if grant.update_on is None:
                     continue
                 for ent in grant.entitlements.all():

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -53,9 +53,7 @@ def restore_organization():
     grant_uuids = set()
     active_expired = list(expired_grants.filter(active=True))
     if active_expired:
-        qs_list = [
-            g.matching_organizations().values("uuid") for g in active_expired
-        ]
+        qs_list = [g.matching_organizations().values("uuid") for g in active_expired]
         union_qs = qs_list[0].union(*qs_list[1:])
         grant_uuids = {row["uuid"] for row in union_qs}
     expired_grants.update(update_on=today + Interval("1 month"))

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -51,10 +51,13 @@ def restore_organization():
     # bump too but contribute no UUIDs to the broadcast.
     expired_grants = EntitlementGrant.objects.expired(today)
     grant_uuids = set()
-    for grant in expired_grants.filter(active=True):
-        grant_uuids.update(
-            grant.matching_organizations().values_list("uuid", flat=True)
-        )
+    active_expired = list(expired_grants.filter(active=True))
+    if active_expired:
+        qs_list = [
+            g.matching_organizations().values("uuid") for g in active_expired
+        ]
+        union_qs = qs_list[0].union(*qs_list[1:])
+        grant_uuids = {row["uuid"] for row in union_qs}
     expired_grants.update(update_on=today + Interval("1 month"))
 
     all_uuids = list({*sub_uuids, *grant_uuids})


### PR DESCRIPTION
  querysets.py
  - Replaced EntitlementGrantQuerySet.matching() (Python loop + matches() call + N hidden queries) with for_org() — a pure SQL method that expresses all matching logic as Q objects using the org's known scalar attributes.
  - Rewrote EntitlementQuerySet.for_organization() to pass the lazy for_org() queryset directly as a subquery instead of materializing grant PKs with [g.pk for g in ...].

  serializers.py
  - Added from django.db.models import Q.
  - Rewrote get_entitlements() to compute matching_grants = EntitlementGrant.objects.for_org(obj) once, use it in the Entitlement.objects.filter(...) query, and iterate it again (with prefetch_related("entitlements")) for the grant_update_on map — eliminating the second
  call to matching().

  tasks.py
  - Replaced the for grant in ... N+1 loop in restore_organization() with collecting querysets per grant and merging them via .union(), so all matching-org lookups go through one SQL UNION query instead of N separate queries.