### PR TITLE
Gate requests for verification behind confirmation check

### DIFF
--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -193,12 +193,48 @@ class TestDetail(ViewTestMixin):
     def test_verification_context_for_member(
         self, rf, organization_factory, user_factory
     ):
-        """Test that members don't see verification request prompt"""
+        """Test that members (not just admins) see the verification request"""
         member = user_factory()
         organization = organization_factory(users=[member], verified_journalist=False)
         response = self.call_view(rf, member, slug=organization.slug)
         assert response.status_code == 200
+        assert response.context_data["show_verification_request"] is True
+
+    def test_verification_context_for_non_member(
+        self, rf, organization_factory, user_factory
+    ):
+        """Test that non-members don't see the verification request prompt.
+
+        Use a staff user, since they can view an unverified org they don't
+        belong to (regular non-members can only view verified orgs).
+        """
+        staff_user = user_factory(is_staff=True)
+        organization = organization_factory(verified_journalist=False)
+        response = self.call_view(rf, staff_user, slug=organization.slug)
+        assert response.status_code == 200
         assert response.context_data["show_verification_request"] is False
+
+    def test_has_verified_email_context_true(
+        self, rf, organization_factory, user_factory
+    ):
+        """Members with a confirmed email can request verification"""
+        member = user_factory(email_verified=True)
+        organization = organization_factory(users=[member], verified_journalist=False)
+        response = self.call_view(rf, member, slug=organization.slug)
+        assert response.status_code == 200
+        assert response.context_data["show_verification_request"] is True
+        assert response.context_data["has_verified_email"] is True
+
+    def test_has_verified_email_context_false(
+        self, rf, organization_factory, user_factory
+    ):
+        """Members without a confirmed email cannot request verification"""
+        member = user_factory(email_verified=False)
+        organization = organization_factory(users=[member], verified_journalist=False)
+        response = self.call_view(rf, member, slug=organization.slug)
+        assert response.status_code == 200
+        assert response.context_data["show_verification_request"] is True
+        assert response.context_data["has_verified_email"] is False
 
     def test_security_settings_context_for_admin(
         self, rf, organization_factory, user_factory

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -69,9 +69,15 @@ class Detail(AdminLinkMixin, DetailView):
         if current_plan and subscription:
             context.update(self._get_subscription_context(org, subscription))
 
+        # Any member (not just admins) may request verification, but only if
+        # they have confirmed an email address on their account.
         context["show_verification_request"] = (
-            user.has_perm("organizations.change_organization", org)
+            user.is_authenticated
+            and org.has_member(user)
             and not org.verified_journalist
+        )
+        context["has_verified_email"] = (
+            user.is_authenticated and user.has_verified_email()
         )
 
         if user.has_perm("organizations.can_manage_domains", org):
@@ -384,6 +390,7 @@ class List(ListView):
         context["pending_invitations"] = InvitationAcceptForm.attach_to_invitations(
             list(user.get_pending_invitations()), user, request=self.request
         )
+        context["has_verified_email"] = user.has_verified_email()
 
         return context
 

--- a/squarelet/templates/organizations/organization_detail.html
+++ b/squarelet/templates/organizations/organization_detail.html
@@ -303,9 +303,14 @@
             <h3>{% trans "This organization is not verified." %}</h3>
             {% if show_verification_request %}
               <p class="help-text">{% trans "Request newsroom verification to access additional reporting and publishing tools." %}</p>
-              <a target="_blank" rel="noopener noreferrer" class="btn primary" href="{% airtable_verification_url organization %}">
-                {% trans "Request verification" %}
-              </a>
+              {% if has_verified_email %}
+                <a target="_blank" rel="noopener noreferrer" class="btn primary" href="{% airtable_verification_url organization %}">
+                  {% trans "Request verification" %}
+                </a>
+              {% else %}
+                <button class="btn primary" disabled>{% trans "Request verification" %}</button>
+                <p class="help-text error">{% trans "Confirm your account's email address before requesting verification." %}</p>
+              {% endif %}
             {% endif %}
           </div>
         {% endif %}

--- a/squarelet/templates/organizations/your_organizations.html
+++ b/squarelet/templates/organizations/your_organizations.html
@@ -78,7 +78,7 @@
             {% trans "Request verification" %}
           </a>
           {% else %}
-          <button type="button" class="btn ghost primary small" disabled title="{% trans 'Confirm your account's email address before requesting verification.' %}">
+          <button type="button" class="btn ghost primary small" disabled title="{% trans "Confirm your account's email address before requesting verification." %}">
             {% trans "Request verification" %}
           </button>
           {% endif %}

--- a/squarelet/templates/organizations/your_organizations.html
+++ b/squarelet/templates/organizations/your_organizations.html
@@ -73,9 +73,15 @@
       {% include "account/team_list_item.html" with organization=org %}
       <div class="actions">
         {% if not org.verified_journalist %}
-        <a target="_blank" rel="noopener noreferrer" class="btn ghost primary small" href="{% airtable_verification_url org %}">
-          {% trans "Request verification" %}
-        </a>
+          {% if has_verified_email %}
+          <a target="_blank" rel="noopener noreferrer" class="btn ghost primary small" href="{% airtable_verification_url org %}">
+            {% trans "Request verification" %}
+          </a>
+          {% else %}
+          <button type="button" class="btn ghost primary small" disabled title="{% trans 'Confirm your account's email address before requesting verification.' %}">
+            {% trans "Request verification" %}
+          </button>
+          {% endif %}
         {% endif %}
         <a class="btn ghost primary small" href="{% url "organizations:manage-members" slug=org.slug %}">
           {% icon "gear" %}
@@ -100,9 +106,15 @@
         {% csrf_token %}
         <input type="hidden" name="userid" value="{{ user.id }}">
         {% if not org.verified_journalist %}
-        <a target="_blank" rel="noopener noreferrer" class="btn ghost primary small" href="{% airtable_verification_url org %}">
-          {% trans "Request verification" %}
-        </a>
+          {% if has_verified_email %}
+          <a target="_blank" rel="noopener noreferrer" class="btn ghost primary small" href="{% airtable_verification_url org %}">
+            {% trans "Request verification" %}
+          </a>
+          {% else %}
+          <button type="button" class="btn ghost primary small" disabled title="{% trans 'Confirm an email address on your account before requesting verification.' %}">
+            {% trans "Request verification" %}
+          </button>
+          {% endif %}
         {% endif %}
         <button class="btn danger ghost small" type="submit" name="action" value="leave">
           {% icon "sign-out" %}

--- a/squarelet/users/models.py
+++ b/squarelet/users/models.py
@@ -243,6 +243,10 @@ class User(AvatarMixin, AbstractBaseUser, PermissionsMixin):
     def verified_journalist(self):
         return self.organizations.filter(verified_journalist=True).exists()
 
+    def has_verified_email(self):
+        """Whether the user has at least one confirmed email address."""
+        return self.emailaddress_set.filter(verified=True).exists()
+
     def get_emails(self, verified=False):
         """Returns a list of the user's emails."""
         emails = self.emailaddress_set.all()

--- a/squarelet/users/tests/test_models.py
+++ b/squarelet/users/tests/test_models.py
@@ -34,6 +34,18 @@ def test_get_full_name(user_factory):
     assert user.get_full_name() == user.name
 
 
+@pytest.mark.django_db()
+def test_has_verified_email_true(user_factory):
+    user = user_factory(email_verified=True)
+    assert user.has_verified_email() is True
+
+
+@pytest.mark.django_db()
+def test_has_verified_email_false(user_factory):
+    user = user_factory(email_verified=False)
+    assert user.has_verified_email() is False
+
+
 def test_safe_name_with_name(user_factory):
     user = user_factory.build()
     assert user.safe_name() == user.name

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -155,6 +155,8 @@ class UserDetailView(LoginRequiredMixin, StaffAccessMixin, AdminLinkMixin, Detai
         context["has_unverified_emails"] = user.emailaddress_set.filter(
             verified=False
         ).exists()
+        # Only users with a confirmed email may request verification
+        context["has_verified_email"] = user.has_verified_email()
         context["RECOVERY_CODE_COUNT"] = app_settings.RECOVERY_CODE_COUNT
         context["unused_code_count"] = len(self.get_recovery_codes())
         # Get the current plan and subscription, if any


### PR DESCRIPTION
Fixes #708

Users may request verification for organizations they belong to, as long as they have confirmed their email address.

This ensures consistency between organization and user detail pages.