### PR TITLE
Bill against the new Stripe Prices

### DIFF
--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -387,7 +387,9 @@ class Subscription(models.Model):
     @property
     def free(self):
         """A subscription costs nothing when every line does."""
-        return all(item.plan is None or item.plan.free for item in self.items.all())
+        return all(
+            item.is_free for item in self.items.select_related("plan", "plan_price")
+        )
 
     @property
     def auto_renew(self):
@@ -424,8 +426,14 @@ class Subscription(models.Model):
         each line's own id to update it in place rather than replace it.
         """
         specs = []
-        for item in self.items.select_related("plan"):
-            spec = {"plan": item.plan.stripe_id, "quantity": item.quantity}
+        for item in self.items.select_related("plan", "plan_price"):
+            if item.is_free:
+                # Nothing for Stripe to bill.  A comped line has no Stripe
+                # Price at all, so naming it would reference an object that
+                # does not exist - and a subscription where *every* line is
+                # free never reaches Stripe in the first place.
+                continue
+            spec = {"plan": item.stripe_price_id, "quantity": item.quantity}
             if include_ids and item.stripe_item_id:
                 spec["id"] = item.stripe_item_id
             specs.append(spec)
@@ -773,6 +781,37 @@ class SubscriptionItem(models.Model):
     def __str__(self):
         plan_name = self.plan.name if self.plan else "Free"
         return f"SubscriptionItem: {self.subscription.organization} to {plan_name}"
+
+    @property
+    def is_free(self):
+        """Whether this line costs anything.
+
+        Reads the price once the line has one, and falls back to the plan
+        while `plan_price` can still be null - which it is for every
+        subscriber the backfill deliberately skipped, and for every signup
+        until the purchase flow starts recording a price.
+        """
+        if self.plan_price_id:
+            return self.plan_price.amount == 0
+        return self.plan is None or self.plan.free
+
+    @property
+    def stripe_price_id(self):
+        """The Stripe object this line bills against.
+
+        Prefers the `PlanPrice`'s Stripe Price.  Falls back to the plan's
+        legacy id in two cases: while `plan_price` is still null, and when
+        a price exists but has no Stripe Price yet - a partial state
+        `consolidate_stripe_products` can leave and completes on a re-run.
+        Falling back means the line keeps billing exactly as it did before,
+        which is the safe reading of "not ready yet".
+
+        A free line has no Stripe counterpart at all; `stripe_items` drops
+        those before asking.
+        """
+        if self.plan_price_id and self.plan_price.stripe_price_id:
+            return self.plan_price.stripe_price_id
+        return self.plan.stripe_id
 
     @property
     def organization(self):

--- a/squarelet/organizations/tests/models/test_billing_on_price.py
+++ b/squarelet/organizations/tests/models/test_billing_on_price.py
@@ -1,0 +1,144 @@
+# Third Party
+import pytest
+
+
+@pytest.fixture(name="legacy_plan")
+def legacy_plan_fixture(plan_factory):
+    """A plan that costs something, with no PlanPrice behind it yet."""
+    return plan_factory(name="Legacy Plan", base_price=100)
+
+
+@pytest.fixture(name="paid_price")
+def paid_price_fixture(plan_price_factory):
+    """A price with a Stripe Price behind it."""
+    return plan_price_factory(amount=10_000, stripe_price_id="price_paid")
+
+
+@pytest.mark.django_db()
+class TestWhatIsSentToStripe:
+    """Which identifier each line bills against.
+
+    The fallback to the plan's legacy id is not a transitional convenience
+    that disappears when the backfill finishes -- it covers the three
+    populations that keep a null `plan_price` by design: per-user
+    subscribers awaiting decomposition, deferred slugs, and every signup
+    until the purchase flow records a price.
+    """
+
+    def test_a_line_with_a_price_bills_against_it(
+        self, subscription_item_factory, paid_price
+    ):
+        item = subscription_item_factory(plan=paid_price.plan, plan_price=paid_price)
+
+        assert item.subscription.stripe_items() == [
+            {"plan": "price_paid", "quantity": item.quantity}
+        ]
+
+    def test_a_line_without_a_price_falls_back_to_the_plan(
+        self, subscription_item_factory, legacy_plan
+    ):
+        item = subscription_item_factory(plan=legacy_plan)
+
+        assert item.subscription.stripe_items() == [
+            {"plan": item.plan.stripe_id, "quantity": item.quantity}
+        ]
+
+    def test_a_mixed_subscription_sends_the_right_thing_per_line(
+        self, subscription_item_factory, paid_price, legacy_plan
+    ):
+        """The state production sits in for the whole window before 3c."""
+        migrated = subscription_item_factory(
+            plan=paid_price.plan, plan_price=paid_price
+        )
+        legacy = subscription_item_factory(
+            subscription=migrated.subscription, plan=legacy_plan
+        )
+
+        specs = migrated.subscription.stripe_items()
+
+        assert {s["plan"] for s in specs} == {"price_paid", legacy.plan.stripe_id}
+
+    def test_a_price_with_no_stripe_price_yet_falls_back(
+        self, subscription_item_factory, plan_price_factory, plan_factory
+    ):
+        """consolidate_stripe_products can leave a paid row blank on failure."""
+        price = plan_price_factory(
+            plan=plan_factory(name="Unready Plan", base_price=100),
+            amount=10_000,
+            stripe_price_id="",
+        )
+        item = subscription_item_factory(plan=price.plan, plan_price=price)
+
+        assert item.subscription.stripe_items() == [
+            {"plan": item.plan.stripe_id, "quantity": item.quantity}
+        ]
+
+    def test_include_ids_still_carries_the_item_id(
+        self, subscription_item_factory, paid_price
+    ):
+        item = subscription_item_factory(
+            plan=paid_price.plan, plan_price=paid_price, stripe_item_id="si_1"
+        )
+
+        specs = item.subscription.stripe_items(include_ids=True)
+
+        assert specs == [
+            {"plan": "price_paid", "quantity": item.quantity, "id": "si_1"}
+        ]
+
+
+@pytest.mark.django_db()
+class TestCompedLinesNeverReachStripe:
+    """A comped price has no Stripe Price, so there is nothing to name."""
+
+    def test_a_comped_line_is_omitted(
+        self, subscription_item_factory, plan_price_factory, paid_price
+    ):
+        paid = subscription_item_factory(plan=paid_price.plan, plan_price=paid_price)
+        comped_price = plan_price_factory(
+            plan=paid_price.plan, label="comped", amount=0, stripe_price_id=""
+        )
+        subscription_item_factory(
+            subscription=paid.subscription,
+            plan=plan_price_factory(amount=0).plan,
+            plan_price=comped_price,
+        )
+
+        specs = paid.subscription.stripe_items()
+
+        assert specs == [{"plan": "price_paid", "quantity": paid.quantity}]
+
+    def test_an_all_comped_subscription_is_free(
+        self, subscription_item_factory, plan_price_factory
+    ):
+        price = plan_price_factory(label="comped", amount=0, stripe_price_id="")
+        item = subscription_item_factory(plan=price.plan, plan_price=price)
+
+        assert item.subscription.free
+        assert item.subscription.stripe_items() == []
+
+    def test_one_paid_line_makes_the_subscription_not_free(
+        self, subscription_item_factory, plan_price_factory, paid_price
+    ):
+        """The case that would have sent a blank plan id to Stripe."""
+        paid = subscription_item_factory(plan=paid_price.plan, plan_price=paid_price)
+        comped = plan_price_factory(
+            plan=paid_price.plan, label="comped", amount=0, stripe_price_id=""
+        )
+        subscription_item_factory(
+            subscription=paid.subscription,
+            plan=plan_price_factory(amount=0).plan,
+            plan_price=comped,
+        )
+
+        assert not paid.subscription.free
+        assert all(spec["plan"] for spec in paid.subscription.stripe_items())
+
+    def test_free_still_falls_back_to_the_plan_without_a_price(
+        self, subscription_item_factory, plan_factory
+    ):
+        item = subscription_item_factory(
+            plan=plan_factory(name="Free Plan", base_price=0, price_per_user=0)
+        )
+
+        assert item.subscription.free


### PR DESCRIPTION
stripe_items() sent item.plan.stripe_id -- the legacy identifier built from the slug -- so every PlanPrice and every Stripe Price made by consolidate_stripe_products was inert.  Stripe held both the old Plans and the new Prices, and squarelet billed against the old ones.

Lines now bill against their PlanPrice's Stripe Price, falling back to the plan's legacy id.  The fallback is not a transitional convenience that disappears once the backfill finishes: it covers the three populations that keep a null plan_price by design -- per-user subscribers awaiting decomposition, deferred slugs, and every signup until the purchase flow records a price.  It goes away in 3e, once nothing can be null.

Subscription.free moves with it, and has to.  It read Plan.free, which is computed from base_price and price_per_user -- not from the price the line is actually on.  A comped PlanPrice sits on a *paid* plan, so a subscription with one paid line and one comped line was not free, went to Stripe, and would have sent a blank plan id for the comped line, since a comped price has no Stripe Price at all.  Both now ask the line, through SubscriptionItem.is_free, and stripe_items drops free lines rather than naming an object that does not exist.

This has to precede the decomposition: the pack plans are created through a historical model, so the make_stripe_plan signal never fires for them and they have no legacy Stripe Plan to fall back to.  A pack line cannot be created until this exists.