### PR TITLE
Clear payment_failed when an organization's last subscription is cancelled

### DIFF
--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -733,9 +733,28 @@ class Organization(AvatarMixin, models.Model):
         # Delete local subscription record
         subscription.delete()
 
+        # They are back on the free plan - stop asking for payment details
+        self.clear_payment_failed_if_unsubscribed("subscription cancelled")
         # Remove Wix labels now that subscription is gone
         if cancelled_plan:
             self._dispatch_wix_unsync(cancelled_plan)
+
+    def clear_payment_failed_if_unsubscribed(self, reason):
+        """Clear the payment failure flag once no subscription is left
+
+        The flag asks the admins to update their payment information, which is
+        only worth asking while a paid plan is at stake. Once the last
+        subscription is gone they are back on the free plan with nothing left to
+        fix, so the prompt would follow them on every log in until somebody
+        cleared it by hand.
+        """
+        if not self.payment_failed or self.subscriptions.exists():
+            return
+        self.payment_failed = False
+        self.save()
+        logger.info(
+            "Cleared payment_failed flag for organization %s (%s)", self.uuid, reason
+        )
 
     def has_active_subscription(self, plan=None):
         """Check if the organization has an active subscription"""

--- a/squarelet/organizations/tasks.py
+++ b/squarelet/organizations/tasks.py
@@ -440,9 +440,14 @@ def handle_customer_updated(customer_data):
 def _reconcile_cancelled_subscription(subscription, reason):
     """Delete a locally-tracked subscription that Stripe has ended and
     invalidate the organization's entitlement cache."""
-    organization_uuid = subscription.organization.uuid
+    organization = subscription.organization
+    organization_uuid = organization.uuid
     subscription_id = subscription.subscription_id
     subscription.delete()
+    # The org is back on the free plan, so stop asking for payment details
+    organization.clear_payment_failed_if_unsubscribed(
+        f"subscription reconciled: {reason}"
+    )
     send_cache_invalidations("organization", [organization_uuid])
     logger.info(
         "[STRIPE-WEBHOOK-SUBSCRIPTION] Reconciled cancelled subscription %s (%s); "

--- a/squarelet/organizations/tests/models/test_organization.py
+++ b/squarelet/organizations/tests/models/test_organization.py
@@ -597,6 +597,70 @@ class TestOrganization:
 
         mock_unsync.assert_not_called()
 
+    @pytest.mark.django_db
+    def test_subscription_cancelled_clears_payment_failed(
+        self,
+        organization_factory,
+        mocker,
+        professional_plan_factory,
+        subscription_factory,
+    ):
+        """Cancelling the last subscription clears the payment failure prompt"""
+        mocker.patch("stripe.Plan.create")
+        plan = professional_plan_factory()
+        organization = organization_factory(payment_failed=True)
+        sub = subscription_factory(
+            organization=organization, plan=plan, subscription_id=None
+        )
+
+        organization.subscription_cancelled(subscription=sub)
+
+        organization.refresh_from_db()
+        assert not organization.subscriptions.exists()
+        assert organization.payment_failed is False
+
+    @pytest.mark.django_db
+    def test_subscription_cancelled_keeps_payment_failed_if_still_subscribed(
+        self,
+        organization_factory,
+        mocker,
+        professional_plan_factory,
+        plan_factory,
+        subscription_factory,
+    ):
+        """Another paid plan still needs paying for, so keep prompting"""
+        mocker.patch("stripe.Plan.create")
+        organization = organization_factory(payment_failed=True)
+        cancelled_sub = subscription_factory(
+            organization=organization,
+            plan=professional_plan_factory(),
+            subscription_id=None,
+        )
+        subscription_factory(
+            organization=organization,
+            plan=plan_factory(slug="other-plan"),
+            subscription_id=None,
+        )
+
+        organization.subscription_cancelled(subscription=cancelled_sub)
+
+        organization.refresh_from_db()
+        assert organization.subscriptions.count() == 1
+        assert organization.payment_failed is True
+
+    @pytest.mark.django_db
+    def test_clear_payment_failed_if_unsubscribed_without_flag(
+        self, organization_factory, mocker
+    ):
+        """An organization that never failed a payment is left untouched"""
+        organization = organization_factory(payment_failed=False)
+        mock_save = mocker.patch.object(Organization, "save")
+
+        organization.clear_payment_failed_if_unsubscribed("test")
+
+        assert organization.payment_failed is False
+        mock_save.assert_not_called()
+
     @pytest.mark.django_db(transaction=True)
     def test_modify_subscription_changes_plan(
         self, organization_factory, user_factory, plan_factory

--- a/squarelet/organizations/tests/test_tasks.py
+++ b/squarelet/organizations/tests/test_tasks.py
@@ -2279,6 +2279,24 @@ class TestHandleSubscriptionUpdated:
         patched.assert_called_once_with("organization", [org_uuid])
 
     @pytest.mark.django_db
+    def test_canceled_status_clears_payment_failed(
+        self, organization_factory, subscription_factory, mocker
+    ):
+        """Reconciling the last subscription clears the payment failure prompt"""
+        mocker.patch("squarelet.organizations.tasks.send_cache_invalidations")
+        organization = organization_factory(payment_failed=True)
+        subscription_factory(
+            organization=organization, subscription_id="sub_upd_cancel_flag"
+        )
+
+        tasks.handle_subscription_updated(
+            {"id": "sub_upd_cancel_flag", "status": "canceled"}
+        )
+
+        organization.refresh_from_db()
+        assert organization.payment_failed is False
+
+    @pytest.mark.django_db
     def test_unknown_subscription(self, mocker):
         """Logs a warning and returns gracefully for unknown subscription"""
         mock_logger = mocker.patch("squarelet.organizations.tasks.logger")


### PR DESCRIPTION
This PR proposes clearing an organization's `payment_failed` flag once its last subscription is cancelled, so admins stop being prompted to update payment details for a plan they no longer have (Fixes #540). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/243. You can sign in with your GitHub ID to claim ownership of the project.

### The defect

`payment_failed` is set when Stripe reports a failed invoice, and it is cleared in only two places: `Organization.save_card` and `handle_invoice_paid`. Neither happens once the plan itself is gone. On the fourth failed attempt `handle_invoice_failed` calls `Organization.subscription_cancelled`, which deletes the local `Subscription` record and leaves `payment_failed` set to `True`; `_reconcile_cancelled_subscription` does the same when Stripe reports the cancellation from the other direction (`customer.subscription.updated` with a terminal status, or `customer.subscription.deleted`). The organization is back on the free plan with no invoice left to pay, so nothing will ever clear the flag, and the prompt follows the user on every log in until someone edits the record in the admin by hand — the manual workaround described in #540.

### Reproducing it on master

At `c89f574` I added a temporary test asserting the flag is cleared once no subscription remains, and ran it against both cancellation paths:

```
E       AssertionError: org has no paid subscription left but is still flagged payment_failed
E       assert True is False
E        +  where True = <Organization: org-0>.payment_failed
...
INFO tasks [STRIPE-WEBHOOK-SUBSCRIPTION] Reconciled cancelled subscription sub_x (status=canceled);
     deleted local record and invalidated cache for org b01fefc8-0a08-423b-955a-1192067d88d3
2 failed
```

Both paths delete the subscription and leave the flag set.

### The change

`Organization.clear_payment_failed_if_unsubscribed(reason)` clears the flag only when the organization has no subscriptions left, and is called from `subscription_cancelled` and from `_reconcile_cancelled_subscription` right after the local record is deleted. An organization that still holds another paid subscription keeps the flag, because that prompt is still worth showing. The method is a no-op when the flag was never set, so no extra writes and no extra cache invalidations happen on the common path; clearing it goes through `Organization.save()`, which already invalidates the org cache so the clients pick up the new value.

Four tests cover it: the two cancellation paths clearing the flag, an organization with a second subscription keeping it, and the unflagged no-op. Reverting just the two call sites (leaving the new method in place) turns the first and last of those red while the two control tests stay green.

### Verification

Run against the CI harness in `.github/workflows/test.yml` (Postgres service, `pytest squarelet`), before and after the change:

```
before:  1392 passed
after:   1396 passed        # the 4 new tests, no new failures
```

`black --check squarelet --exclude migrations`, `isort --check-only`, and `pylint` on the changed modules are all clean (`organization.py` stays under the 1000-line limit at 999).

### How this was managed

This work was tracked as [a story on our board](https://eastagiletracker.com/projects/243/stories/129751), on [a board imported from this repository's issues and pull requests](https://eastagiletracker.com/projects/243) — 618 stories and 20 labels, with #540 among them as the story above.

![board](https://raw.githubusercontent.com/eastagiletracker/squarelet/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
