### PR TITLE
Look up change requests to redirect on old org slugs

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -101,6 +101,8 @@ urlpatterns = [
     ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+handler404 = "squarelet.core.views.page_not_found"
+
 if settings.DEBUG:
     # This allows the error pages to be debugged during development, just visit
     # these url in browser to see how these error pages look like.

--- a/squarelet/core/exceptions.py
+++ b/squarelet/core/exceptions.py
@@ -1,0 +1,10 @@
+# Django
+from django.http import Http404
+
+
+class ContextHttp404(Http404):
+    """Http404 that carries extra template context for the 404 page."""
+
+    def __init__(self, *args, context=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.context = context or {}

--- a/squarelet/core/tests/test_views.py
+++ b/squarelet/core/tests/test_views.py
@@ -1,0 +1,80 @@
+# Django
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.backends.db import SessionStore
+from django.http import Http404
+
+# Third Party
+import pytest
+
+# Squarelet
+from squarelet.core.exceptions import ContextHttp404
+from squarelet.core.views import page_not_found
+
+
+def _request(rf, user=None):
+    """Build a request suitable for rendering the 404 page"""
+    request = rf.get("/this-page-does-not-exist/")
+    request.user = AnonymousUser() if user is None else user
+    request.session = SessionStore()
+    return request
+
+
+class TestContextHttp404:
+    """Unit tests for the ContextHttp404 exception"""
+
+    def test_is_an_http404(self):
+        """It must behave like a normal Http404 so Django's handler picks it up"""
+        assert issubclass(ContextHttp404, Http404)
+        assert isinstance(ContextHttp404(), Http404)
+
+    def test_context_defaults_to_empty_dict(self):
+        assert ContextHttp404().context == {}
+
+    def test_explicit_none_context_becomes_empty_dict(self):
+        assert ContextHttp404("missing", context=None).context == {}
+
+    def test_carries_context_and_message(self):
+        exception = ContextHttp404("missing", context={"user_orgs": []})
+        assert exception.context == {"user_orgs": []}
+        assert exception.args[0] == "missing"
+
+
+@pytest.mark.django_db()
+class TestPageNotFoundRendering:
+    """Rendering tests for the 404 template driven by the custom handler"""
+
+    def test_generic_404_shows_default_copy(self, rf):
+        response = page_not_found(_request(rf), Http404())
+
+        content = response.content.decode()
+        assert response.status_code == 404
+        assert "Page not found" in content
+        assert "Organization not found" not in content
+
+    def test_org_404_without_orgs_shows_org_copy_only(self, rf):
+        response = page_not_found(
+            _request(rf), ContextHttp404(context={"user_orgs": []})
+        )
+
+        content = response.content.decode()
+        assert response.status_code == 404
+        assert "Organization not found" in content
+        assert "Were you looking for one of these organizations?" not in content
+
+    def test_org_404_lists_the_users_organizations(
+        self, rf, user_factory, organization_factory
+    ):
+        user = user_factory()
+        organization = organization_factory(name="Test Newsroom", users=[user])
+
+        response = page_not_found(
+            _request(rf, user),
+            ContextHttp404(context={"user_orgs": [organization]}),
+        )
+
+        content = response.content.decode()
+        assert response.status_code == 404
+        assert "Organization not found" in content
+        assert "Were you looking for one of these organizations?" in content
+        assert "Test Newsroom" in content
+        assert organization.get_absolute_url() in content

--- a/squarelet/core/views.py
+++ b/squarelet/core/views.py
@@ -101,5 +101,4 @@ def page_not_found(request, exception, template_name="404.html"):
     # structured context from ContextHttp404
     if isinstance(exception, ContextHttp404):
         context.update(exception.context)
-        print(context)
     return render(request, template_name, context, status=404)

--- a/squarelet/core/views.py
+++ b/squarelet/core/views.py
@@ -1,8 +1,10 @@
 # Django
+from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic.base import RedirectView, TemplateView
 
 # Squarelet
+from squarelet.core.exceptions import ContextHttp404
 from squarelet.organizations.models import Plan
 
 
@@ -90,3 +92,14 @@ class SelectPlanView(TemplateView):
         ]
 
         return context
+
+
+def page_not_found(request, exception, template_name="404.html"):
+    context = {}
+    if exception and exception.args and isinstance(exception.args[0], str):
+        context["message"] = exception.args[0]
+    # structured context from ContextHttp404
+    if isinstance(exception, ContextHttp404):
+        context.update(exception.context)
+        print(context)
+    return render(request, template_name, context, status=404)

--- a/squarelet/organizations/mixins.py
+++ b/squarelet/organizations/mixins.py
@@ -6,6 +6,7 @@ from django.shortcuts import redirect
 # Squarelet
 from squarelet.core.exceptions import ContextHttp404
 from squarelet.organizations.models import ProfileChangeRequest
+from squarelet.organizations.models.organization import Organization
 
 
 class OrganizationAdminMixin(UserPassesTestMixin):
@@ -83,16 +84,19 @@ class ResolveOrganizationSlugMixin:
         slug = self.kwargs.get("slug")
         change_request = (
             ProfileChangeRequest.objects.filter(previous__slug=slug, status="accepted")
+            .exclude(organization__slug=slug)
             .select_related("organization")
             .order_by("-updated_at")
             .first()
         )
         if change_request is None:
             return None
-        org = change_request.organization
-        if not user.has_perm("organizations.view_organization", org):
+        try:
+            pk = change_request.organization.pk
+            org = Organization.objects.get_viewable(user).get(pk=pk)
+            return redirect(org.get_absolute_url(), permanent=False)
+        except Organization.DoesNotExist:
             return None
-        return redirect(org.get_absolute_url(), permanent=True)
 
     def get_user_orgs(self, request):
         user = request.user

--- a/squarelet/organizations/mixins.py
+++ b/squarelet/organizations/mixins.py
@@ -1,5 +1,10 @@
 # Django
 from django.contrib.auth.mixins import PermissionRequiredMixin, UserPassesTestMixin
+from django.http import Http404
+from django.shortcuts import redirect
+
+# Squarelet
+from squarelet.organizations.models import ProfileChangeRequest
 
 
 class OrganizationAdminMixin(UserPassesTestMixin):
@@ -55,3 +60,32 @@ class VerifiedJournalistMixin(UserPassesTestMixin):
             and organization.verified_journalist
             and organization.has_admin(self.request.user)
         )
+
+
+class ResolveOrganizationSlugMixin:
+    """Resolve an org by slug, or look for a matching change request
+    and return a redirect if one is found."""
+
+    def get(self, request, *args, **kwargs):
+        try:
+            self.object = self.get_object()
+            context = self.get_context_data(object=self.object)
+            return self.render_to_response(context)
+        except Http404:
+            slug_redirect = self.get_slug_redirect()
+            if slug_redirect is not None:
+                return slug_redirect
+            raise
+
+    def get_slug_redirect(self):
+        slug = self.kwargs.get("slug")
+        change_request = (
+            ProfileChangeRequest.objects.filter(previous__slug=slug, status="accepted")
+            .select_related("organization")
+            .order_by("-updated_at")
+            .first()
+        )
+        if change_request is None:
+            return None
+        org = change_request.organization
+        return redirect(org.get_absolute_url(), permanent=True)

--- a/squarelet/organizations/mixins.py
+++ b/squarelet/organizations/mixins.py
@@ -6,7 +6,6 @@ from django.shortcuts import redirect
 # Squarelet
 from squarelet.core.exceptions import ContextHttp404
 from squarelet.organizations.models import ProfileChangeRequest
-from squarelet.organizations.models.organization import Organization
 
 
 class OrganizationAdminMixin(UserPassesTestMixin):
@@ -98,8 +97,4 @@ class ResolveOrganizationSlugMixin:
         user = request.user
         if not hasattr(user, "organizations"):
             return []
-
-        user_org_ids = user.organizations.filter(individual=False).values_list(
-            "id", flat=True
-        )
-        return Organization.objects.filter(id__in=user_org_ids)
+        return user.organizations.filter(individual=False)

--- a/squarelet/organizations/mixins.py
+++ b/squarelet/organizations/mixins.py
@@ -4,7 +4,9 @@ from django.http import Http404
 from django.shortcuts import redirect
 
 # Squarelet
+from squarelet.core.exceptions import ContextHttp404
 from squarelet.organizations.models import ProfileChangeRequest
+from squarelet.organizations.models.organization import Organization
 
 
 class OrganizationAdminMixin(UserPassesTestMixin):
@@ -75,7 +77,7 @@ class ResolveOrganizationSlugMixin:
             slug_redirect = self.get_slug_redirect()
             if slug_redirect is not None:
                 return slug_redirect
-            raise
+            raise ContextHttp404(context={"user_orgs": self.get_user_orgs(request)})
 
     def get_slug_redirect(self):
         slug = self.kwargs.get("slug")
@@ -89,3 +91,13 @@ class ResolveOrganizationSlugMixin:
             return None
         org = change_request.organization
         return redirect(org.get_absolute_url(), permanent=True)
+
+    def get_user_orgs(self, request):
+        user = request.user
+        if not hasattr(user, "organizations"):
+            return []
+
+        user_org_ids = user.organizations.filter(individual=False).values_list(
+            "id", flat=True
+        )
+        return Organization.objects.filter(id__in=user_org_ids)

--- a/squarelet/organizations/mixins.py
+++ b/squarelet/organizations/mixins.py
@@ -70,13 +70,14 @@ class ResolveOrganizationSlugMixin:
     def get(self, request, *args, **kwargs):
         try:
             self.object = self.get_object()
-            context = self.get_context_data(object=self.object)
-            return self.render_to_response(context)
         except Http404:
             slug_redirect = self.get_slug_redirect(request.user)
             if slug_redirect is not None:
                 return slug_redirect
             raise ContextHttp404(context={"user_orgs": self.get_user_orgs(request)})
+
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
 
     def get_slug_redirect(self, user):
         slug = self.kwargs.get("slug")
@@ -97,4 +98,4 @@ class ResolveOrganizationSlugMixin:
         user = request.user
         if not hasattr(user, "organizations"):
             return []
-        return user.organizations.filter(individual=False)
+        return user.organizations.filter(individual=False).order_by("name")

--- a/squarelet/organizations/mixins.py
+++ b/squarelet/organizations/mixins.py
@@ -74,12 +74,12 @@ class ResolveOrganizationSlugMixin:
             context = self.get_context_data(object=self.object)
             return self.render_to_response(context)
         except Http404:
-            slug_redirect = self.get_slug_redirect()
+            slug_redirect = self.get_slug_redirect(request.user)
             if slug_redirect is not None:
                 return slug_redirect
             raise ContextHttp404(context={"user_orgs": self.get_user_orgs(request)})
 
-    def get_slug_redirect(self):
+    def get_slug_redirect(self, user):
         slug = self.kwargs.get("slug")
         change_request = (
             ProfileChangeRequest.objects.filter(previous__slug=slug, status="accepted")
@@ -90,6 +90,8 @@ class ResolveOrganizationSlugMixin:
         if change_request is None:
             return None
         org = change_request.organization
+        if not user.has_perm("organizations.view_organization", org):
+            return None
         return redirect(org.get_absolute_url(), permanent=True)
 
     def get_user_orgs(self, request):

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -551,7 +551,7 @@ class TestDetail(ViewTestMixin):
 
         response = self.call_view(rf, user, slug=old_slug)
 
-        assert response.status_code == 301
+        assert response.status_code == 302
         assert response.url == organization.get_absolute_url()
         assert response.url == "/organizations/new-newsroom/"
 
@@ -567,7 +567,7 @@ class TestDetail(ViewTestMixin):
 
         response = self.call_view(rf, slug=old_slug)
 
-        assert response.status_code == 301
+        assert response.status_code == 302
         assert response.url == organization.get_absolute_url()
 
     def test_redirects_member_for_private_org(
@@ -584,7 +584,7 @@ class TestDetail(ViewTestMixin):
 
         response = self.call_view(rf, user, slug=old_slug)
 
-        assert response.status_code == 301
+        assert response.status_code == 302
         assert response.url == organization.get_absolute_url()
 
     def test_no_redirect_when_user_cannot_view_org(

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -587,6 +587,23 @@ class TestDetail(ViewTestMixin):
         assert response.status_code == 302
         assert response.url == organization.get_absolute_url()
 
+    def test_redirects_staff_for_private_org(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        """Staff can view private orgs they are not a member of, so a rename
+        redirects."""
+        staff_user = user_factory(is_staff=True)
+        organization = organization_factory(name="Private Newsroom", private=True)
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-private"
+        )
+
+        response = self.call_view(rf, staff_user, slug=old_slug)
+
+        assert response.status_code == 302
+        assert response.url == organization.get_absolute_url()
+
     def test_no_redirect_when_user_cannot_view_org(
         self, rf, user_factory, organization_factory, profile_change_request_factory
     ):
@@ -612,6 +629,80 @@ class TestDetail(ViewTestMixin):
 
         with pytest.raises(ContextHttp404):
             self.call_view(rf, slug=old_slug)
+
+    def test_no_redirect_for_anonymous_user_on_public_unverified_org(
+        self, rf, organization_factory, profile_change_request_factory
+    ):
+        """A public but unverified org with no charges or paid invoices is
+        hidden from anonymous users, so a rename must not redirect."""
+        organization = organization_factory(
+            name="Unverified Newsroom", private=False, verified_journalist=False
+        )
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-unverified"
+        )
+
+        with pytest.raises(ContextHttp404):
+            self.call_view(rf, slug=old_slug)
+
+    def test_no_redirect_for_non_member_on_public_unverified_org(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        """A public but unverified org with no charges or paid invoices is
+        hidden from authenticated non-members, so a rename must not redirect."""
+        outsider = user_factory()
+        organization = organization_factory(
+            name="Unverified Newsroom", private=False, verified_journalist=False
+        )
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-unverified"
+        )
+
+        with pytest.raises(ContextHttp404):
+            self.call_view(rf, outsider, slug=old_slug)
+
+    def test_redirects_staff_for_public_unverified_org(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        """Staff can view any org, so a rename redirects even for an org
+        that would be hidden from non-members."""
+        staff_user = user_factory(is_staff=True)
+        organization = organization_factory(
+            name="Unverified Newsroom", private=False, verified_journalist=False
+        )
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-unverified"
+        )
+
+        response = self.call_view(rf, staff_user, slug=old_slug)
+
+        assert response.status_code == 302
+        assert response.url == organization.get_absolute_url()
+
+    def test_redirects_member_for_public_unverified_org(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        """Members can view their own org even if it is unverified, so a
+        rename redirects."""
+        user = user_factory()
+        organization = organization_factory(
+            name="Unverified Newsroom",
+            private=False,
+            verified_journalist=False,
+            users=[user],
+        )
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-unverified"
+        )
+
+        response = self.call_view(rf, user, slug=old_slug)
+
+        assert response.status_code == 302
+        assert response.url == organization.get_absolute_url()
 
     @pytest.mark.parametrize("status", ["pending", "rejected"])
     def test_no_redirect_for_unaccepted_change_request(

--- a/squarelet/organizations/tests/test_views.py
+++ b/squarelet/organizations/tests/test_views.py
@@ -19,6 +19,7 @@ from actstream.models import Action
 from allauth.account.models import EmailAddress
 
 # Squarelet
+from squarelet.core.exceptions import ContextHttp404
 from squarelet.core.tests.mixins import ViewTestMixin
 
 # Local
@@ -36,6 +37,18 @@ def _assign_org_perm(user, codename):
     perm = Permission.objects.get(codename=codename, content_type=ct)
     user.user_permissions.add(perm)
     return type(user).objects.get(pk=user.pk)
+
+
+def _rename_organization(factory, organization, new_slug, **kwargs):
+    """Rename an organization through an accepted profile change request.
+    Returns the change request, which records the previous slug.
+    """
+    change_request = factory(
+        organization=organization, slug=new_slug, status="pending", **kwargs
+    )
+    change_request.accept("approved")
+    organization.refresh_from_db()
+    return change_request
 
 
 @pytest.mark.django_db()
@@ -525,6 +538,113 @@ class TestDetail(ViewTestMixin):
         )
         # Should still redirect but show an error message
         assert response.status_code == 302
+
+    def test_redirects_old_slug_after_accepted_rename(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        user = user_factory()
+        organization = organization_factory(name="Old Newsroom", users=[user])
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "new-newsroom"
+        )
+
+        response = self.call_view(rf, user, slug=old_slug)
+
+        assert response.status_code == 301
+        assert response.url == organization.get_absolute_url()
+        assert response.url == "/organizations/new-newsroom/"
+
+    def test_redirects_anonymous_user_for_public_org(
+        self, rf, organization_factory, profile_change_request_factory
+    ):
+        """Anonymous users can view public orgs, so they get the redirect too"""
+        organization = organization_factory(name="Public Newsroom", private=False)
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-public"
+        )
+
+        response = self.call_view(rf, slug=old_slug)
+
+        assert response.status_code == 301
+        assert response.url == organization.get_absolute_url()
+
+    def test_redirects_member_for_private_org(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        user = user_factory()
+        organization = organization_factory(
+            name="Private Newsroom", private=True, users=[user]
+        )
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-private"
+        )
+
+        response = self.call_view(rf, user, slug=old_slug)
+
+        assert response.status_code == 301
+        assert response.url == organization.get_absolute_url()
+
+    def test_no_redirect_when_user_cannot_view_org(
+        self, rf, user_factory, organization_factory, profile_change_request_factory
+    ):
+        """A rename must not leak the new slug of a private org to a non member"""
+        outsider = user_factory()
+        organization = organization_factory(name="Secret Newsroom", private=True)
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-secret"
+        )
+
+        with pytest.raises(ContextHttp404):
+            self.call_view(rf, outsider, slug=old_slug)
+
+    def test_no_redirect_for_anonymous_user_on_private_org(
+        self, rf, organization_factory, profile_change_request_factory
+    ):
+        organization = organization_factory(name="Secret Newsroom", private=True)
+        old_slug = organization.slug
+        _rename_organization(
+            profile_change_request_factory, organization, "renamed-secret"
+        )
+
+        with pytest.raises(ContextHttp404):
+            self.call_view(rf, slug=old_slug)
+
+    @pytest.mark.parametrize("status", ["pending", "rejected"])
+    def test_no_redirect_for_unaccepted_change_request(
+        self,
+        rf,
+        status,
+        user_factory,
+        organization_factory,
+        profile_change_request_factory,
+    ):
+        """Only accepted change requests should drive a redirect"""
+        user = user_factory()
+        organization = organization_factory(name="Old Newsroom", users=[user])
+        profile_change_request_factory(
+            organization=organization,
+            slug="never-applied",
+            status=status,
+            previous={"slug": "never-renamed-newsroom"},
+        )
+
+        with pytest.raises(ContextHttp404):
+            self.call_view(rf, user, slug="never-renamed-newsroom")
+
+    def test_unknown_slug_raises_context_http404_with_user_orgs(
+        self, rf, user_factory, organization_factory
+    ):
+        user = user_factory()
+        organization = organization_factory(users=[user])
+
+        with pytest.raises(ContextHttp404) as excinfo:
+            self.call_view(rf, user, slug="no-such-org")
+
+        assert list(excinfo.value.context["user_orgs"]) == [organization]
 
 
 @pytest.mark.django_db()

--- a/squarelet/organizations/views/detail.py
+++ b/squarelet/organizations/views/detail.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from squarelet.core.mixins import AdminLinkMixin
 from squarelet.core.utils import get_redirect_url, is_rate_limited, new_action
 from squarelet.organizations.forms import InvitationAcceptForm
+from squarelet.organizations.mixins import ResolveOrganizationSlugMixin
 from squarelet.organizations.models import Invitation, Membership, Organization, Plan
 from squarelet.organizations.models.invitation import OrganizationInvitation
 from squarelet.organizations.payments.factory import get_payment_provider
@@ -31,7 +32,7 @@ ORG_PAGINATION = 100
 logger = logging.getLogger(__name__)
 
 
-class Detail(AdminLinkMixin, DetailView):
+class Detail(ResolveOrganizationSlugMixin, AdminLinkMixin, DetailView):
     def get_queryset(self):
         return Organization.objects.filter(individual=False).get_viewable(
             self.request.user

--- a/squarelet/templates/404.html
+++ b/squarelet/templates/404.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n icon %}
 
 {% block title %}Page not found{% endblock %}
 
@@ -28,6 +28,10 @@
           {% endfor %}
         </ul>
       {% endif %}
+      <a href="{% url 'organizations:list' %}" class="btn primary">
+        {% icon "chevron-left" %}
+        {% trans "Go to organizations overview" %}
+      </a>
     {% else %}
       <h1>Page not found</h1>
 

--- a/squarelet/templates/404.html
+++ b/squarelet/templates/404.html
@@ -1,11 +1,37 @@
 {% extends "base.html" %}
+{% load i18n %}
 
 {% block title %}Page not found{% endblock %}
 
+{% block css %}
+{{ block.super }}
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+</style>
+{% endblock %}
+
 {% block content %}
   <div class="_cls-content">
-    <h1>Page not found</h1>
+    {% if user_orgs is not None %}
+      <h1>{% trans "Organization not found" %}</h1>
+      
+      {% if user_orgs|length %}
+        <h2>{% trans "Were you looking for one of these organizations?" %}</h2>
+        <ul>
+          {% for org in user_orgs %}
+            <li>
+              <a class="btn ghost primary" href="{{ org.get_absolute_url }}">{{ org.name }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% else %}
+      <h1>Page not found</h1>
 
-    <p>This is not the page you were looking for.</p>
+      <p>This is not the page you were looking for.</p>
+    {% endif %}
   </div>
 {% endblock content %}


### PR DESCRIPTION
Closes #562.

Introduces `ResolveOrganizationSlugMixin`, which tries to match the provided org slug against an accepted profile change request and returns a 301 request if one is found. Currently this is only used with the organization `Detail` view, but it could be added to other org views too.

Also adds a custom 404 handler, and shows signed-in users a list of their orgs on organization 404 pages.

To test the 404 page in context (i.e. `/organizations/not-a-real-org/` rather than `/404`) I had to tweak `config/settings/local.py` locally:

```diff
-DEBUG = True
+DEBUG = False

DJANGO_VITE = {
    "default": {
-       "dev_mode": DEBUG,
+       "dev_mode": True,
``` 