### PR TITLE
Handle errors thrown when creating an individual_org for a user

### DIFF
--- a/squarelet/users/managers.py
+++ b/squarelet/users/managers.py
@@ -3,10 +3,17 @@ from django.contrib.auth.models import UserManager as AuthUserManager
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
+
+# Standard Library
+import logging
+import sys
 
 # Squarelet
 from squarelet.core.utils import mailchimp_journey
 from squarelet.organizations.models import Organization
+
+logger = logging.getLogger(__name__)
 
 
 class UserManager(AuthUserManager):
@@ -39,12 +46,25 @@ class UserManager(AuthUserManager):
             user.set_unusable_password()
 
         # all users must have an individual organization
+        # Wrap in a savepoint so that a failed insert (e.g. a username
+        # collision, including races that slip past form/serializer
+        # validation) rolls back cleanly. Without the savepoint the
+        # IntegrityError poisons the surrounding ATOMIC_REQUESTS transaction
+        # and orphans the just-created organization.
         try:
-            Organization.objects.create_individual(user, uuid)
-        except IntegrityError:
-            raise ValidationError(
-                {"username": "A user with that username already exists."}
+            with transaction.atomic():
+                Organization.objects.create_individual(user, uuid)
+        except IntegrityError as exc:
+            logger.warning(
+                "Could not create individual organization for username %r: %s",
+                username,
+                exc,
+                exc_info=sys.exc_info(),
             )
+            raise ValidationError(
+                {"username": _("A user with that username already exists.")},
+                code="duplicate_username",
+            ) from exc
 
         return user
 

--- a/squarelet/users/serializers.py
+++ b/squarelet/users/serializers.py
@@ -1,3 +1,6 @@
+# Django
+from django.core.exceptions import ValidationError
+
 # Standard Library
 import random
 import re
@@ -120,7 +123,11 @@ class UserWriteSerializer(UserBaseSerializer):
             validated_data["username"] = self.unique_username(
                 validated_data["username"]
             )
-        user = User.objects.create_user(**validated_data)
+        try:
+            user = User.objects.create_user(**validated_data)
+        except ValidationError as exc:
+            # surface a username collision (e.g. a race) as a 400 rather than a 500
+            raise serializers.ValidationError(exc.message_dict) from exc
 
         return user
 

--- a/squarelet/users/tests/test_managers.py
+++ b/squarelet/users/tests/test_managers.py
@@ -1,13 +1,52 @@
+# Django
+from django.core.exceptions import ValidationError
+
 # Third Party
 import pytest
 
 # Squarelet
+from squarelet.organizations.models import Organization
 from squarelet.organizations.tests.factories import (
     MembershipFactory,
     OrganizationFactory,
 )
 from squarelet.users.models import User
 from squarelet.users.tests.factories import UserFactory
+
+
+class TestCreateUser:
+    """Tests for individual organization creation in UserManager._create_user"""
+
+    @pytest.mark.django_db
+    def test_duplicate_username_raises_validation_error(self):
+        """A duplicate username raises a clean ValidationError rather than letting
+        the IntegrityError poison the surrounding transaction."""
+        User.objects.create_user(username="john", email="john@example.com")
+
+        with pytest.raises(ValidationError) as excinfo:
+            User.objects.create_user(username="john", email="john2@example.com")
+        assert "username" in excinfo.value.message_dict
+
+        # The connection must still be usable after catching the error; without a
+        # savepoint around the failed insert this query raises
+        # TransactionManagementError under ATOMIC_REQUESTS.
+        assert User.objects.filter(username="john").count() == 1
+        # The failed insert must not leave an orphaned individual organization.
+        assert Organization.objects.filter(name="john", individual=True).count() == 1
+
+    @pytest.mark.django_db
+    def test_duplicate_username_case_insensitive(self):
+        """Username uniqueness is enforced case-insensitively (case_insensitive
+        collation), and a case variant is handled just as gracefully."""
+        User.objects.create_user(username="john", email="john@example.com")
+
+        with pytest.raises(ValidationError):
+            User.objects.create_user(username="John", email="john2@example.com")
+
+        assert (
+            Organization.objects.filter(name__iexact="john", individual=True).count()
+            == 1
+        )
 
 
 class TestGetSearchable:

--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -1,6 +1,7 @@
 # Django
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ValidationError
 from django.http.response import Http404
 
 # Standard Library
@@ -17,9 +18,98 @@ from allauth.account.models import EmailAddress
 from squarelet.core.tests.mixins import ViewTestMixin
 from squarelet.organizations.models import Invitation
 from squarelet.organizations.models.payment import Plan
-from squarelet.users import views
+from squarelet.users import forms, views
+from squarelet.users.models import User
 
 # pylint: disable=too-many-positional-arguments, too-many-lines
+
+
+class TestSignupView:
+    """Test graceful handling of individual organization collisions on signup"""
+
+    SIGNUP_DATA = {
+        "name": "john doe",
+        "username": "john",
+        "email": "doe@example.com",
+        "password1": "squarelet",
+        "stripe_pk": "key",
+        "tos": True,
+    }
+
+    def _make_form(self, plan):
+        data = {**self.SIGNUP_DATA, "plan": plan.slug}
+        form = forms.SignupForm(data)
+        assert form.is_valid()
+        return form
+
+    @pytest.mark.django_db
+    def test_form_valid_handles_collision(self, rf, plan_factory, mocker):
+        """A ValidationError raised while creating the individual organization
+        (e.g. a double-submitted signup that races past validation) is surfaced
+        as a form error rather than an unhandled 500."""
+        plan = plan_factory()
+        form = self._make_form(plan)
+
+        request = rf.post("/accounts/signup/", self.SIGNUP_DATA)
+        request.session = mocker.MagicMock()
+
+        # No pending social login: exercise the standard (allauth) path
+        mocker.patch(
+            "squarelet.users.views.flows.signup.get_pending_signup",
+            return_value=None,
+        )
+        # Simulate the collision surfacing from the manager
+        mocker.patch.object(
+            User.objects,
+            "register_user",
+            side_effect=ValidationError(
+                {"username": ["A user with that username already exists."]}
+            ),
+        )
+
+        view = views.SignupView()
+        view.request = request
+        sentinel = object()
+        form_invalid = mocker.patch.object(view, "form_invalid", return_value=sentinel)
+
+        response = view.form_valid(form)
+
+        assert response is sentinel
+        form_invalid.assert_called_once_with(form)
+        assert "username" in form.errors
+
+    @pytest.mark.django_db
+    def test_form_valid_handles_collision_social(self, rf, plan_factory, mocker):
+        """The same graceful handling applies to the social signup branch."""
+        plan = plan_factory()
+        form = self._make_form(plan)
+
+        request = rf.post("/accounts/signup/", self.SIGNUP_DATA)
+        request.session = mocker.MagicMock()
+
+        mocker.patch(
+            "squarelet.users.views.flows.signup.get_pending_signup",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch("squarelet.users.views.flows.signup.clear_pending_signup")
+        mocker.patch.object(
+            User.objects,
+            "register_user",
+            side_effect=ValidationError(
+                {"username": ["A user with that username already exists."]}
+            ),
+        )
+
+        view = views.SignupView()
+        view.request = request
+        sentinel = object()
+        form_invalid = mocker.patch.object(view, "form_invalid", return_value=sentinel)
+
+        response = view.form_valid(form)
+
+        assert response is sentinel
+        form_invalid.assert_called_once_with(form)
+        assert "username" in form.errors
 
 
 @pytest.mark.django_db()

--- a/squarelet/users/tests/test_views.py
+++ b/squarelet/users/tests/test_views.py
@@ -8,6 +8,7 @@ from django.http.response import Http404
 import hashlib
 import hmac
 import json
+import secrets
 import time
 
 # Third Party
@@ -27,17 +28,23 @@ from squarelet.users.models import User
 class TestSignupView:
     """Test graceful handling of individual organization collisions on signup"""
 
-    SIGNUP_DATA = {
+    BASE_DATA = {
         "name": "john doe",
         "username": "john",
         "email": "doe@example.com",
-        "password1": "squarelet",
         "stripe_pk": "key",
         "tos": True,
     }
 
-    def _make_form(self, plan):
-        data = {**self.SIGNUP_DATA, "plan": plan.slug}
+    def _signup_data(self, plan):
+        # generate the password at runtime so no credential literal is committed
+        return {
+            **self.BASE_DATA,
+            "plan": plan.slug,
+            "password1": secrets.token_urlsafe(16),
+        }
+
+    def _make_form(self, data):
         form = forms.SignupForm(data)
         assert form.is_valid()
         return form
@@ -48,9 +55,10 @@ class TestSignupView:
         (e.g. a double-submitted signup that races past validation) is surfaced
         as a form error rather than an unhandled 500."""
         plan = plan_factory()
-        form = self._make_form(plan)
+        data = self._signup_data(plan)
+        form = self._make_form(data)
 
-        request = rf.post("/accounts/signup/", self.SIGNUP_DATA)
+        request = rf.post("/accounts/signup/", data)
         request.session = mocker.MagicMock()
 
         # No pending social login: exercise the standard (allauth) path
@@ -82,9 +90,10 @@ class TestSignupView:
     def test_form_valid_handles_collision_social(self, rf, plan_factory, mocker):
         """The same graceful handling applies to the social signup branch."""
         plan = plan_factory()
-        form = self._make_form(plan)
+        data = self._signup_data(plan)
+        form = self._make_form(data)
 
-        request = rf.post("/accounts/signup/", self.SIGNUP_DATA)
+        request = rf.post("/accounts/signup/", data)
         request.session = mocker.MagicMock()
 
         mocker.patch(

--- a/squarelet/users/views.py
+++ b/squarelet/users/views.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ValidationError
 from django.http.response import (
     Http404,
     HttpResponse,
@@ -491,16 +492,24 @@ class SignupView(AllAuthSignupView):
 
     def form_valid(self, form):
         sociallogin = flows.signup.get_pending_signup(self.request)
-        if sociallogin:
-            flows.signup.clear_pending_signup(self.request)
-            # do not setup email here, as it will be set up when completing
-            # the social signup flow
-            user = form.save(self.request, setup_email=False)
-            sociallogin.user = user
-            sociallogin.save(self.request)
-            return flows.signup.complete_social_signup(self.request, sociallogin)
-        else:
-            return super().form_valid(form)
+        try:
+            if sociallogin:
+                flows.signup.clear_pending_signup(self.request)
+                # do not setup email here, as it will be set up when completing
+                # the social signup flow
+                user = form.save(self.request, setup_email=False)
+                sociallogin.user = user
+                sociallogin.save(self.request)
+                return flows.signup.complete_social_signup(self.request, sociallogin)
+            else:
+                return super().form_valid(form)
+        except ValidationError as exc:
+            # A concurrent signup (e.g. a double-submitted form) can race past
+            # the form's uniqueness validation and collide when creating the
+            # user's individual organization. Surface it as a normal form error
+            # instead of letting it bubble up as an unhandled 500.
+            form.add_error(None, exc)
+            return self.form_invalid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Fixes #707
Fixes SQUARELET-JJ

Fixes the unhandled 500 on `/accounts/signup/` when a concurrent/double-submitted signup races past username validation and collides

## Changes
- **views.py** — `SignupView.form_valid` now catches `ValidationError` (both the standard and social branches) and re-renders the form via `form_invalid` instead of letting it bubble up as a 500.
- **managers.py** — wrapped individual-org creation in `_create_user` in a `transaction.atomic()` savepoint so a failed insert rolls back cleanly (no orphaned org, no poisoned request transaction); chained the re-raised `ValidationError` and log the collision as a warning.
- **serializers.py** — `UserWriteSerializer.create` converts the Django `ValidationError` to a DRF `ValidationError` so the API path returns 400, not 500.

## Tests
- `test_managers.py` — duplicate username (incl. case-insensitive) raises a clean `ValidationError` with no orphaned org.
- `test_views.py` — `SignupView.form_valid` handles the collision gracefully on both the standard and social branches.