### PR TITLE
OIDC Exchange Update

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -14,7 +14,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 # Squarelet
 from squarelet.core.views import HomeView, SelectPlanView
-from squarelet.oidc.views import OIDCRedirectURIUpdater, token_view
+from squarelet.oidc.views import OIDCRedirectURIUpdater
 from squarelet.organizations.fe_api.viewsets import (
     InvitationViewSet as FEInvitationViewSet,
     OrganizationViewSet as FEOrganizationViewSet,
@@ -93,7 +93,6 @@ urlpatterns = [
     path("api/jwt/", OIDCTokenExchangeView.as_view(), name="token_oidc_exchange"),
     path("api/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("openid/", include("oidc_provider.urls", namespace="oidc_provider")),
-    path("openid/jwt", token_view, name="oidc_jwt"),
     path("hijack/", include("hijack.urls", namespace="hijack")),
     re_path(r"^robots\.txt", include("robots.urls")),
     re_path(

--- a/squarelet/oidc/tests/factories.py
+++ b/squarelet/oidc/tests/factories.py
@@ -20,6 +20,7 @@ class ClientFactory(factory.django.DjangoModelFactory):
     website_url = factory.Faker("url")
     terms_url = factory.Faker("url")
     contact_email = factory.Faker("email")
+    _scope = ""
 
     class Meta:
         model = "oidc_provider.Client"

--- a/squarelet/oidc/views.py
+++ b/squarelet/oidc/views.py
@@ -1,88 +1,16 @@
-# Standard
 # Django
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.views.decorators.csrf import csrf_exempt
 
 # Third Party
-from oidc_provider import settings, views
-from oidc_provider.lib import endpoints
-from oidc_provider.lib.errors import TokenError, UserAuthError
-from oidc_provider.lib.utils.token import create_id_token, create_token, encode_id_token
 from oidc_provider.models import Client
 from rest_framework import status
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_simplejwt.tokens import RefreshToken
 
 # Squarelet
 from squarelet.oidc.permissions import ScopePermission
-
-
-class TokenEndpoint(endpoints.token.TokenEndpoint):
-    """Override OIDC token endpoint to use our JWT tokens"""
-
-    def create_code_response_dic(self):
-        # See https://tools.ietf.org/html/rfc6749#section-4.1
-
-        token = create_token(
-            user=self.code.user, client=self.code.client, scope=self.code.scope
-        )
-
-        if self.code.is_authentication:
-            id_token_dic = create_id_token(
-                user=self.code.user,
-                aud=self.client.client_id,
-                token=token,
-                nonce=self.code.nonce,
-                at_hash=token.at_hash,
-                request=self.request,
-                scope=token.scope,
-            )
-        else:
-            id_token_dic = {}
-        token.id_token = id_token_dic
-
-        # Store the token.
-        token.save()
-
-        jwt = RefreshToken.for_user(self.code.user)
-
-        # We don't need to store the code anymore.
-        self.code.delete()
-
-        dic = {
-            "access_token": str(jwt.access_token),
-            "refresh_token": str(jwt),
-            "token_type": "bearer",
-            "expires_in": settings.get("OIDC_TOKEN_EXPIRE"),
-            "id_token": encode_id_token(id_token_dic, token.client),
-        }
-
-        return dic
-
-
-class TokenView(views.TokenView):
-    """Override OIDC provider token view to use our JWT tokens"""
-
-    def post(self, request, *args, **kwargs):
-        token = TokenEndpoint(request)
-
-        try:
-            token.validate_params()
-
-            dic = token.create_response_dic()
-
-            return TokenEndpoint.response(dic)
-
-        except TokenError as error:
-            return TokenEndpoint.response(error.create_dict(), status=400)
-        except UserAuthError as error:
-            return TokenEndpoint.response(error.create_dict(), status=403)
-
-
-token_view = csrf_exempt(TokenView.as_view())
 
 
 class OIDCRedirectURIUpdater(APIView):

--- a/squarelet/users/tests/test_api.py
+++ b/squarelet/users/tests/test_api.py
@@ -178,9 +178,12 @@ class TestOIDCTokenExchangeView:
             _id_token="",
         )
 
-    def test_valid_token_returns_jwt(self, user_factory, client):
+    def test_valid_token_returns_jwt(self, user_factory):
         user = user_factory()
-        self._make_token(user, client, expires_at=timezone.now() + timedelta(hours=1))
+        first_party_client = ClientFactory(_scope="read_auth_token")
+        self._make_token(
+            user, first_party_client, expires_at=timezone.now() + timedelta(hours=1)
+        )
         api_client = APIClient()
         response = api_client.post(
             "/api/jwt/", {"oidc_token": "test-oidc-access-token"}
@@ -202,12 +205,28 @@ class TestOIDCTokenExchangeView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"error": "invalid token"}
 
-    def test_expired_token_returns_400(self, user_factory, client):
+    def test_expired_token_returns_400(self, user_factory):
         user = user_factory()
-        self._make_token(user, client, expires_at=timezone.now() - timedelta(hours=1))
+        first_party_client = ClientFactory(_scope="read_auth_token")
+        self._make_token(
+            user, first_party_client, expires_at=timezone.now() - timedelta(hours=1)
+        )
         api_client = APIClient()
         response = api_client.post(
             "/api/jwt/", {"oidc_token": "test-oidc-access-token"}
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"error": "token expired"}
+
+    def test_third_party_client_returns_403(self, user_factory):
+        user = user_factory()
+        third_party_client = ClientFactory()  # no read_auth_token scope
+        self._make_token(
+            user, third_party_client, expires_at=timezone.now() + timedelta(hours=1)
+        )
+        api_client = APIClient()
+        response = api_client.post(
+            "/api/jwt/", {"oidc_token": "test-oidc-access-token"}
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"error": "first party clients only"}

--- a/squarelet/users/viewsets.py
+++ b/squarelet/users/viewsets.py
@@ -125,13 +125,15 @@ class OIDCTokenExchangeView(APIView):
         # Validate against django-oidc-provider's token model
 
         try:
-            token = Token.objects.get(access_token=oidc_token)
+            token = Token.objects.select_related("client").get(access_token=oidc_token)
         except Token.DoesNotExist:
             return Response({"error": "invalid token"}, status=400)
 
         if token.has_expired():
             return Response({"error": "token expired"}, status=400)
 
+        if "read_auth_token" not in token.client.scope:
+            return Response({"error": "first party clients only"}, status=403)
         refresh = RefreshToken.for_user(token.user)
         return Response(
             {


### PR DESCRIPTION
ScopePermission in squarelet/oidc/permissions checks for auth too, which is why I didn't use it. Took a look at the Klaxon-Cloud code and it POSTs an OIDC token with no auth header. Since this is a one time use case permission, I did the check in line, but if necessary I can break it off into its own permission. 

Also removes the old JWT endpoint. This PR closes #676 