### PR TITLE
Update plan receipt template

### DIFF
--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -712,6 +712,7 @@ class Charge(models.Model):
         merged = list(existing) + [e for e in current_emails if e not in seen]
         self.metadata["receipt_emails"] = merged
         self.save(update_fields=["metadata"])
+        plan = Plan.objects.filter(name=self.metadata.get("plan")).first()
 
         send_mail(
             subject=_("Receipt"),
@@ -720,8 +721,7 @@ class Charge(models.Model):
             organization_to=ORG_TO_RECEIPTS,
             extra_context={
                 "charge": self,
-                "individual_subscription": self.description == "Professional",
-                "group_subscription": self.description.startswith("Organization"),
+                "plan": plan,
                 "receipt_emails": current_emails,
             },
         )

--- a/squarelet/organizations/tests/models/test_charge.py
+++ b/squarelet/organizations/tests/models/test_charge.py
@@ -1,8 +1,18 @@
+# Django
+from django.urls import reverse
+
 # Standard Library
 from unittest.mock import PropertyMock
 
 # Third Party
 import pytest
+
+# pylint: disable=too-many-positional-arguments
+
+
+def receipt_html(mailoutbox):
+    """Return the rendered HTML body of the most recent receipt email."""
+    return mailoutbox[-1].alternatives[0][0]
 
 
 class TestCharge:
@@ -80,6 +90,119 @@ class TestCharge:
             "b@example.com",
             "c@example.com",
         }
+
+    @pytest.mark.django_db()
+    def test_send_receipt_describes_plan(
+        self, charge_factory, plan_factory, mailoutbox, mocker
+    ):
+        """The receipt names the purchased plan and lists its benefits."""
+        mocked = mocker.patch(
+            "squarelet.organizations.models.Charge.charge", new_callable=PropertyMock
+        )
+        mocked.return_value = {"source": {"brand": "Visa", "last4": "1234"}}
+
+        plan_factory(
+            name="Sunlight Research Center - Basic",
+            short_description="Investigative research tools.",
+            benefits=["Unlimited requests", "Priority support"],
+        )
+        charge = charge_factory(metadata={"plan": "Sunlight Research Center - Basic"})
+        charge.organization.set_receipt_emails(["receipts@example.com"])
+        charge.send_receipt()
+
+        html = receipt_html(mailoutbox)
+        assert "Sunlight Research Center - Basic" in html
+        assert "Investigative research tools." in html
+        assert "Unlimited requests" in html
+        assert "Priority support" in html
+
+    @pytest.mark.django_db()
+    def test_send_receipt_individual_management_links(
+        self,
+        charge_factory,
+        plan_factory,
+        individual_organization_factory,
+        mailoutbox,
+        mocker,
+    ):
+        """Individual receipts link to the user settings page."""
+        mocked = mocker.patch(
+            "squarelet.organizations.models.Charge.charge", new_callable=PropertyMock
+        )
+        mocked.return_value = {"source": {"brand": "Visa", "last4": "1234"}}
+
+        plan_factory(name="Professional")
+        organization = individual_organization_factory()
+        charge = charge_factory(
+            organization=organization, metadata={"plan": "Professional"}
+        )
+        organization.set_receipt_emails(["receipts@example.com"])
+        charge.send_receipt()
+
+        html = receipt_html(mailoutbox)
+        assert reverse("users:payment_redirect") in html
+
+    @pytest.mark.django_db()
+    def test_send_receipt_group_management_links(
+        self, charge_factory, plan_factory, organization_factory, mailoutbox, mocker
+    ):
+        """Group receipts link to the org payment and member management pages."""
+        mocked = mocker.patch(
+            "squarelet.organizations.models.Charge.charge", new_callable=PropertyMock
+        )
+        mocked.return_value = {"source": {"brand": "Visa", "last4": "1234"}}
+
+        plan_factory(name="Organization")
+        organization = organization_factory(individual=False)
+        charge = charge_factory(
+            organization=organization, metadata={"plan": "Organization"}
+        )
+        organization.set_receipt_emails(["receipts@example.com"])
+        charge.send_receipt()
+
+        html = receipt_html(mailoutbox)
+        assert (
+            reverse("organizations:payment", kwargs={"slug": organization.slug}) in html
+        )
+        assert (
+            reverse("organizations:manage-members", kwargs={"slug": organization.slug})
+            in html
+        )
+
+    @pytest.mark.django_db()
+    def test_send_receipt_includes_guidance(
+        self, charge_factory, plan_factory, mailoutbox, mocker
+    ):
+        """Every receipt explains how to dispute a charge and links to the
+        cancellation policy."""
+        mocked = mocker.patch(
+            "squarelet.organizations.models.Charge.charge", new_callable=PropertyMock
+        )
+        mocked.return_value = {"source": {"brand": "Visa", "last4": "1234"}}
+
+        plan_factory(name="Professional")
+        charge = charge_factory(metadata={"plan": "Professional"})
+        charge.organization.set_receipt_emails(["receipts@example.com"])
+        charge.send_receipt()
+
+        html = receipt_html(mailoutbox)
+        assert "info@muckrock.com" in html
+        assert "https://www.muckrock.com/tos/#payments" in html
+
+    @pytest.mark.django_db()
+    def test_send_receipt_without_plan(self, charge_factory, mailoutbox, mocker):
+        """A charge with no matching plan still renders the generic receipt."""
+        mocked = mocker.patch(
+            "squarelet.organizations.models.Charge.charge", new_callable=PropertyMock
+        )
+        mocked.return_value = {"source": {"brand": "Visa", "last4": "1234"}}
+
+        charge = charge_factory(metadata={})
+        charge.organization.set_receipt_emails(["receipts@example.com"])
+        charge.send_receipt()
+
+        html = receipt_html(mailoutbox)
+        assert "This receipt confirms your payment to MuckRock." in html
 
     def test_items_no_fee(self, charge_factory):
         charge = charge_factory.build()

--- a/squarelet/templates/organizations/email/receipt.html
+++ b/squarelet/templates/organizations/email/receipt.html
@@ -50,52 +50,54 @@
       {% endif %}
     </p>
     {% block description %}
-      <p>{% trans "This receipt confirms your payment to MuckRock." %}</p>
+      {% if plan %}
+        <p>
+          {% blocktrans with plan_name=plan.name %}This receipt confirms your subscription to the {{ plan_name }} plan.{% endblocktrans %}
+        </p>
+        {% if plan.short_description %}
+          <p>{{ plan.short_description }}</p>
+        {% endif %}
+        {% if plan.benefits %}
+          <p>{% trans "Your plan includes:" %}</p>
+          <ul>
+            {% for benefit in plan.benefits %}
+              <li>{{ benefit }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      {% else %}
+        <p>{% trans "This receipt confirms your payment to MuckRock." %}</p>
+      {% endif %}
     {% endblock %}
-    {% if individual_subscription %}
+    {% if charge.organization.individual %}
       {% url "users:payment_redirect" as user_payment_url %}
       {% blocktrans with user_payment_url=user_payment_url %}
         <p>
-          Your account includes up to 20 requests per month, the ability to
-          embargo requests, and access to priority support. It also includes, upon
-          account verification, access to DocumentCloud, including 
-          2,000 AI credits per month which you can use to perform advanced 
-          OCR or run other premium Add-Ons.  
-        </p>
-
-        <p>
-          You can manage your account
-          from <a href="{{ user_payment_url }}"q>your settings</a>, including
-          upgrading, downgrading, and cancelling your account.
+          You can manage your subscription from
+          <a href="{{ user_payment_url }}">your settings</a>, including
+          upgrading, downgrading, and cancelling at any time.
         </p>
       {% endblocktrans %}
-    {% endif %}
-    {% if group_subscription %}
+    {% else %}
       {% url "organizations:payment" slug=charge.organization.slug as org_payment_url %}
       {% url "organizations:manage-members" slug=charge.organization.slug as org_member_url %}
-      {% blocktrans with org_payment_url=org_payment_url org_payment_url=org_payment_url %}
+      {% blocktrans with org_payment_url=org_payment_url org_member_url=org_member_url %}
         <p>
-          Your account starts with 5 members and 50 collective requests 
-          per month on MuckRock, the ability to embargo requests and 
-          access to priority support. It also includes, upon
-          account verification, access to DocumentCloud including 5,000
-          AI credits per month which you can use to run advanced OCR 
-          or run other premium Add-Ons. Additional members can be added 
-          for $10/each, which includes 5 additional requests and 500 advanced 
-          OCR pages per member added. To update your account payment settings, 
-          such as adjusting receipt delivery preferences, updating the card on file 
-          or canceling your account, please visit the 
+          To update your account payment settings — such as adjusting receipt
+          delivery preferences, updating the card on file, or cancelling your
+          subscription — please visit the
           <a href="{{ org_payment_url }}">account payment settings page</a>.
-          To add or remove members to your organization please visit the <a href="{{ org_member_url }}"> membership management page</a>.
+          To add or remove members from your organization, please visit the
+          <a href="{{ org_member_url }}">membership management page</a>.
         </p>
       {% endblocktrans %}
     {% endif %}
-    {% blocktrans %}
-      <p>
-        For concerns or more information about this charge, please contact
-        <a href="mailto:info@muckrock.com">info@muckrock.com</a>.
-      </p>
-      <p>Thank you,<br/>The MuckRock Team</p>
-    {% endblocktrans %}
+    <p>
+      {% blocktrans %}For more information about this charge or to dispute it, please contact <a href="mailto:info@muckrock.com">info@muckrock.com</a>.{% endblocktrans %}
+    </p>
+    <p>
+      {% blocktrans %}For details on how subscriptions are billed and cancelled, see our <a href="https://www.muckrock.com/tos/#payments">Payments Policy</a>.{% endblocktrans %}
+    </p>
+    <p>{% blocktrans %}Thank you,<br/>The MuckRock Team{% endblocktrans %}</p>
   </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #605

- Dynamically loads plan descriptions and benefits in receipts, instead of using hardcoded language.
- Includes links to Payments policy, links to manage the assocated organization (individual or group), and a link to contact support

# Preview

<img width="614" height="965" alt="receipt_group_example" src="https://github.com/user-attachments/assets/9e893202-32b7-4b53-86f0-bfa8f5e72ec4" />
<img width="632" height="621" alt="receipt_individual_example" src="https://github.com/user-attachments/assets/f92c4751-a2ba-45de-abde-e14d5dcb59b3" />
