### PR TITLE
backfill subscriptions onto plan prices

### DIFF
--- a/squarelet/organizations/management/commands/backfill_plan_prices.py
+++ b/squarelet/organizations/management/commands/backfill_plan_prices.py
@@ -212,17 +212,7 @@ class Command(BaseCommand):
                 "consolidate_stripe_products first: " + str(sorted(missing))
             )
 
-        # Several legacy plans collapse onto one canonical plan, so an
-        # organization holding two of them would violate
-        # Subscription.unique_together ("organization", "plan") mid-loop and
-        # abort the transaction.  Report it up front instead.
-        seen = collections.defaultdict(list)
-        for sub in pending:
-            key = (sub.plan.slug, is_billing(sub))
-            if key not in LEGACY_PLAN_MAP:
-                continue
-            seen[(sub.organization_id, LEGACY_PLAN_MAP[key][0])].append(sub.plan.slug)
-        collisions = {k: v for k, v in seen.items() if len(v) > 1}
+        collisions = self._collisions(pending)
         if collisions:
             raise CommandError(
                 "These organizations hold several subscriptions that would "
@@ -231,6 +221,40 @@ class Command(BaseCommand):
                     {f"org {org} -> {plan}": v for (org, plan), v in collisions.items()}
                 )
             )
+
+    def _collisions(self, pending):
+        """Organizations that would end up with two subscriptions to one plan.
+
+        Several legacy plans collapse onto a single canonical one, and
+        Subscription is unique on (organization, plan), so this has to be
+        caught before anything is written - otherwise the transaction aborts
+        half way through on a bare IntegrityError.
+        """
+        seen = collections.defaultdict(list)
+        for sub in pending:
+            key = (sub.plan.slug, is_billing(sub))
+            if key not in LEGACY_PLAN_MAP:
+                continue
+            seen[(sub.organization_id, LEGACY_PLAN_MAP[key][0])].append(sub.plan.slug)
+        if not seen:
+            return {}
+
+        # A subscription this step leaves alone still occupies
+        # (organization, plan), so a pending row landing on its canonical
+        # plan collides with it just as surely as with another pending row.
+        held = (
+            Subscription.objects.exclude(pk__in={sub.pk for sub in pending})
+            .filter(
+                organization_id__in={org for org, _ in seen},
+                plan__slug__in={slug for _, slug in seen},
+            )
+            .values_list("organization_id", "plan__slug")
+        )
+        for org_id, slug in held:
+            if (org_id, slug) in seen:
+                seen[(org_id, slug)].append(f"{slug} (already held)")
+
+        return {k: v for k, v in seen.items() if len(v) > 1}
 
     def _migrate(self, sub, actor, dry_run):
         if sub.plan.slug in DEFERRED_SLUGS:

--- a/squarelet/organizations/management/commands/backfill_plan_prices.py
+++ b/squarelet/organizations/management/commands/backfill_plan_prices.py
@@ -20,8 +20,9 @@ logger = logging.getLogger(__name__)
 # comped price for those.  `is_billing` - whether a Stripe subscription
 # exists - is what separates them.
 #
-# Derived from the plan-mapping document; see it for why each target was
-# chosen.  Values are (canonical slug, interval, label, code).
+# Every target was chosen against the legacy plan it replaces so that no
+# subscriber's bill changes.  Values are (canonical slug, interval, label,
+# code).
 LEGACY_PLAN_MAP = {
     # MuckRock Professional
     ("professional", True): ("professional", "monthly", "standard", ""),
@@ -63,7 +64,7 @@ LEGACY_PLAN_MAP = {
 }
 
 # Deliberately left alone.  Each needs a decision or an action outside this
-# migration; see the plan-mapping and reconciliation documents.
+# command, given per entry below.
 DEFERRED_SLUGS = {
     # Pays $0 by manual invoice for 200 blocks; needs a conversation before
     # anyone moves them onto a real price.
@@ -94,10 +95,9 @@ class Command(BaseCommand):
     so there is no PlanPrice to look up via the old plan.
 
     Subscriptions still billing on a per-user plan are **not** touched.  They
-    need splitting into a base subscription plus usage packs, which changes
-    what Stripe charges and therefore happens per subscriber at renewal - see
-    the Migration Path section of the plan.  Everything else is a local
-    pointer update that changes nobody's bill.
+    need decomposing into a base plan plus a usage pack, which changes what
+    Stripe charges and so is a separate, deliberate step.  Everything this
+    command does is a local pointer update that changes nobody's bill.
 
     Run `consolidate_stripe_products` first; this needs the PlanPrice rows to
     exist.
@@ -164,7 +164,7 @@ class Command(BaseCommand):
         """Subscriptions this step handles.
 
         Everything except those still billing on a per-user plan, which the
-        renewal-time split handles instead.
+        per-user decomposition handles instead.
         """
         return list(
             Subscription.objects.select_related("organization", "plan")
@@ -177,8 +177,9 @@ class Command(BaseCommand):
         """Refuse to write anything unless every case is accounted for.
 
         Deliberately no log-and-skip fallback.  A silent skip leaves
-        `plan_price` null, which fails step 3c later and much less legibly
-        than stopping here.
+        `plan_price` null, which surfaces much later and much less legibly
+        - as a failure to make the column non-null, long after the run that
+        caused it.
         """
         unmapped = {
             (sub.plan.slug, is_billing(sub))
@@ -304,6 +305,6 @@ class Command(BaseCommand):
             .count()
         )
         self.stdout.write(
-            f"still without a plan_price: {per_user} awaiting their "
-            f"renewal-time split, {deferred} deferred by choice"
+            f"still without a plan_price: {per_user} awaiting the per-user "
+            f"decomposition, {deferred} deferred by choice"
         )

--- a/squarelet/organizations/management/commands/backfill_plan_prices.py
+++ b/squarelet/organizations/management/commands/backfill_plan_prices.py
@@ -66,9 +66,6 @@ LEGACY_PLAN_MAP = {
 # Deliberately left alone.  Each needs a decision or an action outside this
 # command, given per entry below.
 DEFERRED_SLUGS = {
-    # Pays $0 by manual invoice for 200 blocks; needs a conversation before
-    # anyone moves them onto a real price.
-    "organization-flexible-users-annual",
     # Two organizations going opposite ways - one cancelled, one comped - so
     # the slug alone cannot decide.
     "custom-crp",

--- a/squarelet/organizations/management/commands/backfill_plan_prices.py
+++ b/squarelet/organizations/management/commands/backfill_plan_prices.py
@@ -1,0 +1,285 @@
+# Django
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+# Standard Library
+import collections
+import logging
+
+# Squarelet
+from squarelet.organizations.models.payment import PlanPrice, Subscription
+
+logger = logging.getLogger(__name__)
+
+# Where each legacy plan's subscriptions land, keyed on the legacy slug and
+# whether the subscription is actually billing.
+#
+# The slug alone is not enough.  Admins granted free access for years by
+# putting organizations on a paid plan without a Stripe subscription, so
+# `organization` means the standard price for its paying subscribers and the
+# comped price for those.  `is_billing` - whether a Stripe subscription
+# exists - is what separates them.
+#
+# Derived from the plan-mapping document; see it for why each target was
+# chosen.  Values are (canonical slug, interval, label, code).
+LEGACY_PLAN_MAP = {
+    # MuckRock Professional
+    ("professional", True): ("professional", "monthly", "standard", ""),
+    ("professional", False): ("professional", "monthly", "comped", ""),
+    ("professional-pre-paid", True): ("professional", "annual", "standard", ""),
+    # Beta - early users grandfathered onto a free plan, not a distinct tier
+    ("beta", False): ("professional", "monthly", "comped", ""),
+    ("beta", True): ("professional", "monthly", "comped", ""),
+    # MuckRock Organization
+    ("organization", False): ("organization", "monthly", "comped", ""),
+    # Comped organizations, previously each with their own plan
+    ("muckrock-editorial-partner", False): (
+        "organization",
+        "monthly",
+        "comped",
+        "",
+    ),
+    ("premium-org-comp", False): ("organization", "monthly", "comped", ""),
+    ("education-grant", False): ("organization", "monthly", "comped", ""),
+    ("startsmall-grants", False): ("organization", "monthly", "comped", ""),
+    ("education-plan", False): ("organization", "monthly", "comped", ""),
+    # A negotiated rate, so a price of its own rather than a coupon
+    ("insideclimate-news-plan", True): (
+        "organization",
+        "monthly",
+        "standard",
+        "insideclimate",
+    ),
+    # Sunlight
+    ("sunlight-enterprise-rnn", False): (
+        "sunlight-enterprise",
+        "annual",
+        "comped",
+        "",
+    ),
+    # Admin keeps its own plan - the only one granting staff access across
+    # all three products - and simply gains a comped price.
+    ("admin", False): ("admin", "monthly", "comped", ""),
+}
+
+# Deliberately left alone.  Each needs a decision or an action outside this
+# migration; see the plan-mapping and reconciliation documents.
+DEFERRED_SLUGS = {
+    # Pays $0 by manual invoice for 200 blocks; needs a conversation before
+    # anyone moves them onto a real price.
+    "organization-flexible-users-annual",
+    # Two organizations going opposite ways - one cancelled, one comped - so
+    # the slug alone cannot decide.
+    "custom-crp",
+    # Its one subscription belongs to an organization that was merged away.
+    "sunlight-premium-annual",
+}
+
+
+def is_billing(subscription):
+    """Whether Stripe is charging for this subscription.
+
+    Presence of a subscription id is the signal.  Rows pointing at a
+    cancelled Stripe subscription would confuse this, which is why the
+    Stripe reconciliation is a prerequisite - it drove those to zero.
+    """
+    return bool(subscription.subscription_id)
+
+
+class Command(BaseCommand):
+    """Point existing subscriptions at their new PlanPrice.
+
+    Sets `plan_price` and repoints `plan` to the canonical tier, in one
+    operation: several legacy plans consolidate onto a single canonical row,
+    so there is no PlanPrice to look up via the old plan.
+
+    Subscriptions still billing on a per-user plan are **not** touched.  They
+    need splitting into a base subscription plus usage packs, which changes
+    what Stripe charges and therefore happens per subscriber at renewal - see
+    the Migration Path section of the plan.  Everything else is a local
+    pointer update that changes nobody's bill.
+
+    Run `consolidate_stripe_products` first; this needs the PlanPrice rows to
+    exist.
+    """
+
+    help = "Point existing subscriptions at their new PlanPrice"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything",
+        )
+        parser.add_argument(
+            "--actor",
+            help=(
+                "Username recorded as granted_by on migrated comped "
+                "subscriptions.  Required unless --dry-run."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN - nothing written"))
+
+        actor = self._resolve_actor(options["actor"], dry_run)
+        pending = self._pending()
+        self._preflight(pending)
+
+        counts = collections.Counter()
+        with transaction.atomic():
+            for sub in pending:
+                counts[self._migrate(sub, actor, dry_run)] += 1
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self.stdout.write(
+            f"\n{counts['migrated']} migrated, {counts['deferred']} deferred"
+        )
+        self._report_remaining()
+
+    def _resolve_actor(self, username, dry_run):
+        # Imported here rather than at module scope: get_user_model() must
+        # not run before the app registry is ready.
+        # pylint: disable=import-outside-toplevel
+        # Django
+        from django.contrib.auth import get_user_model
+
+        if not username:
+            if dry_run:
+                return None
+            raise CommandError(
+                "--actor is required: migrated comped subscriptions record "
+                "who authorized them."
+            )
+        user_model = get_user_model()
+        try:
+            return user_model.objects.get(username=username)
+        except user_model.DoesNotExist as exc:
+            raise CommandError(f"No such user: {username}") from exc
+
+    def _pending(self):
+        """Subscriptions this step handles.
+
+        Everything except those still billing on a per-user plan, which the
+        renewal-time split handles instead.
+        """
+        return list(
+            Subscription.objects.select_related("organization", "plan")
+            .filter(plan_price__isnull=True)
+            .exclude(plan__price_per_user__gt=0, subscription_id__isnull=False)
+            .order_by("plan__slug", "pk")
+        )
+
+    def _preflight(self, pending):
+        """Refuse to write anything unless every case is accounted for.
+
+        Deliberately no log-and-skip fallback.  A silent skip leaves
+        `plan_price` null, which fails step 3c later and much less legibly
+        than stopping here.
+        """
+        unmapped = {
+            (sub.plan.slug, is_billing(sub))
+            for sub in pending
+            if sub.plan.slug not in DEFERRED_SLUGS
+            and (sub.plan.slug, is_billing(sub)) not in LEGACY_PLAN_MAP
+        }
+        if unmapped:
+            raise CommandError(
+                "No mapping for: "
+                + ", ".join(
+                    f"{slug} (billing={billing})" for slug, billing in sorted(unmapped)
+                )
+                + ".  Add them to LEGACY_PLAN_MAP or DEFERRED_SLUGS."
+            )
+
+        missing = set()
+        for target in LEGACY_PLAN_MAP.values():
+            slug, interval, label, code = target
+            if not PlanPrice.objects.filter(
+                plan__slug=slug,
+                interval=interval,
+                label=label,
+                code=code,
+                active=True,
+            ).exists():
+                missing.add(target)
+        if missing:
+            raise CommandError(
+                "These target prices do not exist - run "
+                "consolidate_stripe_products first: " + str(sorted(missing))
+            )
+
+        # Several legacy plans collapse onto one canonical plan, so an
+        # organization holding two of them would violate
+        # Subscription.unique_together ("organization", "plan") mid-loop and
+        # abort the transaction.  Report it up front instead.
+        seen = collections.defaultdict(list)
+        for sub in pending:
+            key = (sub.plan.slug, is_billing(sub))
+            if key not in LEGACY_PLAN_MAP:
+                continue
+            seen[(sub.organization_id, LEGACY_PLAN_MAP[key][0])].append(sub.plan.slug)
+        collisions = {k: v for k, v in seen.items() if len(v) > 1}
+        if collisions:
+            raise CommandError(
+                "These organizations hold several subscriptions that would "
+                "collapse onto one plan; resolve by hand first: "
+                + str(
+                    {f"org {org} -> {plan}": v for (org, plan), v in collisions.items()}
+                )
+            )
+
+    def _migrate(self, sub, actor, dry_run):
+        if sub.plan.slug in DEFERRED_SLUGS:
+            self.stdout.write(f"  ~ {sub.organization.slug}: {sub.plan.slug} deferred")
+            return "deferred"
+
+        slug, interval, label, code = LEGACY_PLAN_MAP[(sub.plan.slug, is_billing(sub))]
+        plan_price = PlanPrice.objects.select_related("plan").get(
+            plan__slug=slug,
+            interval=interval,
+            label=label,
+            code=code,
+            active=True,
+        )
+
+        legacy_name = sub.plan.name  # captured before repointing
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"  + {sub.organization.slug}: {sub.plan.slug} -> {plan_price}"
+            )
+        )
+        if dry_run:
+            return "migrated"
+
+        sub.plan = plan_price.plan
+        sub.plan_price = plan_price
+        fields = ["plan", "plan_price"]
+        if label == "comped":
+            # Migrated comps carry the same provenance the admin path
+            # requires, so "why is this organization free" stays answerable.
+            sub.granted_reason = f"Migrated from legacy {legacy_name} plan"
+            sub.granted_by = actor
+            fields += ["granted_reason", "granted_by"]
+        sub.save(update_fields=fields)
+        return "migrated"
+
+    def _report_remaining(self):
+        """What is left, and why - so a non-zero count is not alarming."""
+        per_user = (
+            Subscription.objects.filter(plan_price__isnull=True)
+            .filter(plan__price_per_user__gt=0, subscription_id__isnull=False)
+            .count()
+        )
+        deferred = (
+            Subscription.objects.filter(plan_price__isnull=True)
+            .filter(plan__slug__in=DEFERRED_SLUGS)
+            .count()
+        )
+        self.stdout.write(
+            f"still without a plan_price: {per_user} awaiting their "
+            f"renewal-time split, {deferred} deferred by choice"
+        )

--- a/squarelet/organizations/tests/test_backfill_plan_prices.py
+++ b/squarelet/organizations/tests/test_backfill_plan_prices.py
@@ -246,3 +246,50 @@ class TestDryRun:
         run(dry_run=True)
 
         assert Subscription.objects.filter(plan_price__isnull=False).count() == 0
+
+
+@pytest.mark.django_db()
+class TestCollisionWithARowItLeavesAlone:
+    """A collision does not have to be between two pending rows.
+
+    A per-user subscriber still billing is excluded from this step, but it
+    still occupies (organization, plan).  A legacy comp for the same
+    organization that maps onto that same canonical plan collides with it,
+    and must be reported up front rather than aborting the write half way
+    through with a bare IntegrityError.
+    """
+
+    @pytest.mark.usefixtures("targets")
+    def test_collision_with_an_excluded_subscription_is_reported(self):
+        actor = UserFactory()
+        org = OrganizationFactory()
+        SubscriptionFactory(
+            organization=org,
+            plan=legacy("organization", price_per_user=10),
+            subscription_id="sub_live",
+        )
+        SubscriptionFactory(
+            organization=org,
+            plan=legacy("premium-org-comp"),
+            subscription_id=None,
+        )
+
+        with pytest.raises(CommandError, match="collapse onto one plan"):
+            run(actor=actor.username)
+
+    @pytest.mark.usefixtures("targets")
+    def test_an_unrelated_existing_subscription_is_not_a_collision(self):
+        """Different organization, same canonical plan - no conflict."""
+        actor = UserFactory()
+        SubscriptionFactory(
+            plan=legacy("organization", price_per_user=10),
+            subscription_id="sub_live",
+        )
+        migrating = SubscriptionFactory(
+            plan=legacy("premium-org-comp"), subscription_id=None
+        )
+
+        run(actor=actor.username)
+
+        migrating.refresh_from_db()
+        assert migrating.plan_price is not None

--- a/squarelet/organizations/tests/test_backfill_plan_prices.py
+++ b/squarelet/organizations/tests/test_backfill_plan_prices.py
@@ -1,0 +1,248 @@
+# Django
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+# Standard Library
+from io import StringIO
+
+# Third Party
+import pytest
+
+# Squarelet
+from squarelet.organizations.management.commands.backfill_plan_prices import (
+    DEFERRED_SLUGS,
+    LEGACY_PLAN_MAP,
+)
+from squarelet.organizations.models import Plan, Subscription
+from squarelet.organizations.tests.factories import (
+    OrganizationFactory,
+    PlanFactory,
+    PlanPriceFactory,
+    SubscriptionFactory,
+)
+from squarelet.users.tests.factories import UserFactory
+
+
+@pytest.fixture(name="targets")
+def targets_fixture(db):  # pylint: disable=unused-argument
+    """Every PlanPrice the map points at.
+
+    _preflight refuses to run unless all of them exist, so this builds the
+    whole target set rather than just the ones a given test uses.  Derived
+    from LEGACY_PLAN_MAP so it cannot drift from it.
+    """
+    plans = {}
+    for slug, interval, label, code in set(LEGACY_PLAN_MAP.values()):
+        if slug not in plans:
+            plans[slug] = PlanFactory(name=f"Canonical {slug}", slug=slug)
+        PlanPriceFactory(
+            plan=plans[slug],
+            interval=interval,
+            label=label,
+            code=code,
+            amount=0 if label == "comped" else 10_000,
+        )
+    return plans
+
+
+def legacy(slug, **kwargs):
+    """A legacy plan under its real slug.
+
+    Several legacy slugs are also canonical ones - `professional` maps to
+    itself - so reuse the row the targets fixture already made rather than
+    letting AutoSlugField uniquify a duplicate into `professional-2`.
+    """
+    existing = Plan.objects.filter(slug=slug).first()
+    if existing is not None:
+        for field, value in kwargs.items():
+            setattr(existing, field, value)
+        if kwargs:
+            existing.save()
+        return existing
+    return PlanFactory(name=f"Legacy {slug}", slug=slug, **kwargs)
+
+
+def run(**kwargs):
+    out = StringIO()
+    call_command("backfill_plan_prices", stdout=out, **kwargs)
+    return out.getvalue()
+
+
+@pytest.mark.django_db()
+class TestBillingDecidesTheLabel:
+    """is_billing is what separates a paying subscriber from a comped one."""
+
+    def test_billing_subscription_gets_the_standard_price(self, targets):
+        actor = UserFactory()
+        sub = SubscriptionFactory(
+            plan=legacy("professional"), subscription_id="sub_live"
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price.label == "standard"
+        assert sub.plan == targets["professional"]
+
+    @pytest.mark.usefixtures("targets")
+    def test_non_billing_subscription_gets_the_comped_price(self):
+        """Years of admin-granted free access live on plans that look paid."""
+        actor = UserFactory()
+        sub = SubscriptionFactory(plan=legacy("professional"), subscription_id=None)
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price.label == "comped"
+
+    @pytest.mark.usefixtures("targets")
+    def test_comped_migration_records_who_authorized_it(self):
+        actor = UserFactory()
+        sub = SubscriptionFactory(plan=legacy("beta"), subscription_id=None)
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.granted_by == actor
+        assert "beta" in sub.granted_reason.lower()
+
+    @pytest.mark.usefixtures("targets")
+    def test_standard_migration_records_no_provenance(self):
+        actor = UserFactory()
+        sub = SubscriptionFactory(
+            plan=legacy("professional"), subscription_id="sub_live"
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.granted_by is None
+        assert sub.granted_reason == ""
+
+
+@pytest.mark.django_db()
+class TestWhatIsLeftAlone:
+    @pytest.mark.usefixtures("targets")
+    def test_deferred_slugs_are_not_touched(self):
+        actor = UserFactory()
+        slug = sorted(DEFERRED_SLUGS)[0]
+        sub = SubscriptionFactory(plan=legacy(slug), subscription_id=None)
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is None
+
+    @pytest.mark.usefixtures("targets")
+    def test_per_user_subscribers_still_billing_are_skipped(self):
+        """They need decomposing, which changes what Stripe charges."""
+        actor = UserFactory()
+        sub = SubscriptionFactory(
+            plan=legacy("organization", price_per_user=10),
+            subscription_id="sub_live",
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is None
+
+    @pytest.mark.usefixtures("targets")
+    def test_a_comped_per_user_subscriber_is_not_skipped(self):
+        """The subtle one.
+
+        The exclusion is per-user AND billing.  A comped organization is on a
+        per-user plan with no Stripe subscription, and must still be migrated
+        -- dropping it here would strand it with a null plan_price and fail
+        step 3c much later.
+        """
+        actor = UserFactory()
+        sub = SubscriptionFactory(
+            plan=legacy("organization", price_per_user=10), subscription_id=None
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is not None
+        assert sub.plan_price.label == "comped"
+
+
+@pytest.mark.django_db()
+class TestPreflightRefusesToGuess:
+    """The command has no log-and-skip path; it stops instead."""
+
+    @pytest.mark.usefixtures("targets")
+    def test_unmapped_plan_aborts(self):
+        actor = UserFactory()
+        SubscriptionFactory(plan=legacy("not-in-the-map"), subscription_id=None)
+
+        with pytest.raises(CommandError, match="No mapping for"):
+            run(actor=actor.username)
+
+    @pytest.mark.usefixtures("targets")
+    def test_unmapped_plan_writes_nothing(self):
+        actor = UserFactory()
+        good = SubscriptionFactory(
+            plan=legacy("professional"), subscription_id="sub_live"
+        )
+        SubscriptionFactory(plan=legacy("not-in-the-map"), subscription_id=None)
+
+        with pytest.raises(CommandError):
+            run(actor=actor.username)
+
+        good.refresh_from_db()
+        assert good.plan_price is None
+
+    @pytest.mark.usefixtures("db")
+    def test_missing_target_price_aborts(self):
+        actor = UserFactory()
+        SubscriptionFactory(plan=legacy("professional"), subscription_id="sub_live")
+
+        with pytest.raises(CommandError, match="consolidate_stripe_products"):
+            run(actor=actor.username)
+
+    @pytest.mark.usefixtures("targets")
+    def test_collapsing_two_plans_onto_one_aborts(self):
+        """Two legacy comps for one org would trip unique_together mid-loop."""
+        actor = UserFactory()
+        org = OrganizationFactory()
+        SubscriptionFactory(
+            organization=org, plan=legacy("premium-org-comp"), subscription_id=None
+        )
+        SubscriptionFactory(
+            organization=org, plan=legacy("education-grant"), subscription_id=None
+        )
+
+        with pytest.raises(CommandError, match="collapse onto one plan"):
+            run(actor=actor.username)
+
+    def test_actor_is_required_unless_dry_running(self):
+        with pytest.raises(CommandError, match="--actor is required"):
+            run()
+
+    def test_unknown_actor_aborts(self):
+        with pytest.raises(CommandError, match="No such user"):
+            run(actor="nobody")
+
+
+@pytest.mark.django_db()
+@pytest.mark.usefixtures("targets")
+class TestDryRun:
+    def test_dry_run_writes_nothing(self):
+        sub = SubscriptionFactory(
+            plan=legacy("professional"), subscription_id="sub_live"
+        )
+
+        output = run(dry_run=True)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is None
+        assert "DRY RUN" in output
+
+    def test_dry_run_needs_no_actor(self):
+        SubscriptionFactory(plan=legacy("professional"), subscription_id=None)
+
+        run(dry_run=True)
+
+        assert Subscription.objects.filter(plan_price__isnull=False).count() == 0

--- a/squarelet/organizations/tests/test_backfill_plan_prices.py
+++ b/squarelet/organizations/tests/test_backfill_plan_prices.py
@@ -34,7 +34,14 @@ def targets_fixture(db):  # pylint: disable=unused-argument
     plans = {}
     for slug, interval, label, code in set(LEGACY_PLAN_MAP.values()):
         if slug not in plans:
-            plans[slug] = PlanFactory(name=f"Canonical {slug}", slug=slug)
+            # Reuse the migration-seeded plan when it is there.  Whether it
+            # is depends on whether a transactional test has flushed the
+            # database yet, and creating a second one would quietly become
+            # `professional-2` via AutoSlugField - which the command then
+            # cannot find, making these tests pass or fail on run order.
+            plans[slug] = Plan.objects.filter(slug=slug).first() or PlanFactory(
+                name=f"Canonical {slug}", slug=slug
+            )
         PlanPriceFactory(
             plan=plans[slug],
             interval=interval,


### PR DESCRIPTION

This adds a command to backfill subscriptions into the new data model

Claude notes:

One command, no schema, no Stripe calls. The checks worth doing are the refusals — no --actor, unknown --actor, and running it before consolidate_stripe_products — because the command's whole safety story is that it stops rather than guessing.

Then spot-check the distinction it exists to make: a paying subscriber lands on the standard price, a comped organization lands on the comped price with granted_by filled in.