### PR TITLE
Fix inefficient SQL queries in fe_api/organizations 

### DIFF
--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -31,19 +31,14 @@ class OrganizationQuerySet(models.QuerySet):
             # or they can auto join that org
             # and they can only see public organizations that are visible
             # (verified or have charges or paid invoices)
+            auto_join_org_pks = user.get_potential_organizations().values("pk")
             viewable_filter = (
                 Q(private=False, verified_journalist=True)
                 | Q(private=False, charges__isnull=False)
                 | Q(private=False, invoices__status="paid")
                 | Q(users=user)
+                | Q(pk__in=auto_join_org_pks)
             )
-
-            # Include auto-join orgs (pre-approved) in the same filter
-            if hasattr(user, "can_auto_join"):
-                auto_join_pks = [org.pk for org in qs if user.can_auto_join(org)]
-                if auto_join_pks:
-                    viewable_filter |= Q(pk__in=auto_join_pks)
-
             return qs.filter(viewable_filter).distinct()
         else:
             return qs.filter(

--- a/squarelet/organizations/tests/test_querysets.py
+++ b/squarelet/organizations/tests/test_querysets.py
@@ -233,6 +233,19 @@ class TestOrganizationQuerySet(TestCase):
         assert isinstance(org, Organization)
         assert org == user.individual_organization
 
+    @pytest.mark.django_db
+    def test_get_viewable_query_count_is_constant(self):
+        """Auto-join orgs resolve via subquery, not a per-org loop."""
+        user = UserFactory()
+        user.emailaddress_set.create(email="reporter@example-news.org", verified=True)
+
+        for _ in range(5):
+            org = OrganizationFactory(private=False, allow_auto_join=True)
+            org.domains.create(domain="example-news.org")
+
+        with self.assertNumQueries(2):
+            list(Organization.objects.get_viewable(user))
+
 
 class TestFuzzySearch(TestCase):
     """Unit tests for Organization.objects.fuzzy_search()"""


### PR DESCRIPTION
Related Sentry error:
https://muckrock.sentry.io/issues/7273932599/?project=1422309&query=is%3Aunresolved&referrer=issue-stream

Started 6 months ago, which I now believe is related to [my own commit](https://github.com/MuckRock/squarelet/commit/f0ba70407cb42df6b600e6a18e928dbace05a1d6) to add back potential orgs a user can join back into the get_viewable in a rush after we released organization search. This is a big contributor to #654 which has since been closed. 

**What this did before:** 
qs is all orgs. For staff, we just return that and don't do any further stuff to the queryset. So when we test something on a staff account we don't notice any performance issues in org search. For non-staff, it ran the can_auto_join check along the entire queryset which checks if the org has auto join enabled and if the org is in the list of potential orgs: https://github.com/MuckRock/squarelet/blob/23470837fdc8f9219b166bd2a5a336610e9b8e21/squarelet/users/models.py#L287
This doesn't scale with the size of the queryset. can_auto_join is a permissions level guard when you're looking at a singular org to determine whether that user should be able to join it automatically. 

**What this does now:**
get_potential_organizations already does the necessary filter to give us the set of orgs that allow_auto_join and are available to the user. All we need to do is pass those orgs to the viewable filter. This passes the orgs as a sub-query of primary keys to the viewable filter so we don't have to hold all the orgs in memory. This should also be a lot more readable. 

I verified this in the shell against a non-staff user with a confirmed email address and some test orgs with auto join enabled and some domains set. The endpoint's number of SQL queries drop from 10 queries to 2. 