### PR TITLE
Fix customer card

### DIFF
--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -15,6 +15,7 @@ from functools import cached_property
 # Third Party
 import stripe
 from autoslug import AutoSlugField
+from dateutil.relativedelta import relativedelta
 from sorl.thumbnail import ImageField
 
 # Squarelet

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -15,7 +15,6 @@ from functools import cached_property
 # Third Party
 import stripe
 from autoslug import AutoSlugField
-from dateutil.relativedelta import relativedelta
 from sorl.thumbnail import ImageField
 
 # Squarelet

--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -102,22 +102,30 @@ class Customer(models.Model):
             return stripe_customer
 
     @cached_property
-    def card(self):
+    def source(self):
         """Retrieve the customer's default saved payment method or source, if any."""
         return (
             get_payment_provider().get_customer_service().get_card(self.stripe_customer)
         )
 
+    @cached_property
+    def card(self):
+        """Retrieve the card from the source - old style sources are cards directly,
+        new style cards have them in a sub-object
+        """
+        source = self.source
+        if source is None:
+            return None
+        elif source.object == "payment_method":
+            return source.card
+        else:
+            return source
+
     @property
     def card_display(self):
-        card = self.card
-        if not card:
+        if not self.card:
             return ""
-        # PaymentMethod objects nest card details under .card; Sources expose
-        # brand/last4 directly.
-        if card.object == "payment_method":
-            return f"{card.card.brand}: x{card.card.last4}"
-        return f"{card.brand}: x{card.last4}"
+        return f"{self.card.brand}: x{self.card.last4}"
 
     def save_card(self, token):
         """Save a new default card"""
@@ -127,10 +135,10 @@ class Customer(models.Model):
 
     def remove_card(self):
         """Remove the default card"""
-        card = self.card
-        if card:
+        source = self.source
+        if source:
             get_payment_provider().get_customer_service().remove_card(
-                self.customer_id, card.id
+                self.customer_id, source.id
             )
 
     def add_source(self, token):

--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 # Standard Library
-import calendar
 import logging
 import sys
 from datetime import datetime, time, timezone as dt_timezone

--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 # Standard Library
+import calendar
 import logging
 import sys
 from datetime import datetime, time, timezone as dt_timezone

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -331,7 +331,7 @@ class ChargeQuerySet(models.QuerySet):
         if token:
             source = customer.add_source(token)
         else:
-            source = customer.card
+            source = customer.source
 
         default_metadata = {
             "organization": organization.name,

--- a/squarelet/organizations/tests/models/test_customer.py
+++ b/squarelet/organizations/tests/models/test_customer.py
@@ -35,7 +35,7 @@ class TestCustomer:
         customer.refresh_from_db()
         assert customer.customer_id == customer_id
 
-    def test_card_existing(self, customer_factory, mocker):
+    def test_source_existing(self, customer_factory, mocker):
         mock_stripe_customer = mocker.patch(
             "squarelet.organizations.models.Customer.stripe_customer"
         )
@@ -45,10 +45,10 @@ class TestCustomer:
         ).return_value.get_customer_service.return_value.get_card
         mock_get_card.return_value = mock_source
         customer = customer_factory.build()
-        assert mock_source == customer.card
+        assert mock_source == customer.source
         mock_get_card.assert_called_once_with(mock_stripe_customer)
 
-    def test_card_ach(self, customer_factory, mocker):
+    def test_source_none(self, customer_factory, mocker):
         mock_stripe_customer = mocker.patch(
             "squarelet.organizations.models.Customer.stripe_customer"
         )
@@ -57,21 +57,45 @@ class TestCustomer:
         ).return_value.get_customer_service.return_value.get_card
         mock_get_card.return_value = None
         customer = customer_factory.build()
-        assert customer.card is None
+        assert customer.source is None
         mock_get_card.assert_called_once_with(mock_stripe_customer)
 
-    def test_card_blank(self, customer_factory, mocker):
-        mocker.patch("squarelet.organizations.models.Customer.stripe_customer")
+    def test_card_legacy_source(self, customer_factory, mocker):
+        """Legacy Source objects are returned as-is from customer.card."""
+        mock_source = mocker.MagicMock(object="card")
         mocker.patch(
-            "squarelet.organizations.models.payment.get_payment_provider"
-        ).return_value.get_customer_service.return_value.get_card.return_value = None
+            "squarelet.organizations.models.Customer.source",
+            new_callable=mocker.PropertyMock,
+            return_value=mock_source,
+        )
+        customer = customer_factory.build()
+        assert customer.card is mock_source
+
+    def test_card_payment_method(self, customer_factory, mocker):
+        """PaymentMethod sources expose card details via .card sub-object."""
+        mock_card_details = mocker.MagicMock(brand="Visa", last4="4242")
+        mock_source = mocker.MagicMock(object="payment_method", card=mock_card_details)
+        mocker.patch(
+            "squarelet.organizations.models.Customer.source",
+            new_callable=mocker.PropertyMock,
+            return_value=mock_source,
+        )
+        customer = customer_factory.build()
+        assert customer.card is mock_card_details
+
+    def test_card_none(self, customer_factory, mocker):
+        mocker.patch(
+            "squarelet.organizations.models.Customer.source",
+            new_callable=mocker.PropertyMock,
+            return_value=None,
+        )
         customer = customer_factory.build()
         assert customer.card is None
 
     def test_card_display(self, customer_factory, mocker):
         brand = "Visa"
         last4 = "4242"
-        mock_card = mocker.MagicMock(object="card", brand=brand, last4=last4)
+        mock_card = mocker.MagicMock(brand=brand, last4=last4)
         mocker.patch(
             "squarelet.organizations.models.Customer.card",
             new_callable=mocker.PropertyMock,
@@ -81,10 +105,11 @@ class TestCustomer:
         assert customer.card_display == f"{brand}: x{last4}"
 
     def test_card_display_empty(self, customer_factory, mocker):
-        mocker.patch("squarelet.organizations.models.Customer.stripe_customer")
         mocker.patch(
-            "squarelet.organizations.models.payment.get_payment_provider"
-        ).return_value.get_customer_service.return_value.get_card.return_value = None
+            "squarelet.organizations.models.Customer.source",
+            new_callable=mocker.PropertyMock,
+            return_value=None,
+        )
         customer = customer_factory.build()
         assert customer.card_display == ""
 

--- a/squarelet/organizations/tests/test_querysets_charge.py
+++ b/squarelet/organizations/tests/test_querysets_charge.py
@@ -30,15 +30,15 @@ class TestChargeQuerySet:
         return mock_stripe_charge, mock_provider
 
     def _mock_customer_with_card(self, mocker):
-        """Mock Customer.card and stripe_customer for saved-card tests."""
-        mock_card = mocker.Mock(id="card_123")
+        """Mock Customer.source and stripe_customer for saved-card tests."""
+        mock_source = mocker.Mock(id="card_123")
         mocker.patch(
-            "squarelet.organizations.models.payment.Customer.card",
+            "squarelet.organizations.models.payment.Customer.source",
             new_callable=mocker.PropertyMock,
-            return_value=mock_card,
+            return_value=mock_source,
         )
         mocker.patch("squarelet.organizations.models.Customer.stripe_customer")
-        return mock_card
+        return mock_source
 
     @pytest.mark.django_db()
     def test_make_charge_with_new_card_token(self, mocker):
@@ -301,7 +301,7 @@ class TestChargeQuerySet:
         org = OrganizationFactory(customer__customer_id="cus_no_card")
         mocker.patch("squarelet.organizations.models.Customer.stripe_customer")
         mocker.patch(
-            "squarelet.organizations.models.payment.Customer.card",
+            "squarelet.organizations.models.payment.Customer.source",
             new_callable=mocker.PropertyMock,
             return_value=None,
         )

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -110,15 +110,8 @@ class Detail(AdminLinkMixin, DetailView):
     def _get_subscription_context(self, org, subscription):
         """Return context dict for card, next charge date, and cancellation status."""
         customer = org.customer()
-        if customer.card is None:
-            card = None
-        elif customer.card.object == "payment_method":
-            card = customer.card.card
-        else:
-            card = customer.card
-
         ctx = {
-            "current_plan_card": card,
+            "current_plan_card": customer.card,
             "current_plan_cancelled": subscription.cancelled,
         }
 


### PR DESCRIPTION
Old accounts will have the source as a card directly.  Updated accounts will have a payment method as the stripe object, which can have a card or bank account sub object.

Breaks out `card` and `source` - `source` just returns the stripe source, whatever it is, for where we need that.  `card` will check if it is old or new style and return the actual card object, so this check does not need to be done at all call sites.