### PR TITLE
Prevent fetching 3rd party code (can cause e2e tests to flake)

### DIFF
--- a/docs/contributors/writing-e2e-tests.md
+++ b/docs/contributors/writing-e2e-tests.md
@@ -6,6 +6,14 @@ This guide covers best practices for writing end-to-end tests with Playwright in
 
 E2E tests live in the `e2e/` directory and run against a real Docker environment with a dedicated test database. See the `e2e/global-setup.ts` and `e2e/global-teardown.ts` files for how the environment is provisioned.
 
+Import `test` and `expect` from `./fixtures`, **not** from `@playwright/test`:
+
+```ts
+import { test, expect } from "./fixtures";
+```
+
+`e2e/fixtures.ts` wraps Playwright's `test` so that third-party requests are blocked. See [Third-Party Requests](#third-party-requests) for why this matters.
+
 ```bash
 # Run with npx
 npx playwright test
@@ -205,6 +213,19 @@ await page.locator('button[value="addmember"]').click();
 await expectFlashMessage(page, "success");
 ```
 
+### `newAnonContext(browser)`
+
+Opens a fresh browser context for a second user, pre-configured for the dev environment. See [Testing Multiple User Contexts](#testing-multiple-user-contexts).
+
+```ts
+import { newAnonContext } from "./helpers";
+
+const anonContext = await newAnonContext(browser);
+const anonPage = await anonContext.newPage();
+// ...
+await anonContext.close();
+```
+
 ### `runManageCommand(args)`
 
 Runs a Django management command inside the Docker container. Useful for setting up or tearing down test state that's hard to create through the UI.
@@ -217,7 +238,7 @@ runManageCommand("some_command --flag");
 
 ## Testing Multiple User Contexts
 
-Use `browser.newContext()` to simulate a second user (e.g., an anonymous visitor) within the same test.
+Use the `newAnonContext(browser)` helper to simulate a second user (e.g., an anonymous visitor) within the same test.
 
 ```ts
 test("invite link is accessible to anonymous users", async ({ page, browser }) => {
@@ -225,7 +246,7 @@ test("invite link is accessible to anonymous users", async ({ page, browser }) =
   // ... generate an invite link ...
 
   // Open a fresh anonymous browser context
-  const anonContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const anonContext = await newAnonContext(browser);
   const anonPage = await anonContext.newPage();
   await anonPage.goto(`https://dev.squarelet.com${invitationPath}`);
 
@@ -235,7 +256,18 @@ test("invite link is accessible to anonymous users", async ({ page, browser }) =
 });
 ```
 
-Always pass `ignoreHTTPSErrors: true` when creating a new context, since the dev environment uses a self-signed certificate.
+Use the helper rather than calling `browser.newContext()` directly. It sets `ignoreHTTPSErrors: true` (the dev environment uses a self-signed certificate) and applies the same third-party request blocking the default `page` gets.
+
+## Third-Party Requests
+
+`base.html` loads Google Fonts, Plausible analytics, and Stripe.js on every page. `page.goto()` waits for the browser's `load` event, which waits on those subresources — so if any of them is slow or unreachable, the navigation stalls until the test's 30s budget is exhausted. The failure then surfaces on whatever step happened to be in flight, typically as a misleading "timed out waiting for locator" against an element that is plainly present in the failure screenshot.
+
+To keep the suite independent of the public internet, `blockThirdPartyRequests()` in `e2e/helpers.ts` aborts those requests. It is applied automatically to:
+
+- the default `page`, via the `context` fixture in `e2e/fixtures.ts`
+- any context created with `newAnonContext(browser)`
+
+None of the blocked resources affect application behavior under test. One caveat: `js.stripe.com` is blocked only because no test currently drives a Stripe card element. **A test that needs Stripe Elements must allow `js.stripe.com` through** by removing it from `THIRD_PARTY_HOSTS` or overriding the route in that spec.
 
 ## Assertions
 
@@ -294,9 +326,10 @@ await modal.locator('button[name="action"][value="join"]').click();
 The Playwright config is in `playwright.config.ts`. Key settings:
 
 - **`baseURL`**: `https://dev.squarelet.com` — all `page.goto("/path")` calls are relative to this.
-- **`workers: 1`**: Tests run sequentially since they share a database.
+- **`fullyParallel: false`**: Tests within a file run sequentially, since they share a database.
 - **`timeout: 30_000`**: Each test has 30 seconds to complete.
 - **`expect.timeout: 10_000`**: Each assertion retries for up to 10 seconds.
+- **`navigationTimeout: 20_000`**: A stalled page load fails on its own, rather than silently consuming the test's budget and failing on a later step.
 - **Screenshots and traces** are captured on failure for debugging.
 
 ## CI
@@ -310,9 +343,10 @@ When a CI run fails:
 
 ## Checklist for New Tests
 
+- [ ] `test` and `expect` are imported from `./fixtures`, not `@playwright/test`
 - [ ] Selectors use `id`, `name`, `value`, `data-*`, or structural CSS — not display text
 - [ ] Tests clean up any state they modify
 - [ ] `login()` and `expectFlashMessage()` helpers are used instead of reimplemented
-- [ ] Extra browser contexts pass `ignoreHTTPSErrors: true` and are closed after use
+- [ ] Extra browser contexts are created with `newAnonContext()` and closed after use
 - [ ] Each test verifies one behavior
 - [ ] Tests are grouped in `describe` blocks by role or workflow

--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { E2E_PASSWORD, deleteTestUser } from "./helpers";
 
 const SIGNUP_USER = "e2e-signup-user";

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,17 @@
+import { test as base, expect } from "@playwright/test";
+import { blockThirdPartyRequests } from "./helpers";
+
+/**
+ * The `test` every spec should import, in place of the one from
+ * @playwright/test.  It overrides the built-in `context` fixture so that the
+ * default `page` never blocks on a third-party request.  Contexts created by
+ * hand inside a test get the same treatment via `newAnonContext`.
+ */
+export const test = base.extend({
+  context: async ({ context }, use) => {
+    await blockThirdPartyRequests(context);
+    await use(context);
+  },
+});
+
+export { expect };

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,9 +1,49 @@
-import { type Page, expect } from "@playwright/test";
+import {
+  type Browser,
+  type BrowserContext,
+  type Page,
+  expect,
+} from "@playwright/test";
 import { execSync } from "child_process";
 
 export const E2E_PASSWORD = "e2e-test-password";
 
 const COMPOSE_E2E = "docker compose -f local.yml -f e2e.yml";
+
+/**
+ * Third-party hosts that base.html pulls in on every page: web fonts,
+ * analytics, and Stripe.js.
+ *
+ * page.goto() waits for the "load" event, which waits on these subresources.
+ * A slow or unreachable response from any of them therefore stalls the
+ * navigation until the test's 30s budget is gone, and the failure surfaces on
+ * whatever step happened to be in flight — usually a misleading "timed out
+ * waiting for locator" on an element that is present on the page.  None of
+ * them affect the behavior under test, so abort them before they can hang.
+ *
+ * NOTE: js.stripe.com is safe to block only because no test currently drives a
+ * Stripe card element.  A test that does will need to allow it through.
+ */
+const THIRD_PARTY_HOSTS =
+  /fonts\.googleapis\.com|fonts\.gstatic\.com|plausible\.io|js\.stripe\.com/;
+
+export async function blockThirdPartyRequests(context: BrowserContext) {
+  await context.route(THIRD_PARTY_HOSTS, (route) => route.abort());
+}
+
+/**
+ * Open a fresh browser context for simulating a second user (e.g. an anonymous
+ * visitor) in the same test.  Ignores HTTPS errors, since the dev environment
+ * uses a self-signed certificate, and blocks third-party requests the same way
+ * the default `page` context does.  Always close the context when done.
+ */
+export async function newAnonContext(
+  browser: Browser,
+): Promise<BrowserContext> {
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  await blockThirdPartyRequests(context);
+  return context;
+}
 
 export async function login(page: Page, username: string) {
   // Clear cookies to ensure any existing session is removed,

--- a/e2e/oidc.spec.ts
+++ b/e2e/oidc.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { login } from "./helpers";
 
 // Matches the verification-gated client seeded in seed_e2e_data.py

--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import {
   login,
   inviteByEmail,
@@ -12,6 +13,7 @@ import {
   acceptMemberOrgInvitation,
   addMemberOrg,
   selectOrgInSearch,
+  newAnonContext,
 } from "./helpers";
 
 const NEW_ORG_SLUG = "e2e-new-org";
@@ -313,7 +315,7 @@ test.describe("Profile Editing", () => {
     await page.locator("section#details button[type='submit']").click();
 
     // Verify anonymous user gets 404
-    const anonContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    const anonContext = await newAnonContext(browser);
     const anonPage = await anonContext.newPage();
     const response = await anonPage.goto(
       "https://dev.squarelet.com/organizations/e2e-public-org/",
@@ -327,7 +329,7 @@ test.describe("Profile Editing", () => {
     await page.locator("section#details button[type='submit']").click();
 
     // Verify anonymous user can access again
-    const anonContext2 = await browser.newContext({ ignoreHTTPSErrors: true });
+    const anonContext2 = await newAnonContext(browser);
     const anonPage2 = await anonContext2.newPage();
     const response2 = await anonPage2.goto(
       "https://dev.squarelet.com/organizations/e2e-public-org/",
@@ -467,7 +469,7 @@ test.describe("Member Management", () => {
     const invitationPath = urlMatch![0];
 
     // Open URL in anonymous context — should show Sign Up / Log In
-    const anonContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    const anonContext = await newAnonContext(browser);
     const anonPage = await anonContext.newPage();
     await anonPage.goto(`https://dev.squarelet.com${invitationPath}`);
     const controls = anonPage.locator(".control-group");
@@ -824,9 +826,7 @@ test.describe("Invitation & Request History", () => {
       browser,
     }) => {
       // Login as requester and submit join request
-      const requesterContext = await browser.newContext({
-        ignoreHTTPSErrors: true,
-      });
+      const requesterContext = await newAnonContext(browser);
       const requesterPage = await requesterContext.newPage();
       await login(requesterPage, "e2e-requester");
       await requesterPage.goto("/organizations/e2e-public-org/");

--- a/e2e/plans.spec.ts
+++ b/e2e/plans.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { login } from "./helpers";
 
 test.describe("Plan purchase redirects", () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
   use: {
     baseURL: "https://dev.squarelet.com",
     ignoreHTTPSErrors: true,
+    // Fail a stalled navigation before it can consume the whole test budget.
+    navigationTimeout: 20_000,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },


### PR DESCRIPTION
Blocks requests for Google Fonts, Plausible, and Stripe code in app when running e2e tests. This caused some tests to fail due to network conditions unrelated to our code.