### PR TITLE
Handle Subscription cancelation webhooks

### DIFF
--- a/squarelet/organizations/payments/providers/stripe_modern.py
+++ b/squarelet/organizations/payments/providers/stripe_modern.py
@@ -188,8 +188,9 @@ class StripeModernSubscriptionService(SubscriptionService):
 
     def get_current_period_end(self, stripe_subscription):
         # current_period_end moved from subscription root to subscription items
-        # in API version 2025-03-31.basil
-        items = stripe_subscription.items
+        # in API version 2025-03-31.basil. Webhook payloads may omit items
+        # entirely (e.g. a bare cancel_at_period_end toggle), so fall back to None.
+        items = getattr(stripe_subscription, "items", None)
         if items and items.data:
             return items.data[0].current_period_end
         return None

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -437,6 +437,22 @@ def handle_customer_updated(customer_data):
     )
 
 
+def _reconcile_cancelled_subscription(subscription, reason):
+    """Delete a locally-tracked subscription that Stripe has ended and
+    invalidate the organization's entitlement cache."""
+    organization_uuid = subscription.organization.uuid
+    subscription_id = subscription.subscription_id
+    subscription.delete()
+    send_cache_invalidations("organization", [organization_uuid])
+    logger.info(
+        "[STRIPE-WEBHOOK-SUBSCRIPTION] Reconciled cancelled subscription %s (%s); "
+        "deleted local record and invalidated cache for org %s",
+        subscription_id,
+        reason,
+        organization_uuid,
+    )
+
+
 @shared_task(
     name="squarelet.organizations.tasks.handle_subscription_updated",
     autoretry_for=(stripe.RateLimitError,),
@@ -456,12 +472,31 @@ def handle_subscription_updated(subscription_data):
         )
         return
 
+    # A terminal status means Stripe has ended the subscription (e.g. it was
+    # cancelled directly in the dashboard). Reconcile by removing the local
+    # record so the org no longer appears subscribed. Stripe normally also
+    # sends customer.subscription.deleted, but handling it here is idempotent
+    # (the other event will hit DoesNotExist). Check before caching fields so a
+    # terminal payload that omits period data does not need to be parsed.
+    if subscription_data.get("status") == "canceled":
+        _reconcile_cancelled_subscription(subscription, "status=canceled")
+        return
+
     stripe_sub = stripe.Subscription.construct_from(subscription_data, key=None)
     subscription.cache_stripe_subscription_fields(stripe_sub)
-    subscription.save(update_fields=["stripe_status", "current_period_end"])
+    # Mirror Stripe's pending-cancellation state onto the local record. This
+    # covers cancellations scheduled outside our own flow (dashboard, or the
+    # cancel_at_period_end set for auto_renew=False plans). The record is
+    # finally deleted when Stripe sends the deletion event at period end.
+    subscription.cancelled = bool(subscription_data.get("cancel_at_period_end"))
+    subscription.save(
+        update_fields=["stripe_status", "current_period_end", "cancelled"]
+    )
     logger.info(
-        "[STRIPE-WEBHOOK-SUBSCRIPTION] subscription.updated cached status for: %s",
+        "[STRIPE-WEBHOOK-SUBSCRIPTION] subscription.updated cached status for: %s "
+        "(cancelled=%s)",
         subscription_id,
+        subscription.cancelled,
     )
 
 
@@ -484,12 +519,7 @@ def handle_subscription_deleted(subscription_data):
         )
         return
 
-    subscription.stripe_status = subscription_data.get("status", "canceled")
-    subscription.save(update_fields=["stripe_status"])
-    logger.info(
-        "[STRIPE-WEBHOOK-SUBSCRIPTION] subscription.deleted cached status for: %s",
-        subscription_id,
-    )
+    _reconcile_cancelled_subscription(subscription, "subscription.deleted")
 
 
 @shared_task(name="squarelet.organizations.tasks.handle_invoice_paid")

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -489,8 +489,19 @@ def handle_subscription_updated(subscription_data):
     # cancel_at_period_end set for auto_renew=False plans). The record is
     # finally deleted when Stripe sends the deletion event at period end.
     subscription.cancelled = bool(subscription_data.get("cancel_at_period_end"))
+    # Track when Stripe will terminate the subscription, consistent with how
+    # Subscription.cancel() sets it. Clear it when a cancellation is reversed.
+    if subscription.cancelled and subscription.current_period_end:
+        subscription.cancel_at = subscription.current_period_end.date()
+    else:
+        subscription.cancel_at = None
     subscription.save(
-        update_fields=["stripe_status", "current_period_end", "cancelled"]
+        update_fields=[
+            "stripe_status",
+            "current_period_end",
+            "cancelled",
+            "cancel_at",
+        ]
     )
     logger.info(
         "[STRIPE-WEBHOOK-SUBSCRIPTION] subscription.updated cached status for: %s "

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -1,9 +1,10 @@
 # Django
 from django.test import override_settings
 from django.utils import timezone
+from django.utils.timezone import get_current_timezone
 
 # Standard Library
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 # Third Party
 import pytest
@@ -2203,6 +2204,63 @@ class TestHandleSubscriptionUpdated:
 
         subscription.refresh_from_db()
         assert subscription.cancelled is False
+
+    @pytest.mark.django_db
+    def test_sets_cancel_at_when_scheduled(self, subscription_factory, mocker):
+        """cancel_at is set from the period end when Stripe schedules cancellation"""
+        subscription = subscription_factory(subscription_id="sub_ca", cancelled=False)
+        period_end_ts = 1800000000
+
+        mock_sub_svc = mocker.MagicMock()
+        mock_sub_svc.get_current_period_end.return_value = period_end_ts
+        mock_provider = mocker.patch(
+            "squarelet.organizations.models.payment.get_payment_provider"
+        )
+        mock_provider.return_value.get_subscription_service.return_value = mock_sub_svc
+
+        tasks.handle_subscription_updated(
+            {
+                "id": "sub_ca",
+                "status": "active",
+                "cancel_at_period_end": True,
+                "items": {"data": [{"current_period_end": period_end_ts}]},
+            }
+        )
+
+        subscription.refresh_from_db()
+        expected = datetime.fromtimestamp(period_end_ts, tz=get_current_timezone())
+        assert subscription.cancelled is True
+        assert subscription.cancel_at == expected.date()
+
+    @pytest.mark.django_db
+    def test_clears_cancel_at_on_reactivation(self, subscription_factory, mocker):
+        """cancel_at is cleared when a scheduled cancellation is reversed"""
+        subscription = subscription_factory(
+            subscription_id="sub_react_ca",
+            cancelled=True,
+            cancel_at=date.today() + timedelta(days=10),
+        )
+        period_end_ts = 1800000000
+
+        mock_sub_svc = mocker.MagicMock()
+        mock_sub_svc.get_current_period_end.return_value = period_end_ts
+        mock_provider = mocker.patch(
+            "squarelet.organizations.models.payment.get_payment_provider"
+        )
+        mock_provider.return_value.get_subscription_service.return_value = mock_sub_svc
+
+        tasks.handle_subscription_updated(
+            {
+                "id": "sub_react_ca",
+                "status": "active",
+                "cancel_at_period_end": False,
+                "items": {"data": [{"current_period_end": period_end_ts}]},
+            }
+        )
+
+        subscription.refresh_from_db()
+        assert subscription.cancelled is False
+        assert subscription.cancel_at is None
 
     @pytest.mark.django_db
     def test_canceled_status_reconciles_subscription(

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -2171,6 +2171,56 @@ class TestHandleSubscriptionUpdated:
         assert int(subscription.current_period_end.timestamp()) == period_end_ts
 
     @pytest.mark.django_db
+    def test_syncs_cancel_at_period_end_true(self, subscription_factory):
+        """Marks the local subscription cancelled when Stripe schedules cancellation"""
+        subscription = subscription_factory(subscription_id="sub_cape", cancelled=False)
+
+        tasks.handle_subscription_updated(
+            {
+                "id": "sub_cape",
+                "status": "active",
+                "cancel_at_period_end": True,
+            }
+        )
+
+        subscription.refresh_from_db()
+        assert subscription.cancelled is True
+
+    @pytest.mark.django_db
+    def test_syncs_cancel_at_period_end_false(self, subscription_factory):
+        """Clears the local cancelled flag when Stripe cancellation is reversed"""
+        subscription = subscription_factory(
+            subscription_id="sub_reactivate", cancelled=True
+        )
+
+        tasks.handle_subscription_updated(
+            {
+                "id": "sub_reactivate",
+                "status": "active",
+                "cancel_at_period_end": False,
+            }
+        )
+
+        subscription.refresh_from_db()
+        assert subscription.cancelled is False
+
+    @pytest.mark.django_db
+    def test_canceled_status_reconciles_subscription(
+        self, subscription_factory, mocker
+    ):
+        """A terminal 'canceled' status deletes the record and invalidates the cache"""
+        patched = mocker.patch("squarelet.organizations.tasks.send_cache_invalidations")
+        subscription = subscription_factory(subscription_id="sub_upd_cancel")
+        org_uuid = subscription.organization.uuid
+
+        tasks.handle_subscription_updated(
+            {"id": "sub_upd_cancel", "status": "canceled"}
+        )
+
+        assert not Subscription.objects.filter(pk=subscription.pk).exists()
+        patched.assert_called_once_with("organization", [org_uuid])
+
+    @pytest.mark.django_db
     def test_unknown_subscription(self, mocker):
         """Logs a warning and returns gracefully for unknown subscription"""
         mock_logger = mocker.patch("squarelet.organizations.tasks.logger")
@@ -2182,12 +2232,18 @@ class TestHandleSubscriptionDeleted:
     """Unit tests for the handle_subscription_deleted task"""
 
     @pytest.mark.django_db
-    def test_marks_canceled(self, subscription_factory):
-        """Sets stripe_status to canceled"""
+    def test_deletes_subscription_and_invalidates_cache(
+        self, subscription_factory, mocker
+    ):
+        """Deleting on Stripe removes the local record and invalidates the cache"""
+        patched = mocker.patch("squarelet.organizations.tasks.send_cache_invalidations")
         subscription = subscription_factory(subscription_id="sub_del")
+        org_uuid = subscription.organization.uuid
+
         tasks.handle_subscription_deleted({"id": "sub_del", "status": "canceled"})
-        subscription.refresh_from_db()
-        assert subscription.stripe_status == "canceled"
+
+        assert not Subscription.objects.filter(pk=subscription.pk).exists()
+        patched.assert_called_once_with("organization", [org_uuid])
 
     @pytest.mark.django_db
     def test_unknown_subscription(self, mocker):


### PR DESCRIPTION
Fixes #731

Will delete a subscription when:

- `subscription.deleted` event received
- `subscription.updated` with `status="canceled"` received