### PR TITLE
Prompt last admin to reassign before leaving

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -83,6 +83,32 @@ Organization.objects.filter(slug='${slug}').update(city='')
   );
 }
 
+/**
+ * Restore e2e-leave-org to its seeded membership state: e2e-lone-admin as the
+ * sole admin, with e2e-member and e2e-regular as regular members. Needed
+ * because the leave/reassign-admin flow deletes and promotes memberships, and
+ * clear_invitations only removes non-seeded memberships (it can't restore a
+ * removed admin or demote a promoted member).
+ */
+export function resetLeaveOrgState() {
+  runManageCommand(
+    `shell -c "
+from squarelet.organizations.models import Membership, Organization
+from squarelet.users.models import User
+org = Organization.objects.get(slug='e2e-leave-org')
+org.memberships.all().delete()
+usernames = ['e2e-lone-admin', 'e2e-member', 'e2e-regular']
+for i, username in enumerate(usernames):
+    user = User.objects.get(username=username)
+    Membership.objects.create(user=user, organization=org, admin=(i == 0))
+    # Individual orgs are hidden (and therefore unsearchable) by default;
+    # unhide so the outgoing admin can find members in the reassign widget.
+    user.individual_organization.hidden = False
+    user.individual_organization.save()
+"`,
+  );
+}
+
 export function resetAutoJoinState(slug: string) {
   runManageCommand(
     `shell -c "

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -85,7 +85,7 @@ Organization.objects.filter(slug='${slug}').update(city='')
 
 /**
  * Restore e2e-leave-org to its seeded membership state: e2e-lone-admin as the
- * sole admin, with e2e-member and e2e-regular as regular members. Needed
+ * sole admin, with e2e-member and e2e-leave-member as regular members. Needed
  * because the leave/reassign-admin flow deletes and promotes memberships, and
  * clear_invitations only removes non-seeded memberships (it can't restore a
  * removed admin or demote a promoted member).
@@ -97,7 +97,7 @@ from squarelet.organizations.models import Membership, Organization
 from squarelet.users.models import User
 org = Organization.objects.get(slug='e2e-leave-org')
 org.memberships.all().delete()
-usernames = ['e2e-lone-admin', 'e2e-member', 'e2e-regular']
+usernames = ['e2e-lone-admin', 'e2e-member', 'e2e-leave-member']
 for i, username in enumerate(usernames):
     user = User.objects.get(username=username)
     Membership.objects.create(user=user, organization=org, admin=(i == 0))

--- a/e2e/leave-organization.spec.ts
+++ b/e2e/leave-organization.spec.ts
@@ -1,0 +1,250 @@
+import { test, expect, type Page } from "@playwright/test";
+import { login, expectFlashMessage, resetLeaveOrgState } from "./helpers";
+
+const LEAVE_ORG = "e2e-leave-org";
+const LEAVE_URL = `/organizations/${LEAVE_ORG}/leave/`;
+const ORG_URL = `/organizations/${LEAVE_ORG}/`;
+
+/**
+ * Locate a member's row within a rendered member list. Both the organization
+ * detail page and the manage-members page render the same user_list_item
+ * partial, so each member appears as a `.user` block containing a link to their
+ * profile.
+ */
+export function memberRow(page: Page, username: string) {
+  return page.locator(".user").filter({
+    has: page.locator(`a[href="/users/${username}/"]`),
+  });
+}
+
+/** Assert, via the DOM, that a user appears as an admin in the member list. */
+export async function expectAdminBadge(page: Page, username: string) {
+  await expect(
+    memberRow(page, username).locator(".badge", { hasText: "Admin" }),
+  ).toBeVisible();
+}
+
+/**
+ * Assert, via the DOM, that a user appears in the member list as a regular
+ * member (present, but without the Admin badge).
+ */
+export async function expectMemberWithoutAdmin(page: Page, username: string) {
+  const row = memberRow(page, username);
+  await expect(row).toBeVisible();
+  await expect(row.locator(".badge", { hasText: "Admin" })).toHaveCount(0);
+}
+
+/** Assert, via the DOM, that a user is not present in the member list. */
+export async function expectNotMember(page: Page, username: string) {
+  await expect(memberRow(page, username)).toHaveCount(0);
+}
+
+test.describe("Leaving an organization as the sole admin", () => {
+  // The reassign flow mutates memberships (removing the admin, promoting a
+  // replacement), so establish a known state before each test and restore it
+  // after so other specs are unaffected.
+  test.beforeEach(() => {
+    resetLeaveOrgState();
+  });
+
+  test.afterEach(() => {
+    resetLeaveOrgState();
+  });
+
+  test("sole admin clicking Leave is redirected to the reassign form", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(`/organizations/${LEAVE_ORG}/`);
+
+    await page.locator('button[value="leave"]').click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/organizations/${LEAVE_ORG}/leave/`),
+    );
+    // The admin has not been removed yet — they must reassign or confirm first.
+    await page.goto(ORG_URL);
+    await expectAdminBadge(page, "e2e-lone-admin");
+  });
+
+  test("the reassign form renders the member-select widget", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(LEAVE_URL);
+
+    await expect(page.locator("#user-select")).toBeVisible();
+    await expect(page.locator("#user-select input")).toBeVisible();
+  });
+
+  test("leaving without assigning removes the sole admin", async ({ page }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(LEAVE_URL);
+
+    // Submit without selecting a replacement.
+    await page.locator('form.leave-form button[type="submit"]').click();
+
+    await expectFlashMessage(page, "info");
+    // The outgoing admin is no longer listed among the members. Verify as a
+    // remaining member, since a non-member cannot view the member list.
+    await login(page, "e2e-member");
+    await page.goto(ORG_URL);
+    await expectNotMember(page, "e2e-lone-admin");
+  });
+
+  test("assigning a replacement promotes them and removes the outgoing admin", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(LEAVE_URL);
+
+    // Open the member dropdown. The widget lists the organization's members
+    // (fetched from the org-scoped search endpoint); pick one as the new admin.
+    await page.locator("#user-select .sv-control").click();
+
+    const option = page
+      .locator("#user-select .sv-dropdown-content .sv-item--wrap")
+      .filter({ hasText: "e2e-member" });
+    await expect(option.first()).toBeVisible({ timeout: 10_000 });
+    await option.first().click();
+
+    await page.locator('form.leave-form button[type="submit"]').click();
+
+    // Two info flashes appear (promotion + departure); assert at least one.
+    await expect(page.locator("._cls-alerts .alert-info").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    // Replacement was promoted; the outgoing admin left. Verify as the newly
+    // promoted admin, who can view the member list.
+    await login(page, "e2e-member");
+    await page.goto(ORG_URL);
+    await expectAdminBadge(page, "e2e-member");
+    await expectNotMember(page, "e2e-lone-admin");
+  });
+
+  test("cancelling returns to the organization without leaving", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(LEAVE_URL);
+
+    await page.locator(".leave-form .actions a.btn.ghost").click();
+
+    await expect(page).toHaveURL(new RegExp(`/organizations/${LEAVE_ORG}/$`));
+    // Cancelling lands back on the org page, where the admin is still listed.
+    await expectAdminBadge(page, "e2e-lone-admin");
+  });
+});
+
+test.describe("Demoting yourself as the sole admin", () => {
+  const MANAGE_URL = `/organizations/${LEAVE_ORG}/manage-members/`;
+  const DEMOTE_URL = `/organizations/${LEAVE_ORG}/demote/`;
+
+  // The demote flow mutates memberships, so reset before and after each test.
+  test.beforeEach(() => {
+    resetLeaveOrgState();
+  });
+
+  test.afterEach(() => {
+    resetLeaveOrgState();
+  });
+
+  test("sole admin clicking Demote is redirected to the demote form", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(MANAGE_URL);
+
+    const row = page.locator(".membership", {
+      has: page.locator("h3", { hasText: "e2e-lone-admin" }),
+    });
+
+    await row.locator('button[value="makeadmin"]').click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/organizations/${LEAVE_ORG}/demote/`),
+    );
+    // Still an admin — the demote is deferred until they reassign or confirm.
+    await page.goto(ORG_URL);
+    await expectAdminBadge(page, "e2e-lone-admin");
+  });
+
+  test("demoting without assigning keeps the user as a member", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(DEMOTE_URL);
+
+    // Submit without selecting a replacement.
+    await page.locator('form.leave-form button[type="submit"]').click();
+
+    await expectFlashMessage(page, "info");
+    // Demoted from admin, but still a member of the organization. The demoted
+    // user remains a member, so they can still view the member list.
+    await page.goto(ORG_URL);
+    await expectMemberWithoutAdmin(page, "e2e-lone-admin");
+  });
+
+  test("assigning a replacement promotes them and demotes the outgoing admin", async ({
+    page,
+  }) => {
+    await login(page, "e2e-lone-admin");
+    await page.goto(DEMOTE_URL);
+
+    // Open the member dropdown and pick a replacement admin.
+    await page.locator("#user-select .sv-control").click();
+
+    const option = page
+      .locator("#user-select .sv-dropdown-content .sv-item--wrap")
+      .filter({ hasText: "e2e-member" });
+    await expect(option.first()).toBeVisible({ timeout: 10_000 });
+    await option.first().click();
+
+    await page.locator('form.leave-form button[type="submit"]').click();
+
+    await expect(page.locator("._cls-alerts .alert-info").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    // Replacement promoted; outgoing admin demoted but still a member. The
+    // demoted admin remains a member, so verify from their own view.
+    await page.goto(ORG_URL);
+    await expectAdminBadge(page, "e2e-member");
+    await expectMemberWithoutAdmin(page, "e2e-lone-admin");
+  });
+});
+
+test.describe("Leaving an organization as a regular member", () => {
+  test.beforeEach(() => {
+    resetLeaveOrgState();
+  });
+
+  test.afterEach(() => {
+    resetLeaveOrgState();
+  });
+
+  test("a non-admin member leaves directly without the reassign form", async ({
+    page,
+  }) => {
+    await login(page, "e2e-regular");
+    await page.goto(`/organizations/${LEAVE_ORG}/`);
+
+    await page.locator('button[value="leave"]').click();
+
+    // Not redirected to the reassign form; the member is removed immediately.
+    await expect(page).not.toHaveURL(
+      new RegExp(`/organizations/${LEAVE_ORG}/leave/`),
+    );
+    // The member is gone from the list. Verify as the admin, who can view it.
+    await login(page, "e2e-lone-admin");
+    await page.goto(ORG_URL);
+    await expectNotMember(page, "e2e-regular");
+  });
+
+  test("a non-sole-admin cannot access the reassign form (403)", async ({
+    page,
+  }) => {
+    await login(page, "e2e-member");
+    const response = await page.goto(LEAVE_URL);
+    expect(response?.status()).toBe(403);
+  });
+});

--- a/e2e/leave-organization.spec.ts
+++ b/e2e/leave-organization.spec.ts
@@ -225,7 +225,7 @@ test.describe("Leaving an organization as a regular member", () => {
   test("a non-admin member leaves directly without the reassign form", async ({
     page,
   }) => {
-    await login(page, "e2e-regular");
+    await login(page, "e2e-leave-member");
     await page.goto(`/organizations/${LEAVE_ORG}/`);
 
     await page.locator('button[value="leave"]').click();
@@ -237,7 +237,7 @@ test.describe("Leaving an organization as a regular member", () => {
     // The member is gone from the list. Verify as the admin, who can view it.
     await login(page, "e2e-lone-admin");
     await page.goto(ORG_URL);
-    await expectNotMember(page, "e2e-regular");
+    await expectNotMember(page, "e2e-leave-member");
   });
 
   test("a non-sole-admin cannot access the reassign form (403)", async ({

--- a/frontend/components/OrgUserSelect.svelte
+++ b/frontend/components/OrgUserSelect.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import type { User } from "@/types";
+
+  import Svelecte from "svelecte";
+  import UserListItem from "./UserListItem.svelte";
+
+  interface Props {
+    organizationSlug: string;
+    organizationName: string;
+    onChange?: (selection: User) => void;
+  }
+
+  let { onChange, organizationName, organizationSlug }: Props = $props();
+
+  let value: User = $state();
+  const fetchProps: RequestInit = { credentials: "include" };
+
+  function handleChange() {
+    onChange?.(value);
+  }
+
+  /** Svelecte doesn't catch AbortError when it cancels in-flight fetches. */
+  function suppressAbortError(e: PromiseRejectionEvent) {
+    if (e.reason instanceof DOMException && e.reason.name === "AbortError") {
+      e.preventDefault();
+    }
+  }
+</script>
+
+<svelte:window onunhandledrejection={suppressAbortError} />
+
+<Svelecte
+  name="userid"
+  placeholder="Search for a member of {organizationName}..."
+  bind:value
+  valueAsObject
+  valueField="id"
+  labelField="name"
+  fetch="/fe_api/users/?organization={organizationSlug}"
+  {fetchProps}
+  fetchCallback={({ results }) => results}
+  fetchDebounceTime={400}
+  minQuery={0}
+  fetchResetOnBlur={false}
+  resetOnBlur={false}
+  lazyDropdown={false}
+  onChange={handleChange}
+  class="svelecte-control user-search"
+  --sv-min-height="2rem"
+  --sv-disabled-bg="var(--gray-1, #f5f6f7)"
+  --sv-border="1px solid var(--gray-3, #99a8b3)"
+  --sv-border-radius="0.5rem"
+  --sv-placeholder-color="var(--gray-3, #99a8b3)"
+  --sv-icon-color="var(--gray-3, #99a8b3)"
+  --sv-icon-color-hover="var(--gray-4, #5c717c)"
+  --sv-separator-bg="var(--gray-2, #d8dee2)"
+  --sv-dropdown-border="1px solid var(--gray-2, #d8dee2)"
+  --sv-dropdown-shadow="var(--shadow-2, 0 6px 8px 0px rgba(30 48 56 / 0.1))"
+  --sv-dropdown-active-bg="var(--blue-1, #eef3f9)"
+  --sv-dropdown-selected-bg="var(--blue-1, #eef3f9)"
+  --sv-loader-border="2px solid var(--blue-3, #4294f0)"
+>
+  {#snippet option(item: User)}
+    <UserListItem user={item} />
+  {/snippet}
+
+  {#snippet selection(selectedOptions: User[], bindItem)}
+    {#each selectedOptions as sel (sel.id)}
+      <div class="chip">
+        {sel.name || sel.username}
+        <button data-action="deselect" use:bindItem={sel}>&times;</button>
+      </div>
+    {/each}
+  {/snippet}
+</Svelecte>
+
+<style>
+  :global(.sv-control--selection) {
+    padding: 0 0.25em;
+  }
+
+  :global(.svelecte-control.user-search) {
+    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
+    font-size: var(--font-md, 1rem);
+    font-feature-settings: "ss04" on;
+  }
+
+  :global(.svelecte-control.user-search input) {
+    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
+    font-size: var(--font-md, 1rem);
+  }
+
+  :global(.svelecte-control.user-search .sv-dropdown) {
+    border-radius: 0.5rem;
+  }
+
+  :global(.svelecte-control.user-search .sv-dropdown .sv-dd-item) {
+    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
+    font-size: var(--font-md, 1rem);
+    padding: 0.375rem 0.75rem;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
+    font-size: var(--font-sm, 0.875rem);
+    font-weight: 600;
+    line-height: normal;
+    background: var(--blue-1, #eef3f9);
+    border: 1px solid var(--blue-2, #b5ceed);
+    color: var(--blue-5, #053775);
+  }
+
+  .chip.email {
+    background: var(--gray-1, #ebf9f6);
+    border: 1px solid var(--gray-2, #9de3d3);
+    color: var(--gray-5, #0e4450);
+  }
+
+  .chip button {
+    all: unset;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    font-size: var(--font-md, 1rem);
+    line-height: 1;
+    color: inherit;
+    opacity: 0.6;
+  }
+
+  .chip button:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.1);
+  }
+</style>

--- a/frontend/components/OrgUserSelect.svelte
+++ b/frontend/components/OrgUserSelect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { User } from "@/types";
 
-  import Svelecte from "svelecte";
+  import Select from "./Select.svelte";
   import UserListItem from "./UserListItem.svelte";
 
   interface Props {
@@ -29,7 +29,7 @@
 
 <svelte:window onunhandledrejection={suppressAbortError} />
 
-<Svelecte
+<Select
   name="userid"
   placeholder="Search for a member of {organizationName}..."
   bind:value
@@ -38,106 +38,19 @@
   labelField="name"
   fetch="/fe_api/users/?organization={organizationSlug}"
   {fetchProps}
-  fetchCallback={({ results }) => results}
+  fetchCallback={({ results }) => results as User[]}
   fetchDebounceTime={400}
   minQuery={0}
   fetchResetOnBlur={false}
   resetOnBlur={false}
   lazyDropdown={false}
   onChange={handleChange}
-  class="svelecte-control user-search"
-  --sv-min-height="2rem"
-  --sv-disabled-bg="var(--gray-1, #f5f6f7)"
-  --sv-border="1px solid var(--gray-3, #99a8b3)"
-  --sv-border-radius="0.5rem"
-  --sv-placeholder-color="var(--gray-3, #99a8b3)"
-  --sv-icon-color="var(--gray-3, #99a8b3)"
-  --sv-icon-color-hover="var(--gray-4, #5c717c)"
-  --sv-separator-bg="var(--gray-2, #d8dee2)"
-  --sv-dropdown-border="1px solid var(--gray-2, #d8dee2)"
-  --sv-dropdown-shadow="var(--shadow-2, 0 6px 8px 0px rgba(30 48 56 / 0.1))"
-  --sv-dropdown-active-bg="var(--blue-1, #eef3f9)"
-  --sv-dropdown-selected-bg="var(--blue-1, #eef3f9)"
-  --sv-loader-border="2px solid var(--blue-3, #4294f0)"
 >
   {#snippet option(item: User)}
     <UserListItem user={item} />
   {/snippet}
 
-  {#snippet selection(selectedOptions: User[], bindItem)}
-    {#each selectedOptions as sel (sel.id)}
-      <div class="chip">
-        {sel.name || sel.username}
-        <button data-action="deselect" use:bindItem={sel}>&times;</button>
-      </div>
-    {/each}
+  {#snippet selectionValue({ name, username })}
+    {name || username}
   {/snippet}
-</Svelecte>
-
-<style>
-  :global(.sv-control--selection) {
-    padding: 0 0.25em;
-  }
-
-  :global(.svelecte-control.user-search) {
-    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
-    font-size: var(--font-md, 1rem);
-    font-feature-settings: "ss04" on;
-  }
-
-  :global(.svelecte-control.user-search input) {
-    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
-    font-size: var(--font-md, 1rem);
-  }
-
-  :global(.svelecte-control.user-search .sv-dropdown) {
-    border-radius: 0.5rem;
-  }
-
-  :global(.svelecte-control.user-search .sv-dropdown .sv-dd-item) {
-    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
-    font-size: var(--font-md, 1rem);
-    padding: 0.375rem 0.75rem;
-  }
-
-  .chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    font-family: var(--font-sans, "Source Sans Pro"), sans-serif;
-    font-size: var(--font-sm, 0.875rem);
-    font-weight: 600;
-    line-height: normal;
-    background: var(--blue-1, #eef3f9);
-    border: 1px solid var(--blue-2, #b5ceed);
-    color: var(--blue-5, #053775);
-  }
-
-  .chip.email {
-    background: var(--gray-1, #ebf9f6);
-    border: 1px solid var(--gray-2, #9de3d3);
-    color: var(--gray-5, #0e4450);
-  }
-
-  .chip button {
-    all: unset;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1rem;
-    height: 1rem;
-    border-radius: 50%;
-    font-size: var(--font-md, 1rem);
-    line-height: 1;
-    color: inherit;
-    opacity: 0.6;
-  }
-
-  .chip button:hover {
-    opacity: 1;
-    background: rgba(0, 0, 0, 0.1);
-  }
-</style>
+</Select>

--- a/frontend/css/organization_leave.css
+++ b/frontend/css/organization_leave.css
@@ -9,3 +9,13 @@
   align-items: center;
   gap: 0.5rem;
 }
+
+/* Switch the message visibility if the user
+makes a selection in the Svelecte component */
+.leave-form:not(:has(option)) .message-selected {
+  display: none;
+}
+
+.leave-form:has(option) .message-initial {
+  display: none;
+}

--- a/frontend/css/organization_leave.css
+++ b/frontend/css/organization_leave.css
@@ -1,0 +1,11 @@
+.leave-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.leave-form .actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/frontend/views/organization_leave.ts
+++ b/frontend/views/organization_leave.ts
@@ -1,0 +1,27 @@
+import "@/css/organization_leave.css";
+
+import OrgUserSelect from "../components/OrgUserSelect.svelte";
+import { mount } from "svelte";
+
+window.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("user-select");
+  if (!el) return;
+
+  const form = el.closest("form");
+  const submitMessage = form.querySelector("button[type=submit] .message");
+
+  mount(OrgUserSelect, {
+    target: el,
+    props: {
+      organizationSlug: el.dataset.orgSlug,
+      organizationName: el.dataset.orgName,
+      onChange(user) {
+        if (user) {
+          submitMessage.textContent = "Assign and leave";
+        } else {
+          submitMessage.textContent = "Leave without assigning";
+        }
+      },
+    },
+  });
+});

--- a/frontend/views/organization_leave.ts
+++ b/frontend/views/organization_leave.ts
@@ -7,21 +7,11 @@ window.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("user-select");
   if (!el) return;
 
-  const form = el.closest("form");
-  const submitMessage = form.querySelector("button[type=submit] .message");
-
   mount(OrgUserSelect, {
     target: el,
     props: {
       organizationSlug: el.dataset.orgSlug,
       organizationName: el.dataset.orgName,
-      onChange(user) {
-        if (user) {
-          submitMessage.textContent = "Assign and leave";
-        } else {
-          submitMessage.textContent = "Leave without assigning";
-        }
-      },
     },
   });
 });

--- a/squarelet/core/management/commands/seed_e2e_data.py
+++ b/squarelet/core/management/commands/seed_e2e_data.py
@@ -33,6 +33,8 @@ USERS = [
     {"username": "e2e-unverified", "is_staff": False, "verified": False},
     # Sole admin of e2e-leave-org, used for the leave/reassign-admin flow
     {"username": "e2e-lone-admin", "is_staff": False},
+    # Non-admin member of e2e-leave-org, removed by the leave flow
+    {"username": "e2e-leave-member", "is_staff": False},
 ]
 
 # DB-assigned Organization permissions for the e2e-staff user
@@ -85,7 +87,7 @@ ORGS = [
         "verified_journalist": True,
         "max_users": 20,
         "admins": ["e2e-lone-admin"],
-        "members": ["e2e-member", "e2e-regular"],
+        "members": ["e2e-member", "e2e-leave-member"],
     },
 ]
 

--- a/squarelet/core/management/commands/seed_e2e_data.py
+++ b/squarelet/core/management/commands/seed_e2e_data.py
@@ -31,6 +31,8 @@ USERS = [
     {"username": "e2e-regular", "is_staff": False},
     {"username": "e2e-requester", "is_staff": False},
     {"username": "e2e-unverified", "is_staff": False, "verified": False},
+    # Sole admin of e2e-leave-org, used for the leave/reassign-admin flow
+    {"username": "e2e-lone-admin", "is_staff": False},
 ]
 
 # DB-assigned Organization permissions for the e2e-staff user
@@ -72,6 +74,18 @@ ORGS = [
         "admins": ["e2e-admin"],
         "members": [],
         "collective_enabled": True,
+    },
+    {
+        # Dedicated org for the leave / reassign-admin flow. e2e-lone-admin is
+        # the sole admin so leaving triggers the reassign form; the members are
+        # candidates the outgoing admin can promote.
+        "name": "e2e-leave-org",
+        "slug": "e2e-leave-org",
+        "private": False,
+        "verified_journalist": True,
+        "max_users": 20,
+        "admins": ["e2e-lone-admin"],
+        "members": ["e2e-member", "e2e-regular"],
     },
 ]
 

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -398,6 +398,11 @@ class Organization(AvatarMixin, models.Model):
         """Is the given user an admin of this organization"""
         return self.users.filter(pk=user.pk, memberships__admin=True).exists()
 
+    def has_sole_admin(self, user):
+        """Is the given user the only admin of this organization?"""
+        admin_count = self.users.filter(memberships__admin=True).count()
+        return self.has_admin(user) and admin_count == 1
+
     def has_member(self, user):
         """Is the user a member?"""
         return self.users.filter(pk=user.pk).exists()

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -90,6 +90,34 @@ class TestOrganization:
         assert not group.has_member_org(other_org)
 
     @pytest.mark.django_db()
+    def test_has_sole_admin(self, organization_factory, user_factory):
+        """A user who is the only admin is the sole admin"""
+        admin, member = user_factory.create_batch(2)
+        org = organization_factory(users=[member], admins=[admin])
+
+        assert org.has_sole_admin(admin)
+        # A regular member is never a sole admin
+        assert not org.has_sole_admin(member)
+
+    @pytest.mark.django_db()
+    def test_has_sole_admin_multiple_admins(self, organization_factory, user_factory):
+        """When there are multiple admins, none of them is the sole admin"""
+        admin1, admin2 = user_factory.create_batch(2)
+        org = organization_factory(admins=[admin1, admin2])
+
+        assert not org.has_sole_admin(admin1)
+        assert not org.has_sole_admin(admin2)
+
+    @pytest.mark.django_db()
+    def test_has_sole_admin_non_member(self, organization_factory, user_factory):
+        """A user who is not an admin at all is not the sole admin, even
+        when the org has exactly one admin"""
+        admin, outsider = user_factory.create_batch(2)
+        org = organization_factory(admins=[admin])
+
+        assert not org.has_sole_admin(outsider)
+
+    @pytest.mark.django_db()
     def test_user_count(
         self, organization_factory, membership_factory, invitation_factory
     ):

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -388,109 +388,59 @@ class TestDetail(ViewTestMixin):
         assert not organization.has_member(leaver)
         assert response.url == leaver.get_absolute_url()
 
-    def test_post_staff_remove_user(self, rf, organization_factory, user_factory):
-        """Staff with can_manage_members should be able to remove a user"""
-        staff_member = user_factory(is_staff=True)
-        staff_member = _assign_org_perm(staff_member, "can_manage_members")
+    def test_post_sole_admin_leave_redirects_to_reassign(
+        self, rf, organization_factory, user_factory
+    ):
+        """A sole admin trying to leave is redirected to the reassign form
+        and remains a member of the organization."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+
+        response = self.call_view(
+            rf, admin, {"action": "leave"}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert response.url == f"/organizations/{organization.slug}/leave/"
+        # Admin should still be a member since they have not been reassigned yet
+        assert organization.has_member(admin)
+        assert organization.has_admin(admin)
+
+    def test_post_admin_leave_with_other_admin(
+        self, rf, organization_factory, user_factory
+    ):
+        """When there is more than one admin, an admin may leave directly
+        without being redirected to the reassign form."""
+        admin1, admin2 = user_factory.create_batch(2)
+        organization = organization_factory(admins=[admin1, admin2])
+
+        response = self.call_view(
+            rf, admin1, {"action": "leave"}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert response.url != f"/organizations/{organization.slug}/leave/"
+        assert not organization.has_member(admin1)
+
+    def test_post_leave_ignores_userid_for_other_users(
+        self, rf, organization_factory, user_factory
+    ):
+        """The leave action only removes the requesting user. Passing another
+        user's id no longer removes that user (removal of others now happens
+        exclusively through the manage-members view)."""
+        member = user_factory()
         target_user = user_factory()
-        organization = organization_factory(users=[target_user])
+        organization = organization_factory(users=[member, target_user])
 
         response = self.call_view(
             rf,
-            staff_member,
+            member,
             {"action": "leave", "userid": target_user.pk},
             slug=organization.slug,
         )
         assert response.status_code == 302
-        assert not organization.has_member(target_user)
-        # Ensure staff member is not affected
-        assert not organization.has_member(staff_member)
-
-        # Verify activity stream action was created
-        action = Action.objects.filter(
-            actor_object_id=str(staff_member.pk),
-            verb="removed member from organization",
-        ).first()
-        assert action is not None
-        assert action.actor == staff_member
-        assert action.action_object == target_user
-        assert action.target == organization
-        assert action.public is False
-
-    def test_post_staff_remove_admin(self, rf, organization_factory, user_factory):
-        """Staff with can_manage_members should be able to remove an admin"""
-        staff_member = user_factory(is_staff=True)
-        staff_member = _assign_org_perm(staff_member, "can_manage_members")
-        target_admin = user_factory()
-        organization = organization_factory(admins=[target_admin])
-
-        response = self.call_view(
-            rf,
-            staff_member,
-            {"action": "leave", "userid": target_admin.pk},
-            slug=organization.slug,
-        )
-        assert response.status_code == 302
-        assert not organization.has_member(target_admin)
-        assert not organization.has_admin(target_admin)
-
-        # Verify activity stream action was created
-        action = Action.objects.filter(
-            actor_object_id=str(staff_member.pk),
-            verb="removed member from organization",
-        ).first()
-        assert action is not None
-        assert action.actor == staff_member
-        assert action.action_object == target_admin
-        assert action.target == organization
-        assert action.public is False
-
-    def test_post_staff_remove_other_staff(
-        self, rf, organization_factory, user_factory
-    ):
-        """Staff with can_manage_members should be able to remove another staff"""
-        staff_member1 = user_factory(is_staff=True)
-        staff_member1 = _assign_org_perm(staff_member1, "can_manage_members")
-        staff_member2 = user_factory(is_staff=True)
-        organization = organization_factory(users=[staff_member2])
-
-        response = self.call_view(
-            rf,
-            staff_member1,
-            {"action": "leave", "userid": staff_member2.pk},
-            slug=organization.slug,
-        )
-        assert response.status_code == 302
-        assert not organization.has_member(staff_member2)
-
-    def test_post_non_staff_cannot_remove_other_user(
-        self, rf, organization_factory, user_factory
-    ):
-        """Non-staff member should not be able to remove another user"""
-        regular_user = user_factory()
-        target_user = user_factory()
-        organization = organization_factory(users=[regular_user, target_user])
-
-        response = self.call_view(
-            rf,
-            regular_user,
-            {"action": "leave", "userid": target_user.pk},
-            slug=organization.slug,
-        )
-        assert response.status_code == 302
-        # Both users should still be members since non-staff can't remove others
+        # The other user is untouched; only the requesting user leaves
         assert organization.has_member(target_user)
-        assert organization.has_member(regular_user)
-        self.assert_message(
-            messages.ERROR, "You do not have permission to remove other users"
-        )
-
-        # Verify no activity stream action was created
-        action = Action.objects.filter(
-            actor_object_id=str(regular_user.pk),
-            verb="removed member from organization",
-        ).first()
-        assert action is None
+        assert not organization.has_member(member)
 
     def test_post_staff_remove_themselves_with_userid(
         self, rf, organization_factory, user_factory
@@ -1574,6 +1524,92 @@ class TestManageMembers(ViewTestMixin):  # pylint: disable=too-many-public-metho
         assert not organization.has_member(member)
         self.assert_message(messages.SUCCESS, f"{member.username} removed")
 
+    def test_remove_self_sole_admin_redirects_to_reassign(
+        self, rf, organization_factory, user_factory
+    ):
+        """A sole admin removing themselves is redirected to the reassign
+        admin form instead of being removed immediately."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        data = {"action": "removeuser", "userid": admin.pk}
+        response = self.call_view(rf, admin, data, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url == f"/organizations/{organization.slug}/leave/"
+        # Admin remains until they reassign or confirm on the leave page
+        assert organization.has_admin(admin)
+
+    def test_remove_self_with_other_admin_removes_immediately(
+        self, rf, organization_factory, user_factory
+    ):
+        """An admin who is not the sole admin can remove themselves directly."""
+        admin1, admin2 = user_factory.create_batch(2)
+        organization = organization_factory(admins=[admin1, admin2])
+        data = {"action": "removeuser", "userid": admin1.pk}
+        response = self.call_view(rf, admin1, data, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url != f"/organizations/{organization.slug}/leave/"
+        assert not organization.has_member(admin1)
+
+    def test_admin_remove_other_member_not_redirected(
+        self, rf, organization_factory, user_factory
+    ):
+        """A sole admin removing a different member is not redirected; the
+        reassign flow only applies when removing oneself."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        data = {"action": "removeuser", "userid": member.pk}
+        response = self.call_view(rf, admin, data, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url != f"/organizations/{organization.slug}/leave/"
+        assert not organization.has_member(member)
+        assert organization.has_admin(admin)
+
+    def test_demote_self_sole_admin_redirects_to_demote(
+        self, rf, organization_factory, user_factory
+    ):
+        """A sole admin demoting themselves is redirected to the demote version
+        of the reassign admin form instead of being demoted immediately."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        data = {"action": "makeadmin", "userid": admin.pk, "admin": "false"}
+        response = self.call_view(rf, admin, data, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url == f"/organizations/{organization.slug}/demote/"
+        # Admin remains until they reassign or confirm on the demote page
+        assert organization.has_admin(admin)
+
+    def test_demote_self_with_other_admin_demotes_immediately(
+        self, rf, organization_factory, user_factory
+    ):
+        """An admin who is not the sole admin can demote themselves directly."""
+        admin1, admin2 = user_factory.create_batch(2)
+        organization = organization_factory(admins=[admin1, admin2])
+        data = {"action": "makeadmin", "userid": admin1.pk, "admin": "false"}
+        response = self.call_view(rf, admin1, data, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url != f"/organizations/{organization.slug}/demote/"
+        assert not organization.has_admin(admin1)
+        assert organization.has_member(admin1)
+        self.assert_message(messages.SUCCESS, f"{admin1.username} demoted to member")
+
+    def test_demote_other_admin_not_redirected(
+        self, rf, organization_factory, user_factory
+    ):
+        """Demoting a different admin is not redirected; the demote flow only
+        applies when demoting oneself."""
+        admin1, admin2 = user_factory.create_batch(2)
+        organization = organization_factory(admins=[admin1, admin2])
+        data = {"action": "makeadmin", "userid": admin2.pk, "admin": "false"}
+        response = self.call_view(rf, admin1, data, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url != f"/organizations/{organization.slug}/demote/"
+        assert not organization.has_admin(admin2)
+        assert organization.has_admin(admin1)
+        self.assert_message(messages.SUCCESS, f"{admin2.username} demoted to member")
+
     def test_bad_action(self, rf, organization_factory, user_factory):
         admin = user_factory()
         organization = organization_factory(admins=[admin])
@@ -1743,6 +1779,238 @@ class TestManageMembers(ViewTestMixin):  # pylint: disable=too-many-public-metho
         invitation = organization.invitations.latest("created_at")
         assert invitation.role == InvitationRole.member
         assert invitation.email == ""
+
+
+@pytest.mark.django_db()
+class TestReassignAdmin(ViewTestMixin):
+    """Test the ReassignAdmin view (outgoing sole-admin leave flow)"""
+
+    view = views.ReassignAdmin
+    url = "/organizations/{slug}/leave/"
+
+    def call_demote_view(self, rf, user, data=None, slug=None):
+        """Call the demote variant of the view (action="demote")."""
+        url = self.url.format(slug=slug)
+        if data is None:
+            self.request = rf.get(url)
+        else:
+            self.request = rf.post(url, data)
+        self.request.user = user
+        self.request._messages = MagicMock()
+        self.request.session = MagicMock()
+        return views.ReassignAdmin.as_view(action="demote")(self.request, slug=slug)
+
+    def test_get_sole_admin(self, rf, organization_factory, user_factory):
+        """The sole admin can view the reassign form"""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        response = self.call_view(rf, admin, slug=organization.slug)
+        assert response.status_code == 200
+
+    def test_get_context_leave_flag_true_for_leave_action(
+        self, rf, organization_factory, user_factory
+    ):
+        """The leave action exposes leave=True in the template context."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        response = self.call_view(rf, admin, slug=organization.slug)
+        assert response.context_data["leave"] is True
+
+    def test_get_context_leave_flag_false_for_demote_action(
+        self, rf, organization_factory, user_factory
+    ):
+        """The demote action exposes leave=False in the template context."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        response = self.call_demote_view(rf, admin, slug=organization.slug)
+        assert response.context_data["leave"] is False
+
+    def test_get_denied_for_non_sole_admin(
+        self, rf, organization_factory, user_factory
+    ):
+        """A regular member cannot view the reassign form"""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+        with pytest.raises(PermissionDenied):
+            self.call_view(rf, member, slug=organization.slug)
+
+    def test_get_denied_when_multiple_admins(
+        self, rf, organization_factory, user_factory
+    ):
+        """An admin who is not the sole admin cannot view the reassign form"""
+        admin1, admin2 = user_factory.create_batch(2)
+        organization = organization_factory(admins=[admin1, admin2])
+        with pytest.raises(PermissionDenied):
+            self.call_view(rf, admin1, slug=organization.slug)
+
+    def test_post_promotes_replacement_and_leaves(
+        self, rf, organization_factory, user_factory
+    ):
+        """Selecting a replacement promotes them to admin and removes the
+        outgoing admin from the organization."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+
+        response = self.call_view(
+            rf, admin, {"userid": member.pk}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        # Outgoing admin has left
+        assert not organization.has_member(admin)
+        # Replacement is now an admin
+        assert organization.has_admin(member)
+        # The final flash message confirms the outgoing admin left
+        self.assert_message(messages.INFO, "You left the organization")
+
+    def test_post_no_replacement_creates_zendesk_ticket(
+        self, rf, organization_factory, user_factory, mocker
+    ):
+        """Leaving without a replacement creates a Zendesk ticket and removes
+        the outgoing admin."""
+        mock_ticket = mocker.patch(
+            "squarelet.organizations.views.members.create_zendesk_ticket"
+        )
+        admin = user_factory()
+        organization = organization_factory(admins=[admin])
+
+        response = self.call_view(rf, admin, {}, slug=organization.slug)
+        assert response.status_code == 302
+        assert not organization.has_member(admin)
+        mock_ticket.assert_called_once()
+
+    def test_post_invalid_replacement_does_not_leave(
+        self, rf, organization_factory, user_factory
+    ):
+        """A userid that is not a member of the org shows an error and does
+        not remove the outgoing admin."""
+        admin = user_factory()
+        non_member = user_factory()
+        organization = organization_factory(admins=[admin])
+
+        response = self.call_view(
+            rf, admin, {"userid": non_member.pk}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert response.url == f"/organizations/{organization.slug}/leave/"
+        # Admin has not left since reassignment failed
+        assert organization.has_admin(admin)
+        self.assert_message(messages.ERROR, "User is not a member of this organization")
+
+    def test_post_private_org_redirects_to_user(
+        self, rf, organization_factory, user_factory, mocker
+    ):
+        """Leaving a private org redirects to the user's profile page."""
+        mocker.patch("squarelet.organizations.views.members.create_zendesk_ticket")
+        admin = user_factory()
+        organization = organization_factory(admins=[admin], private=True)
+
+        response = self.call_view(rf, admin, {}, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url == admin.get_absolute_url()
+
+    def test_post_public_org_redirects_to_org(
+        self, rf, organization_factory, user_factory
+    ):
+        """Leaving a public org after reassigning redirects to the org page."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+
+        response = self.call_view(
+            rf, admin, {"userid": member.pk}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert response.url == organization.get_absolute_url()
+
+    def test_demote_promotes_replacement_and_demotes_self(
+        self, rf, organization_factory, user_factory
+    ):
+        """Demoting with a replacement promotes them and demotes the outgoing
+        admin to a member (they remain in the organization)."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+
+        response = self.call_demote_view(
+            rf, admin, {"userid": member.pk}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        # Replacement is now an admin
+        assert organization.has_admin(member)
+        # Outgoing admin is demoted but still a member
+        assert not organization.has_admin(admin)
+        assert organization.has_member(admin)
+        self.assert_message(messages.INFO, "You are demoted to a member")
+
+    def test_demote_no_replacement_creates_zendesk_ticket(
+        self, rf, organization_factory, user_factory, mocker
+    ):
+        """Demoting without a replacement creates a Zendesk ticket and demotes
+        the outgoing admin while keeping them as a member."""
+        mock_ticket = mocker.patch(
+            "squarelet.organizations.views.members.create_zendesk_ticket"
+        )
+        admin = user_factory()
+        organization = organization_factory(admins=[admin])
+
+        response = self.call_demote_view(rf, admin, {}, slug=organization.slug)
+        assert response.status_code == 302
+        assert not organization.has_admin(admin)
+        assert organization.has_member(admin)
+        mock_ticket.assert_called_once()
+
+    def test_demote_invalid_replacement_does_not_demote(
+        self, rf, organization_factory, user_factory
+    ):
+        """A userid that is not a member shows an error and does not demote the
+        outgoing admin."""
+        admin = user_factory()
+        non_member = user_factory()
+        organization = organization_factory(admins=[admin])
+
+        response = self.call_demote_view(
+            rf, admin, {"userid": non_member.pk}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert response.url == f"/organizations/{organization.slug}/demote/"
+        assert organization.has_admin(admin)
+        self.assert_message(messages.ERROR, "User is not a member of this organization")
+
+    def test_demote_self_assignment_rejected(
+        self, rf, organization_factory, user_factory
+    ):
+        """Assigning oneself as the replacement is rejected."""
+        admin = user_factory()
+        member = user_factory()
+        organization = organization_factory(admins=[admin], users=[member])
+
+        response = self.call_demote_view(
+            rf, admin, {"userid": admin.pk}, slug=organization.slug
+        )
+        assert response.status_code == 302
+        assert response.url == f"/organizations/{organization.slug}/demote/"
+        assert organization.has_admin(admin)
+        self.assert_message(
+            messages.WARNING, "You must assign a user other than yourself"
+        )
+
+    def test_demote_redirects_to_org_even_when_private(
+        self, rf, organization_factory, user_factory, mocker
+    ):
+        """The demote action always redirects to the org page, even for a
+        private org (unlike the leave action)."""
+        mocker.patch("squarelet.organizations.views.members.create_zendesk_ticket")
+        admin = user_factory()
+        organization = organization_factory(admins=[admin], private=True)
+
+        response = self.call_demote_view(rf, admin, {}, slug=organization.slug)
+        assert response.status_code == 302
+        assert response.url == organization.get_absolute_url()
 
 
 @pytest.mark.django_db()

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -1946,7 +1946,7 @@ class TestReassignAdmin(ViewTestMixin):
         # Outgoing admin is demoted but still a member
         assert not organization.has_admin(admin)
         assert organization.has_member(admin)
-        self.assert_message(messages.INFO, "You are demoted to a member")
+        self.assert_message(messages.INFO, "You are no longer an admin")
 
     def test_demote_no_replacement_creates_zendesk_ticket(
         self, rf, organization_factory, user_factory, mocker

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -1790,6 +1790,7 @@ class TestReassignAdmin(ViewTestMixin):
 
     def call_demote_view(self, rf, user, data=None, slug=None):
         """Call the demote variant of the view (action="demote")."""
+        # pylint: disable=protected-access
         url = self.url.format(slug=slug)
         if data is None:
             self.request = rf.get(url)

--- a/squarelet/organizations/urls.py
+++ b/squarelet/organizations/urls.py
@@ -65,4 +65,9 @@ urlpatterns = [
         view=views.AcceptMemberOrgInvitation.as_view(),
         name="member-org-invitation",
     ),
+    path(
+        "<slug:slug>/leave/",
+        view=views.ReassignAdmin.as_view(),
+        name="reassign-admin",
+    ),
 ]

--- a/squarelet/organizations/urls.py
+++ b/squarelet/organizations/urls.py
@@ -70,4 +70,9 @@ urlpatterns = [
         view=views.ReassignAdmin.as_view(),
         name="reassign-admin",
     ),
+    path(
+        "<slug:slug>/demote/",
+        view=views.ReassignAdmin.as_view(action="demote"),
+        name="reassign-admin-demote",
+    ),
 ]

--- a/squarelet/organizations/views/__init__.py
+++ b/squarelet/organizations/views/__init__.py
@@ -10,6 +10,7 @@ from .members import (
     ManageMembers,
     OrgInvitationsView,
     OrgRequestsView,
+    ReassignAdmin,
 )
 from .profile import RequestProfileChange, ReviewProfileChange, Update
 from .subscription import (
@@ -41,6 +42,7 @@ __all__ = [
     # Member org views
     "AcceptMemberOrgInvitation",
     "ManageMemberOrgs",
+    "ReassignAdmin",
     # Domain views
     "ManageDomains",
     # Admin views

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -272,56 +272,16 @@ class Detail(AdminLinkMixin, DetailView):
 
     def handle_leave(self, request):
         is_member = self.organization.has_member(self.request.user)
-        can_manage = request.user.has_perm(
-            "organizations.can_manage_members", self.organization
-        )
-        userid = request.POST.get("userid")
-        user_left = False
-        if userid:
-            if userid == str(request.user.id) and is_member:
-                # Users removing themselves
-                request.user.memberships.filter(organization=self.organization).delete()
-                messages.success(request, _("You left the organization"))
-                user_left = True
-            elif can_manage:
-                # User with can_manage_members permission removing another user
-                user_model = get_user_model()
-                try:
-                    target_user = user_model.objects.get(pk=userid)
-                    target_user.memberships.filter(
-                        organization=self.organization
-                    ).delete()
 
-                    # Log staff action to activity stream
-                    new_action(
-                        actor=request.user,
-                        verb="removed member from organization",
-                        action_object=target_user,
-                        target=self.organization,
-                    )
-
-                    messages.success(
-                        request,
-                        _("%(username)s left the organization")
-                        % {"username": target_user.username},
-                    )
-                except user_model.DoesNotExist:
-                    messages.error(request, _("User not found"))
-            else:
-                # Only users with can_manage_members can remove other users
-                messages.error(
-                    request, _("You do not have permission to remove other users")
-                )
-        elif is_member:
-            # User removing themselves (no userid provided)
+        if is_member:
             request.user.memberships.filter(organization=self.organization).delete()
             messages.success(request, _("You left the organization"))
-            user_left = True
 
-        # Redirect to profile if the user left a private org they can no
-        # longer view, otherwise redirect following default behavior
-        if user_left and self.organization.private:
-            return redirect(request.user)
+            # Redirect to profile if the user left a private org they can no
+            # longer view, otherwise redirect following default behavior
+            if self.organization.private:
+                return redirect(request.user)
+            
         return None
 
     def handle_enable_autojoin(self, request):

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 # Squarelet
 from squarelet.core.mixins import AdminLinkMixin
-from squarelet.core.utils import get_redirect_url, is_rate_limited, new_action
+from squarelet.core.utils import get_redirect_url, is_rate_limited
 from squarelet.organizations.forms import InvitationAcceptForm
 from squarelet.organizations.models import Invitation, Membership, Organization, Plan
 from squarelet.organizations.models.invitation import OrganizationInvitation
@@ -271,17 +271,23 @@ class Detail(AdminLinkMixin, DetailView):
         invitation.send()
 
     def handle_leave(self, request):
-        is_member = self.organization.has_member(self.request.user)
+        org = self.organization
+        user = request.user
+        is_sole_admin = org.has_sole_admin(user)
+        is_member = org.has_member(user)
 
-        if is_member:
-            request.user.memberships.filter(organization=self.organization).delete()
+        # If the user is the only admin, send them to the reassign admin page.
+        if is_sole_admin:
+            return redirect("organizations:reassign-admin", org.slug)
+        elif is_member:
+            request.user.memberships.filter(organization=org).delete()
             messages.success(request, _("You left the organization"))
 
             # Redirect to profile if the user left a private org they can no
             # longer view, otherwise redirect following default behavior
-            if self.organization.private:
-                return redirect(request.user)
-            
+            if org.private:
+                return redirect(user)
+
         return None
 
     def handle_enable_autojoin(self, request):

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 # Squarelet
 from squarelet.core.mixins import AdminLinkMixin
-from squarelet.core.utils import get_redirect_url, is_rate_limited
+from squarelet.core.utils import get_redirect_url, is_rate_limited, new_action
 from squarelet.organizations.forms import InvitationAcceptForm
 from squarelet.organizations.models import Invitation, Membership, Organization, Plan
 from squarelet.organizations.models.invitation import OrganizationInvitation

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -204,7 +204,9 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
         try:
             userid = request.POST.get("userid")
             membership = self.organization.memberships.get(user_id=userid)
-            membership_fn(membership)
+            result = membership_fn(membership)
+            if result:
+                return result
             messages.success(self.request, success_message_fn(membership))
         except Membership.DoesNotExist:
             return self._bad_call(request)
@@ -249,6 +251,13 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
     def _handle_remove_user(self, request):
         def handle_remove(membership):
             user = membership.user
+            org = membership.organization
+
+            # If the user is leaving, and they're the only admin,
+            # send them to the reassign admin page.
+            if user == request.user and org.has_sole_admin(user):
+                return redirect("organizations:reassign-admin", org.slug)
+
             membership.delete()
 
             # Log staff action to activity stream
@@ -259,6 +268,8 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
                     action_object=user,
                     target=self.organization,
                 )
+
+            return None
 
         return self._handle_user(
             request,

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -1,14 +1,21 @@
 # Django
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.http.response import HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, ListView
 
 # Squarelet
-from squarelet.core.utils import get_redirect_url, new_action, pluralize
+from squarelet.core.utils import (
+    create_zendesk_ticket,
+    get_redirect_url,
+    new_action,
+    pluralize,
+)
 from squarelet.organizations.choices import InvitationRole
 from squarelet.organizations.forms import AddMemberForm, InvitationAcceptForm
 from squarelet.organizations.mixins import OrganizationPermissionMixin
@@ -395,3 +402,51 @@ class OrgRequestsView(BaseOrgInvitationRequestView):
     template_name = "organizations/organization_requests.html"
     context_object_name = "requests"
     is_request_view = True
+
+
+class ReassignAdmin(UserPassesTestMixin, DetailView):
+    queryset = Organization.objects.filter(individual=False)
+    template_name = "organizations/organization_leave.html"
+
+    def test_func(self):
+        user = self.request.user
+        return self.get_object().has_sole_admin(user)
+
+    def post(self, request, *args, **kwargs):
+        user = request.user
+        org = self.get_object()
+        new_admin_id = request.POST.get("userid")
+
+        if new_admin_id:
+            # If the outgoing admin picked a replacement, promote them
+            try:
+                membership = org.memberships.get(user_id=new_admin_id)
+                membership.admin = True
+                membership.save()
+
+                messages.info(
+                    request, _(f"{membership.user.username} promoted to admin")
+                )
+            except Membership.DoesNotExist:
+                messages.error(request, _("User is not a member of this organization"))
+                return redirect("organizations:reassign-admin", org.slug)
+        else:
+            # If there's no replacement admin, create a Zendesk ticket
+            manage = reverse("organizations:manage-members", args=[org.slug])
+            manage_link = request.build_absolute_uri(manage)
+            subject = f"Organization with no admins: {org.name}"
+            description = (
+                f"The last admin has left {org.name}. ",
+                f"Follow this link to assign a new admin: {manage_link}",
+            )
+
+            create_zendesk_ticket(subject=subject, description=description)
+
+        user.memberships.filter(organization=org).delete()
+
+        messages.info(request, _("You left the organization"))
+
+        if org.private:
+            return redirect(user)
+        else:
+            return redirect(org)

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -222,6 +222,14 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
             return self._bad_call(request)
 
         def handle_make_admin(membership):
+            user = membership.user
+            org = membership.organization
+
+            # If the user is demoting themselves, and they're the only admin,
+            # send them to the demote version of the reassign admin page.
+            if user == request.user and org.has_sole_admin(user) and set_admin == False:
+                return redirect("organizations:reassign-admin-demote", org.slug)
+
             membership.admin = set_admin
             membership.save()
 
@@ -237,6 +245,8 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
                     action_object=membership.user,
                     target=self.organization,
                 )
+
+            return None
 
         return self._handle_user(
             request,
@@ -416,12 +426,18 @@ class OrgRequestsView(BaseOrgInvitationRequestView):
 
 
 class ReassignAdmin(UserPassesTestMixin, DetailView):
+    action = "leave"
     queryset = Organization.objects.filter(individual=False)
     template_name = "organizations/organization_leave.html"
 
     def test_func(self):
         user = self.request.user
         return self.get_object().has_sole_admin(user)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["leave"] = self.action == 'leave'
+        return context
 
     def post(self, request, *args, **kwargs):
         user = request.user
@@ -457,11 +473,17 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
 
             create_zendesk_ticket(subject=subject, description=description)
 
-        user.memberships.filter(organization=org).delete()
+        membership = user.memberships.get(organization=org)
 
-        messages.info(request, _("You left the organization"))
+        if self.action == "leave":
+            membership.delete()
+            messages.info(request, _("You left the organization"))
+        elif self.action == "demote":
+            membership.admin = False
+            membership.save()
+            messages.info(request, _("You are demoted to a member"))
 
-        if org.private:
-            return redirect(user)
-        else:
+        if self.action == "demote" or not org.private:
             return redirect(org)
+        else:
+            return redirect(user)

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -440,13 +440,15 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
         return context
 
     def post(self, request, *args, **kwargs):
+        is_leave_form = self.action == "leave"
         user = request.user
         org = self.get_object()
         new_admin_id = request.POST.get("userid")
+        url = "reassign-admin" if is_leave_form else "reassign-admin-demote"
 
         if new_admin_id == str(user.id):
             messages.warning(request, _("You must assign a user other than yourself"))
-            return redirect("organizations:reassign-admin", org.slug)
+            return redirect(f"organizations:{url}", org.slug)
 
         if new_admin_id:
             # If the outgoing admin picked a replacement, promote them
@@ -460,7 +462,7 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
                 )
             except Membership.DoesNotExist:
                 messages.error(request, _("User is not a member of this organization"))
-                return redirect("organizations:reassign-admin", org.slug)
+                return redirect(f"organizations:{url}", org.slug)
         else:
             # If there's no replacement admin, create a Zendesk ticket
             manage = reverse("organizations:manage-members", args=[org.slug])
@@ -475,15 +477,16 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
 
         membership = user.memberships.get(organization=org)
 
-        if self.action == "leave":
+        if is_leave_form:
             membership.delete()
             messages.info(request, _("You left the organization"))
-        elif self.action == "demote":
+        else:
             membership.admin = False
             membership.save()
             messages.info(request, _("You are demoted to a member"))
 
-        if self.action == "demote" or not org.private:
+        # User can still see the org if it's public or they only self-demoted
+        if not is_leave_form or not org.private:
             return redirect(org)
         else:
             return redirect(user)

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -227,7 +227,7 @@ class ManageMembers(OrganizationPermissionMixin, DetailView):
 
             # If the user is demoting themselves, and they're the only admin,
             # send them to the demote version of the reassign admin page.
-            if user == request.user and org.has_sole_admin(user) and set_admin == False:
+            if user == request.user and org.has_sole_admin(user) and not set_admin:
                 return redirect("organizations:reassign-admin-demote", org.slug)
 
             membership.admin = set_admin
@@ -436,7 +436,7 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["leave"] = self.action == 'leave'
+        context["leave"] = self.action == "leave"
         return context
 
     def post(self, request, *args, **kwargs):

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -428,6 +428,10 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
         org = self.get_object()
         new_admin_id = request.POST.get("userid")
 
+        if new_admin_id == str(user.id):
+            messages.warning(request, _("You must assign a user other than yourself"))
+            return redirect("organizations:reassign-admin", org.slug)
+
         if new_admin_id:
             # If the outgoing admin picked a replacement, promote them
             try:

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.db import transaction
 from django.http.response import HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -450,40 +451,44 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
             messages.warning(request, _("You must assign a user other than yourself"))
             return redirect(f"organizations:{url}", org.slug)
 
-        if new_admin_id:
-            # If the outgoing admin picked a replacement, promote them
-            try:
-                membership = org.memberships.get(user_id=new_admin_id)
-                membership.admin = True
-                membership.save()
+        with transaction.atomic():
+            if new_admin_id:
+                # If the outgoing admin picked a replacement, promote them
+                try:
+                    replacement_admin = org.memberships.get(user_id=new_admin_id)
+                    replacement_admin.admin = True
+                    replacement_admin.save()
 
-                messages.info(
-                    request, _(f"{membership.user.username} promoted to admin")
+                    messages.info(
+                        request,
+                        _(f"{replacement_admin.user.username} promoted to admin"),
+                    )
+                except Membership.DoesNotExist:
+                    messages.error(
+                        request, _("User is not a member of this organization")
+                    )
+                    return redirect(f"organizations:{url}", org.slug)
+            else:
+                # If there's no replacement admin, create a Zendesk ticket
+                manage = reverse("organizations:manage-members", args=[org.slug])
+                manage_link = request.build_absolute_uri(manage)
+                subject = f"Organization with no admins: {org.name}"
+                description = (
+                    f"The last admin has left {org.name}. "
+                    f"Follow this link to assign a new admin: {manage_link}"
                 )
-            except Membership.DoesNotExist:
-                messages.error(request, _("User is not a member of this organization"))
-                return redirect(f"organizations:{url}", org.slug)
-        else:
-            # If there's no replacement admin, create a Zendesk ticket
-            manage = reverse("organizations:manage-members", args=[org.slug])
-            manage_link = request.build_absolute_uri(manage)
-            subject = f"Organization with no admins: {org.name}"
-            description = (
-                f"The last admin has left {org.name}. ",
-                f"Follow this link to assign a new admin: {manage_link}",
-            )
 
-            create_zendesk_ticket(subject=subject, description=description)
+                create_zendesk_ticket(subject=subject, description=description)
 
-        membership = user.memberships.get(organization=org)
+            membership = user.memberships.get(organization=org)
 
-        if is_leave_form:
-            membership.delete()
-            messages.info(request, _("You left the organization"))
-        else:
-            membership.admin = False
-            membership.save()
-            messages.info(request, _("You are no longer an admin"))
+            if is_leave_form:
+                membership.delete()
+                messages.info(request, _("You left the organization"))
+            else:
+                membership.admin = False
+                membership.save()
+                messages.info(request, _("You are no longer an admin"))
 
         # User can still see the org if it's public or they only self-demoted
         if not is_leave_form or not org.private:

--- a/squarelet/organizations/views/members.py
+++ b/squarelet/organizations/views/members.py
@@ -483,7 +483,7 @@ class ReassignAdmin(UserPassesTestMixin, DetailView):
         else:
             membership.admin = False
             membership.save()
-            messages.info(request, _("You are demoted to a member"))
+            messages.info(request, _("You are no longer an admin"))
 
         # User can still see the org if it's public or they only self-demoted
         if not is_leave_form or not org.private:

--- a/squarelet/templates/organizations/organization_leave.html
+++ b/squarelet/templates/organizations/organization_leave.html
@@ -19,7 +19,9 @@
       </h1>
 
       <p>
-        {% trans "Before you leave, please consider assigning another member of the organization to be an admin." %}
+        {% blocktrans with action=leave|yesno:_("leave,demote yourself") %}
+          Before you {{ action }}, please consider assigning another member of the organization to be an admin.
+        {% endblocktrans %}
       </p>
 
       <form method="POST" class="leave-form">

--- a/squarelet/templates/organizations/organization_leave.html
+++ b/squarelet/templates/organizations/organization_leave.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% load avatar humanize django_vite i18n %}
+{% load icon %}
+
+{% block head_title %}{% trans "Leaving" %}{% endblock %}
+
+{% block vite %}
+{{ block.super }}
+{% vite_asset "frontend/views/organization_leave.ts" %}
+{% endblock vite %}
+
+{% block content %}
+  <div class="_cls-content">
+    <div class="card">
+      <h1>
+        {% blocktrans with org=organization.name %}
+          You are the only admin of {{ org }}
+        {% endblocktrans %}
+      </h1>
+
+      <p>
+        {% trans "Before you leave, please consider assigning another member of the organization to be an admin." %}
+      </p>
+
+      <form method="POST" class="leave-form">
+        {% csrf_token %}
+        <div id="user-select" data-org-slug="{{ organization.slug }}" data-org-name="{{ organization.name }}"></div>
+        <div class="actions">
+          <button type="submit" class="btn danger">
+            {% icon "sign-out" %}
+            <span class="message">
+              {% trans "Leave without assigning" %}
+            </span>
+          </button>
+          <a class="btn ghost" href="{% url "organizations:detail" organization.slug %}">
+            {% trans "Cancel" %}
+          </a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/squarelet/templates/organizations/organization_leave.html
+++ b/squarelet/templates/organizations/organization_leave.html
@@ -28,8 +28,15 @@
         <div class="actions">
           <button type="submit" class="btn danger">
             {% icon "sign-out" %}
-            <span class="message">
-              {% trans "Leave without assigning" %}
+            <span class="message-initial">
+              {% blocktrans with action=leave|yesno:_("Leave,Demote") %}
+                {{ action }} without assigning
+              {% endblocktrans %}
+            </span>
+            <span class="message-selected">
+              {% blocktrans with action=leave|yesno:_("leave,demote") %}
+                Assign and {{ action }}
+              {% endblocktrans %}
             </span>
           </button>
           <a class="btn ghost" href="{% url "organizations:detail" organization.slug %}">

--- a/squarelet/users/fe_api/test_user_viewsets.py
+++ b/squarelet/users/fe_api/test_user_viewsets.py
@@ -136,3 +136,101 @@ def test_search_list_fields(client, user_with_org):
     assert "username" in results[0]
     assert "name" in results[0]
     assert "avatar_url" in results[0]
+
+
+@pytest.mark.django_db
+def test_filter_by_organization(client, user_with_org):
+    """?organization=<slug> restricts results to that org's members"""
+    user, org = user_with_org
+    user.individual_organization.hidden = False
+    user.individual_organization.save()
+
+    member = User.objects.create_user(
+        username="member", email="member@example.com", password="password"
+    )
+    member.individual_organization.hidden = False
+    member.individual_organization.save()
+    Membership.objects.create(user=member, organization=org)
+
+    other_org = Organization.objects.create(name="Org B")
+    outsider = User.objects.create_user(
+        username="outsider", email="outsider@example.com", password="password"
+    )
+    outsider.individual_organization.hidden = False
+    outsider.individual_organization.save()
+    Membership.objects.create(user=outsider, organization=other_org)
+
+    client.force_authenticate(user=user)
+    response = client.get(f"/fe_api/users/?organization={org.slug}")
+    assert response.status_code == status.HTTP_200_OK
+    returned_ids = {u["id"] for u in response.data["results"]}
+    assert member.id in returned_ids
+    assert outsider.id not in returned_ids
+
+
+@pytest.mark.django_db
+def test_filter_by_organization_unknown_slug(client, user_with_org):
+    """An organization slug that matches no org returns no members"""
+    user, org = user_with_org
+    user.individual_organization.hidden = False
+    user.individual_organization.save()
+
+    client.force_authenticate(user=user)
+    response = client.get("/fe_api/users/?organization=does-not-exist")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["results"] == []
+
+
+@pytest.mark.django_db
+def test_no_organization_param_returns_all_searchable(client, user_with_org):
+    """Without the organization param, members of any org are searchable"""
+    user, org = user_with_org
+
+    member = User.objects.create_user(
+        username="member", email="member@example.com", password="password"
+    )
+    member.individual_organization.hidden = False
+    member.individual_organization.save()
+    Membership.objects.create(user=member, organization=org)
+
+    other_org = Organization.objects.create(name="Org B")
+    outsider = User.objects.create_user(
+        username="outsider", email="outsider@example.com", password="password"
+    )
+    outsider.individual_organization.hidden = False
+    outsider.individual_organization.save()
+    Membership.objects.create(user=outsider, organization=other_org)
+
+    client.force_authenticate(user=user)
+    response = client.get("/fe_api/users/")
+    assert response.status_code == status.HTTP_200_OK
+    returned_ids = {u["id"] for u in response.data["results"]}
+    assert member.id in returned_ids
+    assert outsider.id in returned_ids
+
+
+@pytest.mark.django_db
+def test_filter_by_organization_with_search(client, user_with_org):
+    """The organization filter combines with the text search"""
+    user, org = user_with_org
+
+    alice = User.objects.create_user(
+        username="alice-org", email="alice@example.com", password="password"
+    )
+    alice.individual_organization.hidden = False
+    alice.individual_organization.save()
+    Membership.objects.create(user=alice, organization=org)
+
+    bob = User.objects.create_user(
+        username="bob-org", email="bob@example.com", password="password"
+    )
+    bob.individual_organization.hidden = False
+    bob.individual_organization.save()
+    Membership.objects.create(user=bob, organization=org)
+
+    client.force_authenticate(user=user)
+    response = client.get(f"/fe_api/users/?organization={org.slug}&search=alice")
+    assert response.status_code == status.HTTP_200_OK
+    returned_ids = {u["id"] for u in response.data["results"]}
+    assert alice.id in returned_ids
+    assert bob.id not in returned_ids

--- a/squarelet/users/fe_api/test_user_viewsets.py
+++ b/squarelet/users/fe_api/test_user_viewsets.py
@@ -210,6 +210,33 @@ def test_no_organization_param_returns_all_searchable(client, user_with_org):
 
 
 @pytest.mark.django_db
+def test_filter_by_organization_does_not_leak_membership(
+    client, user_with_org, user_without_org
+):
+    """The organization param must not reveal members of an org the requester
+    cannot view"""
+    secret_member, private_org = user_with_org
+
+    # the member is otherwise searchable — only the org is off limits
+    secret_member.individual_organization.hidden = False
+    secret_member.individual_organization.save()
+    private_org.private = True
+    private_org.save()
+
+    client.force_authenticate(user=user_without_org)
+    response = client.get(f"/fe_api/users/?organization={private_org.slug}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["results"] == []
+
+    # a member of the private org can still filter by it
+    client.force_authenticate(user=secret_member)
+    response = client.get(f"/fe_api/users/?organization={private_org.slug}")
+    assert response.status_code == status.HTTP_200_OK
+    returned_ids = {u["id"] for u in response.data["results"]}
+    assert secret_member.id in returned_ids
+
+
+@pytest.mark.django_db
 def test_filter_by_organization_with_search(client, user_with_org):
     """The organization filter combines with the text search"""
     user, org = user_with_org

--- a/squarelet/users/fe_api/viewsets.py
+++ b/squarelet/users/fe_api/viewsets.py
@@ -29,6 +29,9 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
                 return User.objects.none()
             qs = User.objects.get_searchable(self.request.user).filter(is_active=True)
             search = self.request.query_params.get("search", "").strip()
+            org = self.request.query_params.get("organization", "").strip()
+            if org:
+                qs = qs.filter(organizations__slug=org)
             if search:
                 # Full-text search with prefix matching.
                 # Strip tsquery special characters so raw queries are safe.

--- a/squarelet/users/fe_api/viewsets.py
+++ b/squarelet/users/fe_api/viewsets.py
@@ -36,7 +36,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
                 viewable_org = Organization.objects.filter(slug=org).get_viewable(user)
                 if not viewable_org.exists():
                     return User.objects.none()
-                qs = qs.filter(organizations__in=viewable_org)
+                qs = qs.filter(organizations__in=viewable_org).order_by("-last_login")
             if search:
                 # Full-text search with prefix matching.
                 # Strip tsquery special characters so raw queries are safe.

--- a/squarelet/users/fe_api/viewsets.py
+++ b/squarelet/users/fe_api/viewsets.py
@@ -9,6 +9,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 
 # Squarelet
+from squarelet.organizations.models.organization import Organization
 from squarelet.users.fe_api.serializers import UserSearchSerializer, UserSerializer
 from squarelet.users.models import User
 
@@ -24,14 +25,18 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         return UserSerializer
 
     def get_queryset(self):
+        user = self.request.user
         if self.action == "list":
-            if not self.request.user.is_authenticated:
+            if not user.is_authenticated:
                 return User.objects.none()
-            qs = User.objects.get_searchable(self.request.user).filter(is_active=True)
+            qs = User.objects.get_searchable(user).filter(is_active=True)
             search = self.request.query_params.get("search", "").strip()
             org = self.request.query_params.get("organization", "").strip()
             if org:
-                qs = qs.filter(organizations__slug=org)
+                viewable_org = Organization.objects.filter(slug=org).get_viewable(user)
+                if not viewable_org.exists():
+                    return User.objects.none()
+                qs = qs.filter(organizations__in=viewable_org)
             if search:
                 # Full-text search with prefix matching.
                 # Strip tsquery special characters so raw queries are safe.


### PR DESCRIPTION
Closes #564.

When the last admin leaves an organization or demotes themselves, they are shown a prompt with an opportunity to assign admin status to another member. If they decline, a Zendesk ticket is created.

<img width="521" height="303" alt="image" src="https://github.com/user-attachments/assets/98d3e285-dade-47ba-91ef-fca8d7e92160" />

Also simplifies organization `Detail.handle_leave` and its corresponding tests.