### PR TITLE
Improve observability of cache invalidation webhooks

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -237,6 +237,14 @@ LOGGING = {
         }
     },
     "loggers": {
+        # Cache invalidation webhooks are critical client notifications, so this
+        # path logs at INFO. Scoped to squarelet.oidc rather than squarelet so
+        # the other apps' INFO trails stay off and the volume stays predictable.
+        "squarelet.oidc": {
+            "level": env("OIDC_LOG_LEVEL", default="INFO"),
+            "handlers": ["console"],
+            "propagate": False,
+        },
         "django.db.backends": {
             "level": "ERROR",
             "handlers": ["console"],

--- a/squarelet/oidc/models.py
+++ b/squarelet/oidc/models.py
@@ -7,10 +7,38 @@ from django.utils.translation import gettext_lazy as _
 # Standard Library
 import hashlib
 import hmac
+import logging
 import time
 
 # Third Party
 import requests
+
+logger = logging.getLogger(__name__)
+
+# (connect, read) - a stuck TLS handshake should not pin a worker for the full
+# read timeout
+WEBHOOK_TIMEOUT = (5, 30)
+# clients return full debug HTML on error, and a sustained outage logs this on
+# every attempt of every broadcast - enough to identify the error, no more
+ERROR_BODY_CHARS = 200
+# Log every uuid for interactive saves, where the list itself is what you need to
+# trace a delivery. Bulk jobs like restore_organization pass thousands at once.
+UUID_LOG_THRESHOLD = 30
+UUID_LOG_SAMPLE = 3
+
+
+def get_elapsed_ms(start):
+    """Return elapsed ms since start"""
+    return int((time.monotonic() - start) * 1000)
+
+
+def format_uuids(uuids):
+    """Render a uuid list for logging, abbreviating bulk batches"""
+    uuid_strs = [str(u) for u in uuids]
+    if len(uuid_strs) <= UUID_LOG_THRESHOLD:
+        return str(uuid_strs)
+    remaining = len(uuid_strs) - UUID_LOG_SAMPLE
+    return f"{uuid_strs[:UUID_LOG_SAMPLE]} +{remaining} more"
 
 
 class ClientProfile(models.Model):
@@ -60,7 +88,11 @@ class ClientProfile(models.Model):
         return str(self.client)
 
     def send_cache_invalidation(self, model, uuids):
-        """Send a cache invalidation to this client"""
+        """Send a cache invalidation to this client
+
+        Returns the response on success. Raises requests.HTTPError on a non-2xx
+        response and requests.RequestException on network failure.
+        """
         timestamp = int(time.time())
         uuid_str = "".join(str(u) for u in uuids)
         signature = hmac.new(
@@ -74,4 +106,49 @@ class ClientProfile(models.Model):
             "timestamp": timestamp,
             "signature": signature,
         }
-        requests.post(self.webhook_url, data=data, timeout=30)
+
+        start = time.monotonic()
+        try:
+            response = requests.post(
+                self.webhook_url, data=data, timeout=WEBHOOK_TIMEOUT
+            )
+        except requests.RequestException as exc:
+            logger.warning(
+                "[CACHE-INVALIDATION] Network failure client=%s model=%s uuids=%s "
+                "elapsed_ms=%d url=%s: %s",
+                self.client.name,
+                model,
+                format_uuids(uuids),
+                get_elapsed_ms(start),
+                self.webhook_url,
+                exc,
+            )
+            raise
+
+        elapsed_ms = get_elapsed_ms(start)
+        if not response.ok:
+            # log at warning, not error: the task logs a single error once it has
+            # exhausted its retries, so one failed delivery is one Sentry event
+            logger.warning(
+                "[CACHE-INVALIDATION] Rejected client=%s model=%s uuids=%s "
+                "status=%d elapsed_ms=%d body=%s",
+                self.client.name,
+                model,
+                format_uuids(uuids),
+                response.status_code,
+                elapsed_ms,
+                response.text[:ERROR_BODY_CHARS],
+            )
+            response.raise_for_status()
+
+        logger.info(
+            "[CACHE-INVALIDATION] Sent client=%s model=%s count=%d status=%d "
+            "elapsed_ms=%d uuids=%s",
+            self.client.name,
+            model,
+            len(uuids),
+            response.status_code,
+            elapsed_ms,
+            format_uuids(uuids),
+        )
+        return response

--- a/squarelet/oidc/models.py
+++ b/squarelet/oidc/models.py
@@ -87,8 +87,11 @@ class ClientProfile(models.Model):
     def __str__(self):
         return str(self.client)
 
-    def send_cache_invalidation(self, model, uuids):
+    def send_cache_invalidation(self, model, uuids, invalidation_id=None):
         """Send a cache invalidation to this client
+
+        `invalidation_id` is logged, not sent, so one broadcast's fan-out can be
+        traced across clients and retries.
 
         Returns the response on success. Raises requests.HTTPError on a non-2xx
         response and requests.RequestException on network failure.
@@ -114,13 +117,14 @@ class ClientProfile(models.Model):
             )
         except requests.RequestException as exc:
             logger.warning(
-                "[CACHE-INVALIDATION] Network failure client=%s model=%s uuids=%s "
-                "elapsed_ms=%d url=%s: %s",
+                "[CACHE-INVALIDATION] Network failure id=%s client=%s url=%s "
+                "model=%s uuids=%s elapsed_ms=%d: %s",
+                invalidation_id,
                 self.client.name,
+                self.webhook_url,
                 model,
                 format_uuids(uuids),
                 get_elapsed_ms(start),
-                self.webhook_url,
                 exc,
             )
             raise
@@ -130,9 +134,11 @@ class ClientProfile(models.Model):
             # log at warning, not error: the task logs a single error once it has
             # exhausted its retries, so one failed delivery is one Sentry event
             logger.warning(
-                "[CACHE-INVALIDATION] Rejected client=%s model=%s uuids=%s "
-                "status=%d elapsed_ms=%d body=%s",
+                "[CACHE-INVALIDATION] Rejected id=%s client=%s url=%s model=%s "
+                "uuids=%s status=%d elapsed_ms=%d body=%s",
+                invalidation_id,
                 self.client.name,
+                self.webhook_url,
                 model,
                 format_uuids(uuids),
                 response.status_code,
@@ -142,9 +148,11 @@ class ClientProfile(models.Model):
             response.raise_for_status()
 
         logger.info(
-            "[CACHE-INVALIDATION] Sent client=%s model=%s count=%d status=%d "
-            "elapsed_ms=%d uuids=%s",
+            "[CACHE-INVALIDATION] Sent id=%s client=%s url=%s model=%s count=%d "
+            "status=%d elapsed_ms=%d uuids=%s",
+            invalidation_id,
             self.client.name,
+            self.webhook_url,
             model,
             len(uuids),
             response.status_code,

--- a/squarelet/oidc/tasks.py
+++ b/squarelet/oidc/tasks.py
@@ -2,18 +2,26 @@
 from celery import shared_task
 from django.utils import timezone
 
+# Standard Library
+import logging
+
 # Local
 from .models import ClientProfile
 
+logger = logging.getLogger(__name__)
+
 
 @shared_task(name="squarelet.oidc.tasks.send_cache_invalidation")
-def send_cache_invalidation(client_profile_pk, model, uuids):
+def send_cache_invalidation(client_profile_pk, model, uuids, invalidation_id=None):
     # pylint: disable=import-outside-toplevel
     # Squarelet
     from squarelet.organizations.models import Organization
     from squarelet.users.models import User
 
-    client_profile = ClientProfile.objects.get(pk=client_profile_pk)
+    client_profile = ClientProfile.objects.select_related("client").get(
+        pk=client_profile_pk
+    )
+    original_count = len(uuids)
     if client_profile.client.require_consent:
         # If this client requires consent, we must filter out the users or orgs
         # to just the ones that they have permissions to view
@@ -40,3 +48,14 @@ def send_cache_invalidation(client_profile_pk, model, uuids):
 
     if uuids:
         client_profile.send_cache_invalidation(model, uuids)
+    else:
+        # this drop was previously indistinguishable from a successful send
+        logger.info(
+            "[CACHE-INVALIDATION] Nothing to send id=%s client=%s model=%s "
+            "reason=%s original_count=%d",
+            invalidation_id,
+            client_profile.client.name,
+            model,
+            "consent-filtered" if original_count else "empty-input",
+            original_count,
+        )

--- a/squarelet/oidc/tasks.py
+++ b/squarelet/oidc/tasks.py
@@ -4,15 +4,37 @@ from django.utils import timezone
 
 # Standard Library
 import logging
+import sys
+from random import randint
+
+# Third Party
+import requests
 
 # Local
-from .models import ClientProfile
+from .models import ClientProfile, format_uuids
 
 logger = logging.getLogger(__name__)
 
+# A client outage is measured in minutes, not seconds: 1, 2 and 4 minutes plus
+# jitter, so a client coming back up is not hit by every retry at once
+MAX_RETRIES = 3
+RETRY_BACKOFF = 60
+RETRY_JITTER = 30
 
-@shared_task(name="squarelet.oidc.tasks.send_cache_invalidation")
-def send_cache_invalidation(client_profile_pk, model, uuids, invalidation_id=None):
+
+def retry_countdown(retries):
+    """Seconds to wait before the next delivery attempt"""
+    return 2**retries * RETRY_BACKOFF + randint(0, RETRY_JITTER)
+
+
+@shared_task(
+    bind=True,
+    max_retries=MAX_RETRIES,
+    name="squarelet.oidc.tasks.send_cache_invalidation",
+)
+def send_cache_invalidation(
+    self, client_profile_pk, model, uuids, invalidation_id=None
+):
     # pylint: disable=import-outside-toplevel
     # Squarelet
     from squarelet.organizations.models import Organization
@@ -47,7 +69,42 @@ def send_cache_invalidation(client_profile_pk, model, uuids, invalidation_id=Non
             uuids = [str(i) for i in organizations.values_list("uuid", flat=True)]
 
     if uuids:
-        client_profile.send_cache_invalidation(model, uuids)
+        try:
+            client_profile.send_cache_invalidation(model, uuids, invalidation_id)
+        except requests.RequestException as exc:
+            # the model logs each rejected or failed attempt at warning level
+            if self.request.retries >= self.max_retries:
+                # the one error per lost delivery, so one Sentry event - the task
+                # itself succeeds, as a dropped invalidation only leaves the
+                # client's cache stale until its next write
+                logger.error(
+                    "[CACHE-INVALIDATION] Retries exceeded, giving up! id=%s client=%s url=%s "
+                    "model=%s count=%d attempts=%d uuids=%s: %s",
+                    invalidation_id,
+                    client_profile.client.name,
+                    client_profile.webhook_url,
+                    model,
+                    len(uuids),
+                    self.request.retries + 1,
+                    format_uuids(uuids),
+                    exc,
+                    exc_info=sys.exc_info(),
+                )
+                return
+            countdown = retry_countdown(self.request.retries)
+            logger.info(
+                "[CACHE-INVALIDATION] Retrying id=%s client=%s url=%s model=%s "
+                "count=%d attempt=%d/%d countdown=%d",
+                invalidation_id,
+                client_profile.client.name,
+                client_profile.webhook_url,
+                model,
+                len(uuids),
+                self.request.retries + 1,
+                self.max_retries + 1,
+                countdown,
+            )
+            raise self.retry(countdown=countdown, exc=exc)
     else:
         # this drop was previously indistinguishable from a successful send
         logger.info(

--- a/squarelet/oidc/tasks.py
+++ b/squarelet/oidc/tasks.py
@@ -78,8 +78,8 @@ def send_cache_invalidation(
                 # itself succeeds, as a dropped invalidation only leaves the
                 # client's cache stale until its next write
                 logger.error(
-                    "[CACHE-INVALIDATION] Retries exceeded, giving up! id=%s client=%s url=%s "
-                    "model=%s count=%d attempts=%d uuids=%s: %s",
+                    "[CACHE-INVALIDATION] Retries exceeded, giving up! id=%s "
+                    "client=%s url=%s model=%s count=%d attempts=%d uuids=%s: %s",
                     invalidation_id,
                     client_profile.client.name,
                     client_profile.webhook_url,

--- a/squarelet/oidc/tests/test_models.py
+++ b/squarelet/oidc/tests/test_models.py
@@ -1,0 +1,186 @@
+"""
+Tests for OIDC models
+
+These cover the actual webhook HTTP send, which was previously untested - every
+test in test_tasks.py mocks `ClientProfile.send_cache_invalidation` away.
+"""
+
+# Standard Library
+import hashlib
+import hmac
+import logging
+from urllib.parse import parse_qs
+from uuid import uuid4
+
+# Third Party
+import pytest
+import requests
+
+# Squarelet
+from squarelet.oidc.models import ERROR_BODY_CHARS, UUID_LOG_SAMPLE, UUID_LOG_THRESHOLD
+from squarelet.oidc.tests.factories import ClientProfileFactory
+
+
+@pytest.mark.django_db()
+class TestSendCacheInvalidation:
+    """Test ClientProfile.send_cache_invalidation"""
+
+    def test_success_posts_expected_payload(self, requests_mock):
+        """A successful send posts the documented form payload"""
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+        uuids = [str(uuid4()) for _ in range(3)]
+
+        client_profile.send_cache_invalidation("user", uuids)
+
+        posted = parse_qs(requests_mock.last_request.text)
+        assert posted["type"] == ["user"]
+        assert posted["uuids"] == uuids
+        assert len(posted["timestamp"]) == 1
+        assert len(posted["signature"]) == 1
+
+    def test_signature_is_correct_hmac(self, requests_mock):
+        """The signature is an HMAC-SHA256 over timestamp + model + joined uuids
+
+        Regression guard on the wire contract: MuckRock and DocumentCloud both
+        verify this signature, so a change here breaks them simultaneously.
+        """
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+        uuids = [str(uuid4()) for _ in range(3)]
+
+        client_profile.send_cache_invalidation("organization", uuids)
+
+        posted = parse_qs(requests_mock.last_request.text)
+        uuid_str = "".join(posted["uuids"])
+        expected = hmac.new(
+            key=client_profile.client.client_secret.encode("utf8"),
+            msg=f"{posted['timestamp'][0]}organization{uuid_str}".encode("utf8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+        assert posted["signature"] == [expected]
+
+    def test_success_returns_response_and_logs_info(self, requests_mock, caplog):
+        """A 2xx response is returned and logged with context"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+        uuids = [str(uuid4()) for _ in range(3)]
+
+        response = client_profile.send_cache_invalidation("user", uuids)
+
+        assert response.status_code == 200
+        assert "[CACHE-INVALIDATION] Sent" in caplog.text
+        assert f"client={client_profile.client.name}" in caplog.text
+        assert "model=user" in caplog.text
+        assert "count=3" in caplog.text
+        assert "status=200" in caplog.text
+
+    @pytest.mark.parametrize("status_code", [400, 404, 413, 500, 502])
+    def test_non_2xx_raises_and_logs_warning(self, requests_mock, caplog, status_code):
+        """A non-2xx response raises HTTPError instead of passing silently"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=status_code)
+
+        with pytest.raises(requests.HTTPError):
+            client_profile.send_cache_invalidation("user", [str(uuid4())])
+
+        assert "[CACHE-INVALIDATION] Rejected" in caplog.text
+        assert f"status={status_code}" in caplog.text
+
+    def test_network_error_raises_and_logs_warning(self, requests_mock, caplog):
+        """A connection failure propagates and is logged"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(
+            client_profile.webhook_url, exc=requests.exceptions.ConnectTimeout
+        )
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            client_profile.send_cache_invalidation("user", [str(uuid4())])
+
+        assert "[CACHE-INVALIDATION] Network failure" in caplog.text
+
+    def test_error_response_body_is_truncated(self, requests_mock, caplog):
+        """A client's debug HTML error page does not flood the log"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=500, text="x" * 5000)
+
+        with pytest.raises(requests.HTTPError):
+            client_profile.send_cache_invalidation("user", [str(uuid4())])
+
+        assert "x" * ERROR_BODY_CHARS in caplog.text
+        assert "x" * (ERROR_BODY_CHARS + 1) not in caplog.text
+
+    def test_logs_every_uuid_at_threshold(self, requests_mock, caplog):
+        """An interactive-sized batch logs every uuid, so it can be traced"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+        uuids = [str(uuid4()) for _ in range(UUID_LOG_THRESHOLD)]
+
+        client_profile.send_cache_invalidation("organization", uuids)
+
+        assert f"count={UUID_LOG_THRESHOLD}" in caplog.text
+        for uuid in uuids:
+            assert uuid in caplog.text
+        assert "more" not in caplog.text
+
+    def test_bulk_batch_is_abbreviated(self, requests_mock, caplog):
+        """A bulk batch logs a sample and a remainder, not thousands of uuids
+
+        restore_organization sends every due org in one batch. The full list
+        would exceed Heroku's 10KB per-line limit and be truncated by the log
+        drain anyway.
+        """
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+        uuids = [str(uuid4()) for _ in range(500)]
+
+        client_profile.send_cache_invalidation("organization", uuids)
+
+        assert "count=500" in caplog.text
+        assert f"+{500 - UUID_LOG_SAMPLE} more" in caplog.text
+        for uuid in uuids[:UUID_LOG_SAMPLE]:
+            assert uuid in caplog.text
+        assert uuids[UUID_LOG_SAMPLE] not in caplog.text
+        # the whole line stays well inside the log drain's per-line limit
+        assert len(caplog.text) < 1024
+
+    def test_failure_logs_every_uuid(self, requests_mock, caplog):
+        """A rejected delivery names every uuid the client did not receive"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=502)
+        uuids = [str(uuid4()) for _ in range(5)]
+
+        with pytest.raises(requests.HTTPError):
+            client_profile.send_cache_invalidation("organization", uuids)
+
+        for uuid in uuids:
+            assert uuid in caplog.text
+
+    def test_bulk_failure_is_abbreviated(self, requests_mock, caplog):
+        """A failed bulk delivery reports its size without the full list"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=502)
+        uuids = [str(uuid4()) for _ in range(500)]
+
+        with pytest.raises(requests.HTTPError):
+            client_profile.send_cache_invalidation("organization", uuids)
+
+        assert f"+{500 - UUID_LOG_SAMPLE} more" in caplog.text
+        assert uuids[UUID_LOG_SAMPLE] not in caplog.text
+
+    def test_timeout_is_connect_read_tuple(self, requests_mock):
+        """A stuck handshake must not pin a worker for the full read timeout"""
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+
+        client_profile.send_cache_invalidation("user", [str(uuid4())])
+
+        assert requests_mock.last_request.timeout == (5, 30)

--- a/squarelet/oidc/tests/test_models.py
+++ b/squarelet/oidc/tests/test_models.py
@@ -176,6 +176,53 @@ class TestSendCacheInvalidation:
         assert f"+{500 - UUID_LOG_SAMPLE} more" in caplog.text
         assert uuids[UUID_LOG_SAMPLE] not in caplog.text
 
+    def test_success_logs_webhook_url_and_id(self, requests_mock, caplog):
+        """A send names the endpoint it reached and the broadcast it belongs to
+
+        With several clients configured, the client name alone does not say
+        which URL a delivery went to after a webhook_url is changed.
+        """
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=200)
+
+        client_profile.send_cache_invalidation(
+            "user", [str(uuid4())], invalidation_id="abc12345"
+        )
+
+        assert f"url={client_profile.webhook_url}" in caplog.text
+        assert "id=abc12345" in caplog.text
+
+    def test_rejection_logs_webhook_url_and_id(self, requests_mock, caplog):
+        """A rejected delivery names the endpoint that rejected it"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(client_profile.webhook_url, status_code=502)
+
+        with pytest.raises(requests.HTTPError):
+            client_profile.send_cache_invalidation(
+                "user", [str(uuid4())], invalidation_id="abc12345"
+            )
+
+        assert f"url={client_profile.webhook_url}" in caplog.text
+        assert "id=abc12345" in caplog.text
+
+    def test_network_failure_logs_webhook_url_and_id(self, requests_mock, caplog):
+        """A network failure names the endpoint that could not be reached"""
+        caplog.set_level(logging.WARNING, logger="squarelet.oidc.models")
+        client_profile = ClientProfileFactory()
+        requests_mock.post(
+            client_profile.webhook_url, exc=requests.exceptions.ConnectTimeout
+        )
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            client_profile.send_cache_invalidation(
+                "user", [str(uuid4())], invalidation_id="abc12345"
+            )
+
+        assert f"url={client_profile.webhook_url}" in caplog.text
+        assert "id=abc12345" in caplog.text
+
     def test_timeout_is_connect_read_tuple(self, requests_mock):
         """A stuck handshake must not pin a worker for the full read timeout"""
         client_profile = ClientProfileFactory()

--- a/squarelet/oidc/tests/test_tasks.py
+++ b/squarelet/oidc/tests/test_tasks.py
@@ -2,7 +2,12 @@
 Tests for OIDC tasks
 """
 
+# send_cache_invalidation is a bind=True task, so calling it directly passes
+# `self` implicitly - pylint reads every call here as missing its first argument
+# pylint: disable=no-value-for-parameter
+
 # Django
+from celery.exceptions import Retry
 from django.utils import timezone
 
 # Standard Library
@@ -12,11 +17,18 @@ from uuid import uuid4
 
 # Third Party
 import pytest
+import requests
 from oidc_provider.models import UserConsent
 
 # Squarelet
 from squarelet.oidc.models import ClientProfile
-from squarelet.oidc.tasks import send_cache_invalidation
+from squarelet.oidc.tasks import (
+    MAX_RETRIES,
+    RETRY_BACKOFF,
+    RETRY_JITTER,
+    retry_countdown,
+    send_cache_invalidation,
+)
 from squarelet.oidc.tests.factories import ClientFactory, ClientProfileFactory
 from squarelet.organizations.tests.factories import (
     MembershipFactory,
@@ -566,3 +578,106 @@ class TestSendCacheInvalidationObservability:
         send_cache_invalidation(client_profile.pk, "user", [str(uuid4())])
 
         mock_send.assert_called_once()
+
+
+@pytest.mark.django_db()
+class TestSendCacheInvalidationRetries:
+    """Test that a failed delivery is retried before it is abandoned
+
+    A client restart or deploy used to drop every invalidation in flight, with
+    no reattempt and no error - the client's cache stayed stale until the next
+    write to the same record.
+    """
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            requests.exceptions.ConnectTimeout("unreachable"),
+            requests.exceptions.HTTPError("502 Bad Gateway"),
+        ],
+    )
+    def test_failed_delivery_is_retried(self, mocker, caplog, client_profile, exc):
+        """Both a network failure and a rejection schedule another attempt"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.tasks")
+        mocker.patch(
+            "squarelet.oidc.models.ClientProfile.send_cache_invalidation",
+            side_effect=exc,
+        )
+        mock_retry = mocker.patch.object(
+            send_cache_invalidation, "retry", side_effect=Retry
+        )
+
+        with pytest.raises(Retry):
+            send_cache_invalidation(client_profile.pk, "user", [str(uuid4())])
+
+        mock_retry.assert_called_once()
+        assert mock_retry.call_args.kwargs["exc"] is exc
+        assert mock_retry.call_args.kwargs["countdown"] >= RETRY_BACKOFF
+        assert "[CACHE-INVALIDATION] Retrying" in caplog.text
+        assert f"url={client_profile.webhook_url}" in caplog.text
+
+    def test_retries_exhausted_logs_one_error(self, mocker, caplog, client_profile):
+        """The last attempt reports the lost delivery exactly once
+
+        The model logs each attempt at warning level, so this error is the only
+        Sentry event for a broadcast that never landed.
+        """
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.tasks")
+        mocker.patch(
+            "squarelet.oidc.models.ClientProfile.send_cache_invalidation",
+            side_effect=requests.exceptions.HTTPError("502 Bad Gateway"),
+        )
+        mock_retry = mocker.patch.object(send_cache_invalidation, "retry")
+        uuids = [str(uuid4())]
+
+        result = send_cache_invalidation.apply(
+            args=(client_profile.pk, "user", uuids, "abc12345"),
+            retries=MAX_RETRIES,
+        )
+
+        # the task itself succeeds: a stale client cache is not worth a task
+        # left in a failed state, and the error above is the alarm
+        assert result.successful()
+        mock_retry.assert_not_called()
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "[CACHE-INVALIDATION] Giving up" in caplog.text
+        assert "id=abc12345" in caplog.text
+        assert f"url={client_profile.webhook_url}" in caplog.text
+        assert f"attempts={MAX_RETRIES + 1}" in caplog.text
+        assert uuids[0] in caplog.text
+        # exc_info is what carries the traceback into Sentry
+        assert errors[0].exc_info is not None
+
+    def test_successful_delivery_does_not_retry(self, mocker, client_profile):
+        """A delivered invalidation is not reattempted"""
+        mocker.patch("squarelet.oidc.models.ClientProfile.send_cache_invalidation")
+        mock_retry = mocker.patch.object(send_cache_invalidation, "retry")
+
+        send_cache_invalidation(client_profile.pk, "user", [str(uuid4())])
+
+        mock_retry.assert_not_called()
+
+    def test_non_request_errors_still_propagate(self, mocker, client_profile):
+        """A bug in the send path fails the task instead of being retried"""
+        mocker.patch(
+            "squarelet.oidc.models.ClientProfile.send_cache_invalidation",
+            side_effect=ValueError("bug"),
+        )
+        mock_retry = mocker.patch.object(send_cache_invalidation, "retry")
+
+        with pytest.raises(ValueError):
+            send_cache_invalidation(client_profile.pk, "user", [str(uuid4())])
+
+        mock_retry.assert_not_called()
+
+
+class TestRetryCountdown:
+    """Test the retry backoff schedule"""
+
+    def test_backoff_is_exponential_with_jitter(self):
+        """Each attempt waits longer, and clients do not see a thundering herd"""
+        for retries in range(MAX_RETRIES):
+            countdown = retry_countdown(retries)
+            assert 2**retries * RETRY_BACKOFF <= countdown
+            assert countdown <= 2**retries * RETRY_BACKOFF + RETRY_JITTER

--- a/squarelet/oidc/tests/test_tasks.py
+++ b/squarelet/oidc/tests/test_tasks.py
@@ -6,13 +6,16 @@ Tests for OIDC tasks
 from django.utils import timezone
 
 # Standard Library
+import logging
 from datetime import timedelta
+from uuid import uuid4
 
 # Third Party
 import pytest
 from oidc_provider.models import UserConsent
 
 # Squarelet
+from squarelet.oidc.models import ClientProfile
 from squarelet.oidc.tasks import send_cache_invalidation
 from squarelet.oidc.tests.factories import ClientFactory, ClientProfileFactory
 from squarelet.organizations.tests.factories import (
@@ -20,6 +23,16 @@ from squarelet.organizations.tests.factories import (
     OrganizationFactory,
 )
 from squarelet.users.tests.factories import UserFactory
+
+
+@pytest.fixture(name="client_profile")
+def client_profile_fixture():
+    """A client profile that sends unconditionally
+
+    require_consent defaults to True on oidc_provider.Client, which would
+    otherwise filter every uuid out before the send is attempted.
+    """
+    return ClientProfileFactory(client=ClientFactory(require_consent=False))
 
 
 @pytest.mark.django_db()
@@ -470,3 +483,86 @@ class TestSendCacheInvalidation:
 
         # Verify - function should not be called since org has no users
         mock_send.assert_not_called()
+
+
+@pytest.mark.django_db()
+class TestSendCacheInvalidationObservability:
+    """Test that every non-sending branch of the task leaves a trace"""
+
+    def test_missing_client_profile_still_propagates(self):
+        """A deleted client profile fails the task, as it did before"""
+        with pytest.raises(ClientProfile.DoesNotExist):
+            send_cache_invalidation(999999, "user", [str(uuid4())])
+
+    def test_consent_filtered_to_empty_logs_reason(self, caplog, mocker):
+        """A consent-filtered drop is distinguishable from a send"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.tasks")
+        client_profile = ClientProfileFactory(
+            client=ClientFactory(require_consent=True)
+        )
+        user = UserFactory()  # no consent granted
+        mock_send = mocker.patch(
+            "squarelet.oidc.models.ClientProfile.send_cache_invalidation"
+        )
+
+        send_cache_invalidation(
+            client_profile.pk, "user", [str(user.individual_organization_id)]
+        )
+
+        mock_send.assert_not_called()
+        assert "reason=consent-filtered" in caplog.text
+        assert "original_count=1" in caplog.text
+
+    def test_empty_input_logs_distinct_reason(self, caplog, mocker, client_profile):
+        """An empty uuid list from the caller is reported as such"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.tasks")
+        mocker.patch("squarelet.oidc.models.ClientProfile.send_cache_invalidation")
+
+        send_cache_invalidation(client_profile.pk, "user", [])
+
+        assert "reason=empty-input" in caplog.text
+
+    def test_partial_consent_reduction_logs_no_extra_line(self, caplog, mocker):
+        """A partial reduction sends the reduced list and stays quiet
+
+        The Dispatching and Sent lines already carry both counts under a shared
+        invalidation_id, so a third line per client per broadcast is wasted
+        log volume.
+        """
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.tasks")
+        client = ClientFactory(require_consent=True)
+        client_profile = ClientProfileFactory(client=client)
+        consenting = UserFactory()
+        UserConsent.objects.create(
+            user=consenting,
+            client=client,
+            expires_at=timezone.now() + timedelta(days=1),
+            date_given=timezone.now(),
+        )
+        other = UserFactory()
+        mock_send = mocker.patch(
+            "squarelet.oidc.models.ClientProfile.send_cache_invalidation"
+        )
+
+        send_cache_invalidation(
+            client_profile.pk,
+            "user",
+            [
+                str(consenting.individual_organization_id),
+                str(other.individual_organization_id),
+            ],
+        )
+
+        mock_send.assert_called_once()
+        assert mock_send.call_args[0][1] == [str(consenting.individual_organization_id)]
+        assert caplog.text == ""
+
+    def test_callable_without_invalidation_id(self, mocker, client_profile):
+        """Messages queued before deploy still deserialize"""
+        mock_send = mocker.patch(
+            "squarelet.oidc.models.ClientProfile.send_cache_invalidation"
+        )
+
+        send_cache_invalidation(client_profile.pk, "user", [str(uuid4())])
+
+        mock_send.assert_called_once()

--- a/squarelet/oidc/tests/test_tasks.py
+++ b/squarelet/oidc/tests/test_tasks.py
@@ -641,7 +641,7 @@ class TestSendCacheInvalidationRetries:
         mock_retry.assert_not_called()
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert len(errors) == 1
-        assert "[CACHE-INVALIDATION] Giving up" in caplog.text
+        assert "[CACHE-INVALIDATION] Retries exceeded, giving up!" in caplog.text
         assert "id=abc12345" in caplog.text
         assert f"url={client_profile.webhook_url}" in caplog.text
         assert f"attempts={MAX_RETRIES + 1}" in caplog.text

--- a/squarelet/oidc/tests/test_utils.py
+++ b/squarelet/oidc/tests/test_utils.py
@@ -1,0 +1,118 @@
+"""
+Tests for OIDC utils
+"""
+
+# Django
+from django.test import override_settings
+
+# Standard Library
+import logging
+from uuid import uuid4
+
+# Third Party
+import pytest
+
+# Squarelet
+from squarelet.oidc.models import UUID_LOG_SAMPLE, UUID_LOG_THRESHOLD
+from squarelet.oidc.tests.factories import ClientProfileFactory
+from squarelet.oidc.utils import send_cache_invalidations
+
+
+@pytest.mark.django_db()
+class TestSendCacheInvalidations:
+    """Test the fan-out of a cache invalidation broadcast to every client"""
+
+    @override_settings(ENABLE_SEND_CACHE_INVALIDATIONS=False)
+    def test_disabled_flag_logs_and_enqueues_nothing(self, caplog, mocker):
+        """The feature flag being off is no longer a silent no-op"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.utils")
+        ClientProfileFactory()
+        mock_delay = mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+
+        send_cache_invalidations("user", [str(uuid4())])
+
+        mock_delay.assert_not_called()
+        assert "Disabled by ENABLE_SEND_CACHE_INVALIDATIONS" in caplog.text
+
+    def test_no_clients_with_webhook_url_is_logged(self, caplog, mocker):
+        """A client set with no webhook URLs is a misconfiguration, not silence"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.utils")
+        ClientProfileFactory(webhook_url="")
+        mock_delay = mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+
+        send_cache_invalidations("user", [str(uuid4())])
+
+        mock_delay.assert_not_called()
+        assert "No client has a webhook_url configured" in caplog.text
+
+    def test_dispatch_logs_client_names_and_count(self, caplog, mocker):
+        """The dispatch line names every client it fanned out to"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.utils")
+        profiles = ClientProfileFactory.create_batch(2)
+        mock_delay = mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+
+        send_cache_invalidations("organization", [str(uuid4()), str(uuid4())])
+
+        assert mock_delay.call_count == 2
+        assert "Dispatching id=" in caplog.text
+        assert "count=2" in caplog.text
+        for profile in profiles:
+            assert profile.client.name in caplog.text
+
+    def test_all_clients_share_one_invalidation_id(self, mocker):
+        """One broadcast is greppable across every client's task"""
+        ClientProfileFactory.create_batch(3)
+        mock_delay = mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+
+        send_cache_invalidations("user", [str(uuid4())])
+
+        ids = {call.kwargs["invalidation_id"] for call in mock_delay.call_args_list}
+        assert len(ids) == 1
+        assert len(ids.pop()) == 8
+
+    def test_blank_webhook_url_is_excluded(self, mocker):
+        """Clients without a webhook URL are not dispatched to"""
+        configured = ClientProfileFactory()
+        ClientProfileFactory(webhook_url="")
+        mock_delay = mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+
+        send_cache_invalidations("user", [str(uuid4())])
+
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args[0][0] == configured.pk
+
+    def test_dispatch_logs_every_uuid(self, caplog, mocker):
+        """An interactive-sized broadcast names every uuid it dispatched"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.utils")
+        ClientProfileFactory()
+        mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+        uuids = [str(uuid4()) for _ in range(UUID_LOG_THRESHOLD)]
+
+        send_cache_invalidations("organization", uuids)
+
+        assert f"count={UUID_LOG_THRESHOLD}" in caplog.text
+        for uuid in uuids:
+            assert uuid in caplog.text
+
+    def test_bulk_dispatch_is_abbreviated(self, caplog, mocker):
+        """A bulk broadcast logs a sample and a remainder, not the full list"""
+        caplog.set_level(logging.INFO, logger="squarelet.oidc.utils")
+        ClientProfileFactory()
+        mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+        uuids = [str(uuid4()) for _ in range(500)]
+
+        send_cache_invalidations("organization", uuids)
+
+        assert "count=500" in caplog.text
+        assert f"+{500 - UUID_LOG_SAMPLE} more" in caplog.text
+        assert uuids[UUID_LOG_SAMPLE] not in caplog.text
+
+    def test_full_uuid_list_still_reaches_the_task(self, mocker):
+        """Abbreviating the log must not abbreviate what actually gets sent"""
+        ClientProfileFactory()
+        mock_delay = mocker.patch("squarelet.oidc.tasks.send_cache_invalidation.delay")
+        uuids = [str(uuid4()) for _ in range(500)]
+
+        send_cache_invalidations("organization", uuids)
+
+        assert mock_delay.call_args[0][2] == uuids

--- a/squarelet/oidc/utils.py
+++ b/squarelet/oidc/utils.py
@@ -6,20 +6,61 @@ from django.db.models.expressions import F
 
 # Standard Library
 import logging
+import uuid as uuid_lib
 
 # Local
 from . import tasks
-from .models import ClientProfile
+from .models import ClientProfile, format_uuids
 
 logger = logging.getLogger(__name__)
 
 
 def send_cache_invalidations(model, uuids):
     """Send a cache invalidation signal to all clients"""
-    if settings.ENABLE_SEND_CACHE_INVALIDATIONS:
-        logger.info("Sending cache invalidations for: %s %s", model, uuids)
-        for client_profile in ClientProfile.objects.exclude(webhook_url=""):
-            tasks.send_cache_invalidation.delay(client_profile.pk, model, uuids)
+    uuids = list(uuids)
+    formatted_uuids = format_uuids(uuids)
+
+    if not settings.ENABLE_SEND_CACHE_INVALIDATIONS:
+        # the standing alarm for this being off in production is a single
+        # warning at startup, in OidcConfig.ready
+        logger.info(
+            "[CACHE-INVALIDATION] Disabled by ENABLE_SEND_CACHE_INVALIDATIONS - "
+            "dropping model=%s count=%d uuids=%s",
+            model,
+            len(uuids),
+            formatted_uuids,
+        )
+        return
+
+    client_profiles = list(
+        ClientProfile.objects.exclude(webhook_url="").select_related("client")
+    )
+    if not client_profiles:
+        logger.info(
+            "[CACHE-INVALIDATION] No client has a webhook_url configured - "
+            "dropping model=%s count=%d",
+            model,
+            len(uuids),
+        )
+        return
+
+    # short correlation id so one logical broadcast is greppable across the fan-out
+    invalidation_id = uuid_lib.uuid4().hex[:8]
+    logger.info(
+        "[CACHE-INVALIDATION] Dispatching id=%s model=%s count=%d clients=%s "
+        "uuids=%s",
+        invalidation_id,
+        model,
+        len(uuids),
+        [cp.client.name for cp in client_profiles],
+        formatted_uuids,
+    )
+    for client_profile in client_profiles:
+        # keyword argument with a default so messages already queued in Redis at
+        # deploy time still deserialize
+        tasks.send_cache_invalidation.delay(
+            client_profile.pk, model, uuids, invalidation_id=invalidation_id
+        )
 
 
 def oidc_login_hook(request, user, client):


### PR DESCRIPTION
- Adds a custom logger for `squarelet.oidc` to capture INFO in addition to WARNING and ERROR
- Raises errors when webhook tasks return 4xx or 5xx responses.
- Logs when client consent filters lead to no-op cache invalidation