### PR TITLE
Fix user integrity error on user creation during signup

### DIFF
--- a/squarelet/users/managers.py
+++ b/squarelet/users/managers.py
@@ -1,7 +1,7 @@
 # Django
 from django.contrib.auth.models import UserManager as AuthUserManager
 from django.core.exceptions import ValidationError
-from django.db import transaction, IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 
 # Squarelet

--- a/squarelet/users/managers.py
+++ b/squarelet/users/managers.py
@@ -1,6 +1,7 @@
 # Django
 from django.contrib.auth.models import UserManager as AuthUserManager
-from django.db import transaction
+from django.core.exceptions import ValidationError
+from django.db import transaction, IntegrityError
 from django.db.models import Q
 
 # Squarelet
@@ -38,7 +39,12 @@ class UserManager(AuthUserManager):
             user.set_unusable_password()
 
         # all users must have an individual organization
-        Organization.objects.create_individual(user, uuid)
+        try:
+            Organization.objects.create_individual(user, uuid)
+        except IntegrityError:
+            raise ValidationError(
+                {"username": "A user with that username already exists."}
+            )
 
         return user
 


### PR DESCRIPTION
This is issue #692 

I'm like 99% sure these are bot signups triggering this error to begin with, in every single one of these instances the users I can trace this to have garbage emails, sign up, never confirm their email and then never log in again. I think they are probably using some kind of threaded approach to filling out the signup form simultaneously and sometimes two threads hit a race condition. That's how I was able to replicate and confirm this fixes that issue, at least. 

Errors: ["Thread 2: ValidationError: {'username': ['A user with that username already exists.']}", "Thread 4: ValidationError: {'username': ['A user with that username already exists.']}", "Thread 0: ValidationError: {'username': ['A user with that username already exists.']}", "Thread 1: ValidationError: {'username': ['A user with that username already exists.']}", "Thread 3: ValidationError: {'username': ['A user with that username already exists.']}"]
