### PR TITLE
Hide inactive users from fe_api

### DIFF
--- a/squarelet/users/fe_api/viewsets.py
+++ b/squarelet/users/fe_api/viewsets.py
@@ -27,7 +27,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         if self.action == "list":
             if not self.request.user.is_authenticated:
                 return User.objects.none()
-            qs = User.objects.get_searchable(self.request.user)
+            qs = User.objects.get_searchable(self.request.user).filter(is_active=True)
             search = self.request.query_params.get("search", "").strip()
             if search:
                 # Full-text search with prefix matching.


### PR DESCRIPTION
get_searchable may gets called elsewhere and is likely not the appropriate place to add the is_active filter as there are legitimate use case where staff want to see inactive users, so it is filtered on the fe_api level

Should close #679 