### PR TITLE
Fix plan purchase template to show org picker when user belongs to no orgs

### DIFF
--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -117,20 +117,14 @@ test.describe("Organization Viewing", () => {
     });
 
     test("cannot see admin emails without a verified email", async ({ page }) => {
-      // Unverify e2e-regular's email so we can test the unverified case
-      runManageCommand(
-        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=False)"`,
-      );
-
+      await login(page, "e2e-unverified");
       await page.goto("/organizations/e2e-public-org/");
       await expect(page.locator(".user .info .caption")).toHaveCount(0);
+    });
 
-      // Re-verify the email and confirm admin emails now appear
-      runManageCommand(
-        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=True)"`,
-      );
-
-      await page.reload();
+    test("sees admin emails with a verified email", async ({ page }) => {
+      // e2e-regular (logged in via beforeEach) has a verified email.
+      await page.goto("/organizations/e2e-public-org/");
       await expect(page.locator(".user .info .caption").first()).toBeVisible();
     });
   });

--- a/e2e/plans.spec.ts
+++ b/e2e/plans.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { login } from "./helpers";
+import { login, runManageCommand } from "./helpers";
 
 test.describe("Plan purchase redirects", () => {
   test("purchase_redirect query param is preserved in hidden form input", async ({ page }) => {
@@ -50,6 +50,38 @@ test.describe("Plan purchase organization selection", () => {
       await expect(
         page.locator(`${orgForm} .no-subscription-options`),
       ).toHaveCount(0);
+    });
+  });
+
+  test.describe("Group plan, user with no group orgs and unverified email", () => {
+    // A user must verify their email before they can create an organization.
+    // With no eligible orgs and an unverified email, the create-new option must
+    // be withheld and an email-verification message shown instead.
+    test.beforeEach(async ({ page }) => {
+      runManageCommand(
+        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=False)"`,
+      );
+      await login(page, "e2e-regular");
+      await page.goto("/plans/e2e-test-plan/");
+    });
+
+    test.afterEach(() => {
+      // Restore the verified email so other tests see the seeded state
+      runManageCommand(
+        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=True)"`,
+      );
+    });
+
+    test("does not offer the create-new-organization option", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} select.org-select option[value="new"]`),
+      ).toHaveCount(0);
+    });
+
+    test("shows the email-verification message", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} .no-subscription-options.unverified-email`),
+      ).toBeVisible();
     });
   });
 

--- a/e2e/plans.spec.ts
+++ b/e2e/plans.spec.ts
@@ -18,3 +18,66 @@ test.describe("Plan purchase redirects", () => {
     expect(page.url()).toContain("purchase_redirect=https");
   });
 });
+
+test.describe("Plan purchase organization selection", () => {
+  // The organization-selection block renders when the user has eligible
+  // organizations OR the plan is for groups (so a new org can be created).
+  // Otherwise the "no subscription options" message is shown instead.
+  const orgForm = "[data-plan-purchase-form]";
+
+  test.describe("Group plan, user with no group orgs", () => {
+    // e2e-regular is a member of no organizations, so the org queryset is
+    // empty for a groups-only plan. The form must still offer "Create a new
+    // organization" rather than the no-options message.
+    test.beforeEach(async ({ page }) => {
+      await login(page, "e2e-regular");
+      await page.goto("/plans/e2e-test-plan/");
+    });
+
+    test("renders the organization selection block", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} .organization-selection`),
+      ).toBeVisible();
+    });
+
+    test("offers the create-new-organization option", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} select.org-select option[value="new"]`),
+      ).toHaveCount(1);
+    });
+
+    test("does not show the no-subscription-options message", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} .no-subscription-options`),
+      ).toHaveCount(0);
+    });
+  });
+
+  test.describe("Individual-only plan", () => {
+    // The professional plan is for individuals only. The user's individual
+    // organization populates the queryset, so the selection renders without a
+    // create-new option and without the no-options message.
+    test.beforeEach(async ({ page }) => {
+      await login(page, "e2e-regular");
+      await page.goto("/plans/professional/");
+    });
+
+    test("renders the organization selection block", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} .organization-selection`),
+      ).toBeVisible();
+    });
+
+    test("does not offer the create-new-organization option", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} select.org-select option[value="new"]`),
+      ).toHaveCount(0);
+    });
+
+    test("does not show the no-subscription-options message", async ({ page }) => {
+      await expect(
+        page.locator(`${orgForm} .no-subscription-options`),
+      ).toHaveCount(0);
+    });
+  });
+});

--- a/e2e/plans.spec.ts
+++ b/e2e/plans.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { login, runManageCommand } from "./helpers";
+import { login } from "./helpers";
 
 test.describe("Plan purchase redirects", () => {
   test("purchase_redirect query param is preserved in hidden form input", async ({ page }) => {
@@ -58,18 +58,8 @@ test.describe("Plan purchase organization selection", () => {
     // With no eligible orgs and an unverified email, the create-new option must
     // be withheld and an email-verification message shown instead.
     test.beforeEach(async ({ page }) => {
-      runManageCommand(
-        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=False)"`,
-      );
-      await login(page, "e2e-regular");
+      await login(page, "e2e-unverified");
       await page.goto("/plans/e2e-test-plan/");
-    });
-
-    test.afterEach(() => {
-      // Restore the verified email so other tests see the seeded state
-      runManageCommand(
-        `shell -c "from allauth.account.models import EmailAddress; EmailAddress.objects.filter(user__username='e2e-regular').update(verified=True)"`,
-      );
     });
 
     test("does not offer the create-new-organization option", async ({ page }) => {

--- a/squarelet/core/management/commands/seed_e2e_data.py
+++ b/squarelet/core/management/commands/seed_e2e_data.py
@@ -25,6 +25,7 @@ USERS = [
     {"username": "e2e-member", "is_staff": False},
     {"username": "e2e-regular", "is_staff": False},
     {"username": "e2e-requester", "is_staff": False},
+    {"username": "e2e-unverified", "is_staff": False, "verified": False},
 ]
 
 # DB-assigned Organization permissions for the e2e-staff user
@@ -148,7 +149,7 @@ class Command(BaseCommand):
                 user=user,
                 email=email,
                 primary=True,
-                verified=True,
+                verified=user_spec.get("verified", True),
             )
 
             # Set last_mfa_prompt so the MFA onboarding step is snoozed,

--- a/squarelet/payments/forms.py
+++ b/squarelet/payments/forms.py
@@ -12,6 +12,7 @@ import sys
 # Third Party
 import stripe
 from allauth.account.adapter import get_adapter
+from allauth.account.utils import has_verified_email
 
 # Squarelet
 from squarelet.core.forms import StripeForm
@@ -193,6 +194,16 @@ class PlanPurchaseForm(StripeForm):
         if not self.plan or not self.plan.is_sunlight_plan or is_nonprofit_variant:
             del self.fields["is_nonprofit"]
 
+    def user_has_verified_email(self):
+        """
+        Whether the form's user has a verified email address.
+
+        Used by the template to decide whether to offer the
+        "Create a new organization" option, mirroring the server-side
+        constraint enforced in clean().
+        """
+        return has_verified_email(self.user)
+
     def get_org_cards_data(self):
         """
         Build a mapping of organization IDs to their saved card info.
@@ -297,6 +308,16 @@ class PlanPurchaseForm(StripeForm):
         payment_method = data.get("payment_method")
         stripe_token = data.get("stripe_token")
 
+        # Users must verify an email address before creating a new organization
+        if organization == "new" and not has_verified_email(self.user):
+            self.add_error(
+                "organization",
+                _(
+                    "You must verify your email address before "
+                    "creating an organization."
+                ),
+            )
+
         # Validate payment method matches available options
         if payment_method == "existing-card":
             if organization and organization != "new":
@@ -355,6 +376,16 @@ class PlanPurchaseForm(StripeForm):
         organization = self.cleaned_data.get("organization")
 
         if organization == "new":
+            # Defense in depth: clean() rejects new-org creation for users
+            # without a verified email, but guard here as well since this is
+            # the actual creation point.
+            if not has_verified_email(user):
+                raise forms.ValidationError(
+                    _(
+                        "You must verify your email address before "
+                        "creating an organization."
+                    )
+                )
             new_org = Organization.objects.create(
                 name=self.cleaned_data["new_organization_name"],
                 private=False,

--- a/squarelet/payments/tests/test_forms.py
+++ b/squarelet/payments/tests/test_forms.py
@@ -214,7 +214,7 @@ class TestPlanPurchaseFormValidation:
 
     def test_new_organization_requires_name(self, user_factory, plan_factory):
         """Creating new organization requires name"""
-        user = user_factory()
+        user = user_factory(email_verified=True)
         plan = plan_factory(for_groups=True, public=True)
 
         data = {
@@ -228,6 +228,59 @@ class TestPlanPurchaseFormValidation:
         form = PlanPurchaseForm(data, plan=plan, user=user)
         assert not form.is_valid()
         assert "new_organization_name" in form.errors
+
+    def test_new_organization_requires_verified_email(self, user_factory, plan_factory):
+        """Creating a new organization requires a verified email address"""
+        user = user_factory(email_verified=False)
+        plan = plan_factory(for_groups=True, public=True)
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "My New Org",
+            "payment_method": "new-card",
+            "stripe_token": "tok_visa",
+            "stripe_pk": "pk_test",
+        }
+
+        form = PlanPurchaseForm(data, plan=plan, user=user)
+        assert not form.is_valid()
+        assert "organization" in form.errors
+
+    def test_new_organization_allowed_with_verified_email(
+        self, user_factory, plan_factory
+    ):
+        """Verified users may create a new organization"""
+        user = user_factory(email_verified=True)
+        plan = plan_factory(for_groups=True, public=True)
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "My New Org",
+            "payment_method": "new-card",
+            "stripe_token": "tok_visa",
+            "stripe_pk": "pk_test",
+        }
+
+        form = PlanPurchaseForm(data, plan=plan, user=user)
+        assert form.is_valid(), f"Form errors: {form.errors}"
+
+    def test_existing_org_allowed_without_verified_email(
+        self, user_factory, plan_factory
+    ):
+        """The verified-email constraint only applies to creating new orgs;
+        an unverified user may still subscribe an existing organization."""
+        user = user_factory(email_verified=False)
+        plan = plan_factory(public=True, for_individuals=True)
+
+        data = {
+            "organization": str(user.individual_organization.pk),
+            "payment_method": "new-card",
+            "stripe_token": "tok_visa",
+            "stripe_pk": "pk_test",
+        }
+
+        form = PlanPurchaseForm(data, plan=plan, user=user)
+        assert form.is_valid(), f"Form errors: {form.errors}"
 
     def test_existing_card_valid_when_org_has_card(
         self, user_factory, plan_factory, mocker
@@ -294,6 +347,10 @@ class TestPlanPurchaseFormTemplate:
         """Template should render non-field errors"""
         assert "form.non_field_errors" in self.template_content
 
+    def test_template_gates_new_org_option_on_verified_email(self):
+        """The create-new-organization option must be gated on a verified email"""
+        assert "has_verified_email" in self.template_content
+
 
 @pytest.mark.django_db
 class TestPlanPurchaseFormSave:
@@ -323,7 +380,7 @@ class TestPlanPurchaseFormSave:
 
     def test_save_creates_new_organization(self, user_factory, plan_factory):
         """Save creates new organization when selected"""
-        user = user_factory()
+        user = user_factory(email_verified=True)
         plan = plan_factory(for_groups=True, public=True)
 
         data = {

--- a/squarelet/payments/tests/test_views.py
+++ b/squarelet/payments/tests/test_views.py
@@ -26,7 +26,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
         self, rf, user_factory, plan_factory, mocker
     ):
         """Test creating a new organization during plan subscription"""
-        user = user_factory()
+        user = user_factory(email_verified=True)
         plan = plan_factory(for_groups=True, public=True)
 
         # Mock the set_subscription method to avoid Stripe calls
@@ -83,11 +83,38 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
         # Verify no organization was created
         assert not Organization.objects.filter(name="").exists()
 
+    def test_unverified_user_cannot_create_organization(
+        self, rf, user_factory, plan_factory, mocker
+    ):
+        """A user without a verified email may not create a new organization"""
+        user = user_factory(email_verified=False)
+        plan = plan_factory(for_groups=True, public=True)
+
+        # Guard against any subscription side effects
+        mock_set_subscription = mocker.patch.object(
+            Organization, "set_subscription", return_value=None
+        )
+
+        data = {
+            "organization": "new",
+            "new_organization_name": "Should Not Exist",
+            "payment_method": "new-card",
+            "stripe_token": "tok_visa",
+            "stripe_pk": "pk_test",
+        }
+
+        response = self.call_view(rf, user, data=data, pk=plan.pk, slug=plan.slug)
+
+        # Form is invalid: re-renders (200), no org created, no subscription
+        assert response.status_code == 200
+        assert not Organization.objects.filter(name="Should Not Exist").exists()
+        mock_set_subscription.assert_not_called()
+
     def test_new_organization_adds_user_as_admin(
         self, rf, user_factory, plan_factory, mocker
     ):
         """Test that user is added as admin when creating new organization"""
-        user = user_factory()
+        user = user_factory(email_verified=True)
         plan = plan_factory(for_groups=True, public=True)
 
         # Mock set_subscription

--- a/squarelet/templates/payments/forms/plan_purchase.html
+++ b/squarelet/templates/payments/forms/plan_purchase.html
@@ -6,7 +6,7 @@
     {{ hidden }}
   {% endfor %}
 
-  {% if form.organization.field.queryset.exists %}
+  {% if form.organization.field.queryset.exists or form.plan.for_groups %}
     {# Organization selection #}
     <div class="organization-selection">
       <label for="{{ form.organization.id_for_label }}">
@@ -148,15 +148,9 @@
       <span class="discounted-price" style="display:none;"></span>
       <span class="pay-period">/&nbsp;{% if form.plan.annual %}{% trans "year" %}{% else %}{% trans "month" %}{% endif %}</span>
     </div>
-    {% if form.organization.field.queryset.exists %}
-      <button type="submit" class="btn premium" disabled>
-        {% trans "Subscribe" %}
-      </button>
-    {% else %}
-      <button type="submit" class="btn premium" disabled>
-        {% trans "Subscribe" %}
-      </button>
-    {% endif %}
+    <button type="submit" class="btn premium" disabled>
+      {% trans "Subscribe" %}
+    </button>
   </div>
 
   {# JSON data for JavaScript #}

--- a/squarelet/templates/payments/forms/plan_purchase.html
+++ b/squarelet/templates/payments/forms/plan_purchase.html
@@ -6,7 +6,9 @@
     {{ hidden }}
   {% endfor %}
 
-  {% if form.organization.field.queryset.exists or form.plan.for_groups %}
+  {% with verified=form.user_has_verified_email %}
+  {# A new organization can only be created by a user with a verified email #}
+  {% if form.organization.field.queryset.exists or form.plan.for_groups and verified %}
     {# Organization selection #}
     <div class="organization-selection">
       <label for="{{ form.organization.id_for_label }}">
@@ -23,7 +25,7 @@
               {{ org.name }}{% if org.individual %} ({% trans "Personal" %}){% endif %}
             </option>
           {% endfor %}
-          {% if form.plan.for_groups %}
+          {% if form.plan.for_groups and verified %}
             <option value="new" data-slug="" data-individual="false"
                     {% if form.organization.value == 'new' %}selected{% endif %}>
               {% trans "Create a new organization" %}
@@ -126,11 +128,25 @@
     </div>
     {% endif %}
 
+  {% elif form.plan.for_groups and not verified %}
+    <div class="no-subscription-options unverified-email">
+      <p>
+        {% blocktrans %}
+          You must verify your email address before creating an organization.
+          Please check your inbox for a verification email, or view your
+          connected accounts to resend it.
+        {% endblocktrans %}
+      </p>
+      <a href="{% url 'users:detail' form.user %}#accounts" class="btn primary">
+        {% trans "Go to account" %}
+      </a>
+    </div>
   {% else %}
     <div class="no-subscription-options">
       <p>{% trans "You are already subscribed to this plan or don't have permission to subscribe." %}</p>
     </div>
   {% endif %}
+  {% endwith %}
 
   {# Non-field errors #}
   {% if form.non_field_errors %}


### PR DESCRIPTION
Close #695

On Friday, we encountered an issue where a user who belongs to no orgs cannot purchase a group plan. They should be offered the option to create a new org then and there.

This also enforces the requirement that users must have a verified email before they can create an organization through the plan page. This wasn't enforced previously.