### PR TITLE
Add 'election' tier to Wix label aliases

### DIFF
--- a/squarelet/organizations/tests/test_wix.py
+++ b/squarelet/organizations/tests/test_wix.py
@@ -361,8 +361,9 @@ class TestWix:
             ("sunlight-premium", "enhanced"),
             ("sunlight-premium-annual", "enhanced"),
             ("sunlight-nonprofit-premium", "enhanced"),
+            ("election-accountability-cohort", "election"),
             # Non-tiered plans fall back to the raw slug
-            ("election-accountability-cohort", "election-accountability-cohort"),
+            ("another-plan", "another-plan"),
         ],
     )
     def test_get_tier_from_plan(self, plan_slug, expected_tier):

--- a/squarelet/organizations/wix.py
+++ b/squarelet/organizations/wix.py
@@ -86,7 +86,7 @@ def get_tier_from_plan(plan):
         "essential": "essential",
         "basic": "essential",
         "premium": "enhanced",
-        "election": "election"
+        "election": "election",
     }
     return next(
         (label for alias, label in tier_aliases.items() if alias in plan.slug),

--- a/squarelet/organizations/wix.py
+++ b/squarelet/organizations/wix.py
@@ -86,6 +86,7 @@ def get_tier_from_plan(plan):
         "essential": "essential",
         "basic": "essential",
         "premium": "enhanced",
+        "election": "election"
     }
     return next(
         (label for alias, label in tier_aliases.items() if alias in plan.slug),


### PR DESCRIPTION
Wix has a character limit on labels, so we can't use the plan slug as our label. We need custom handling that turns `election-accountability-cohort` into `election`.