### PR TITLE
Bring the backfill command above the split

### DIFF
--- a/squarelet/organizations/management/commands/backfill_plan_prices.py
+++ b/squarelet/organizations/management/commands/backfill_plan_prices.py
@@ -1,0 +1,329 @@
+# Django
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Q
+
+# Standard Library
+import collections
+import logging
+
+# Squarelet
+from squarelet.organizations.models.payment import PlanPrice, SubscriptionItem
+
+logger = logging.getLogger(__name__)
+
+# Where each legacy plan's subscriptions land, keyed on the legacy slug and
+# whether the subscription is actually billing.
+#
+# The slug alone is not enough.  Admins granted free access for years by
+# putting organizations on a paid plan without a Stripe subscription, so
+# `organization` means the standard price for its paying subscribers and the
+# comped price for those.  `is_billing` - whether a Stripe subscription
+# exists - is what separates them.
+#
+# Every target was chosen against the legacy plan it replaces so that no
+# subscriber's bill changes.  Values are (canonical slug, interval, label,
+# code).
+LEGACY_PLAN_MAP = {
+    # MuckRock Professional
+    ("professional", True): ("professional", "monthly", "standard", ""),
+    ("professional", False): ("professional", "monthly", "comped", ""),
+    ("professional-pre-paid", True): ("professional", "annual", "standard", ""),
+    # Beta - early users grandfathered onto a free plan, not a distinct tier
+    ("beta", False): ("professional", "monthly", "comped", ""),
+    ("beta", True): ("professional", "monthly", "comped", ""),
+    # MuckRock Organization
+    ("organization", False): ("organization", "monthly", "comped", ""),
+    # Comped organizations, previously each with their own plan
+    ("muckrock-editorial-partner", False): (
+        "organization",
+        "monthly",
+        "comped",
+        "",
+    ),
+    ("premium-org-comp", False): ("organization", "monthly", "comped", ""),
+    ("education-grant", False): ("organization", "monthly", "comped", ""),
+    ("startsmall-grants", False): ("organization", "monthly", "comped", ""),
+    ("education-plan", False): ("organization", "monthly", "comped", ""),
+    # A negotiated rate, so a price of its own rather than a coupon
+    ("insideclimate-news-plan", True): (
+        "organization",
+        "monthly",
+        "standard",
+        "insideclimate",
+    ),
+    # Sunlight
+    ("sunlight-enterprise-rnn", False): (
+        "sunlight-enterprise",
+        "annual",
+        "comped",
+        "",
+    ),
+    # Admin keeps its own plan - the only one granting staff access across
+    # all three products - and simply gains a comped price.
+    ("admin", False): ("admin", "monthly", "comped", ""),
+}
+
+# Deliberately left alone.  Each needs a decision or an action outside this
+# command, given per entry below.
+DEFERRED_SLUGS = {
+    # Two organizations going opposite ways - one cancelled, one comped - so
+    # the slug alone cannot decide.
+    "custom-crp",
+    # Its one subscription belongs to an organization that was merged away.
+    "sunlight-premium-annual",
+}
+
+
+def is_billing(item):
+    """Whether Stripe is charging for this line.
+
+    The Stripe id lives on the parent subscription.  Reading `subscription_id`
+    off the line itself would read the foreign key column, which is always
+    set - every line would look like it was billing, and every comped
+    organization would be handed a paid price.
+
+    Rows pointing at a cancelled Stripe subscription would confuse this,
+    which is why the Stripe reconciliation is a prerequisite - it drove
+    those to zero.
+    """
+    return bool(item.subscription.subscription_id)
+
+
+class Command(BaseCommand):
+    """Point existing subscriptions at their new PlanPrice.
+
+    Sets `plan_price` and repoints `plan` to the canonical tier, in one
+    operation: several legacy plans consolidate onto a single canonical row,
+    so there is no PlanPrice to look up via the old plan.
+
+    Subscriptions still billing on a per-user plan are **not** touched.  They
+    need decomposing into a base plan plus a usage pack, which changes what
+    Stripe charges and so is a separate, deliberate step.  Everything this
+    command does is a local pointer update that changes nobody's bill.
+
+    Run `consolidate_stripe_products` first; this needs the PlanPrice rows to
+    exist.
+    """
+
+    help = "Point existing subscriptions at their new PlanPrice"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything",
+        )
+        parser.add_argument(
+            "--actor",
+            help=(
+                "Username recorded as granted_by on migrated comped "
+                "subscriptions.  Required unless --dry-run."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN - nothing written"))
+
+        actor = self._resolve_actor(options["actor"], dry_run)
+        pending = self._pending()
+        self._preflight(pending)
+
+        counts = collections.Counter()
+        with transaction.atomic():
+            for sub in pending:
+                counts[self._migrate(sub, actor, dry_run)] += 1
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self.stdout.write(
+            f"\n{counts['migrated']} migrated, {counts['deferred']} deferred"
+        )
+        self._report_remaining()
+
+    def _resolve_actor(self, username, dry_run):
+        # Imported here rather than at module scope: get_user_model() must
+        # not run before the app registry is ready.
+        # pylint: disable=import-outside-toplevel
+        # Django
+        from django.contrib.auth import get_user_model
+
+        if not username:
+            if dry_run:
+                return None
+            raise CommandError(
+                "--actor is required: migrated comped subscriptions record "
+                "who authorized them."
+            )
+        user_model = get_user_model()
+        try:
+            return user_model.objects.get(username=username)
+        except user_model.DoesNotExist as exc:
+            raise CommandError(f"No such user: {username}") from exc
+
+    def _pending(self):
+        """Subscriptions this step handles.
+
+        Everything except those still billing on a per-user plan, which the
+        per-user decomposition handles instead.
+        """
+        return list(
+            SubscriptionItem.objects.select_related(
+                "subscription__organization", "plan"
+            )
+            .filter(plan_price__isnull=True)
+            # Per-user *and* billing.  A blank id on the parent means the
+            # line never reached Stripe, which is what a comped organization
+            # looks like - those are migrated here like any other.
+            .exclude(
+                Q(plan__price_per_user__gt=0) & ~Q(subscription__subscription_id="")
+            )
+            .order_by("plan__slug", "pk")
+        )
+
+    def _preflight(self, pending):
+        """Refuse to write anything unless every case is accounted for.
+
+        Deliberately no log-and-skip fallback.  A silent skip leaves
+        `plan_price` null, which surfaces much later and much less legibly
+        - as a failure to make the column non-null, long after the run that
+        caused it.
+        """
+        unmapped = {
+            (sub.plan.slug, is_billing(sub))
+            for sub in pending
+            if sub.plan.slug not in DEFERRED_SLUGS
+            and (sub.plan.slug, is_billing(sub)) not in LEGACY_PLAN_MAP
+        }
+        if unmapped:
+            raise CommandError(
+                "No mapping for: "
+                + ", ".join(
+                    f"{slug} (billing={billing})" for slug, billing in sorted(unmapped)
+                )
+                + ".  Add them to LEGACY_PLAN_MAP or DEFERRED_SLUGS."
+            )
+
+        missing = set()
+        for target in LEGACY_PLAN_MAP.values():
+            slug, interval, label, code = target
+            if not PlanPrice.objects.filter(
+                plan__slug=slug,
+                interval=interval,
+                label=label,
+                code=code,
+                active=True,
+            ).exists():
+                missing.add(target)
+        if missing:
+            raise CommandError(
+                "These target prices do not exist - run "
+                "consolidate_stripe_products first: " + str(sorted(missing))
+            )
+
+        collisions = self._collisions(pending)
+        if collisions:
+            raise CommandError(
+                "These subscriptions carry several lines that would collapse "
+                "onto one plan; resolve by hand first: "
+                + str(
+                    {
+                        f"subscription {sub_id} -> {plan}": v
+                        for (sub_id, plan), v in collisions.items()
+                    }
+                )
+            )
+
+    def _collisions(self, pending):
+        """Lines that would end up duplicated on one subscription.
+
+        Several legacy plans collapse onto a single canonical one, and
+        SubscriptionItem is unique on (subscription, plan) -- not on
+        (organization, plan), since the split moved the organization to the
+        parent.  Two lines on the *same* subscription collapsing onto one
+        plan is therefore the collision; two on different subscriptions of
+        the same organization is legitimate.
+
+        Catching this before anything is written matters: otherwise the
+        transaction aborts half way through on a bare IntegrityError.
+        """
+        seen = collections.defaultdict(list)
+        for item in pending:
+            key = (item.plan.slug, is_billing(item))
+            if key not in LEGACY_PLAN_MAP:
+                continue
+            seen[(item.subscription_id, LEGACY_PLAN_MAP[key][0])].append(item.plan.slug)
+        if not seen:
+            return {}
+
+        # A line this step leaves alone still occupies (subscription, plan),
+        # so a pending line landing on its canonical plan collides with it
+        # just as surely as with another pending line.
+        held = (
+            SubscriptionItem.objects.exclude(pk__in={item.pk for item in pending})
+            .filter(
+                subscription_id__in={sub_id for sub_id, _ in seen},
+                plan__slug__in={slug for _, slug in seen},
+            )
+            .values_list("subscription_id", "plan__slug")
+        )
+        for sub_id, slug in held:
+            if (sub_id, slug) in seen:
+                seen[(sub_id, slug)].append(f"{slug} (already held)")
+
+        return {k: v for k, v in seen.items() if len(v) > 1}
+
+    def _migrate(self, sub, actor, dry_run):
+        if sub.plan.slug in DEFERRED_SLUGS:
+            self.stdout.write(f"  ~ {sub.organization.slug}: {sub.plan.slug} deferred")
+            return "deferred"
+
+        slug, interval, label, code = LEGACY_PLAN_MAP[(sub.plan.slug, is_billing(sub))]
+        plan_price = PlanPrice.objects.select_related("plan").get(
+            plan__slug=slug,
+            interval=interval,
+            label=label,
+            code=code,
+            active=True,
+        )
+
+        legacy_name = sub.plan.name  # captured before repointing
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"  + {sub.organization.slug}: {sub.plan.slug} -> {plan_price}"
+            )
+        )
+        if dry_run:
+            return "migrated"
+
+        sub.plan = plan_price.plan
+        sub.plan_price = plan_price
+        fields = ["plan", "plan_price"]
+        if label == "comped":
+            # Migrated comps carry the same provenance the admin path
+            # requires, so "why is this organization free" stays answerable.
+            sub.granted_reason = f"Migrated from legacy {legacy_name} plan"
+            sub.granted_by = actor
+            fields += ["granted_reason", "granted_by"]
+        sub.save(update_fields=fields)
+        return "migrated"
+
+    def _report_remaining(self):
+        """What is left, and why - so a non-zero count is not alarming."""
+        per_user = (
+            SubscriptionItem.objects.filter(plan_price__isnull=True)
+            .filter(plan__price_per_user__gt=0)
+            .exclude(subscription__subscription_id="")
+            .count()
+        )
+        deferred = (
+            SubscriptionItem.objects.filter(plan_price__isnull=True)
+            .filter(plan__slug__in=DEFERRED_SLUGS)
+            .count()
+        )
+        self.stdout.write(
+            f"still without a plan_price: {per_user} awaiting the per-user "
+            f"decomposition, {deferred} deferred by choice"
+        )

--- a/squarelet/organizations/models/organization.py
+++ b/squarelet/organizations/models/organization.py
@@ -523,7 +523,15 @@ class Organization(AvatarMixin, models.Model):
         return users_list
 
     @transaction.atomic
-    def add_subscription(self, plan, max_users, user, token=None, payment_method=None):
+    def add_subscription(
+        self,
+        plan,
+        max_users,
+        user,
+        token=None,
+        payment_method=None,
+        nonprofit=False,
+    ):
         """Add a new subscription to a plan.
 
         Raises SubscriptionError if the org already has a non-cancelled
@@ -564,6 +572,7 @@ class Organization(AvatarMixin, models.Model):
             plan=plan,
             payment_method=payment_method,
             quantity=max_users,
+            nonprofit=nonprofit,
         )
 
         if is_first and stripe_subscription:

--- a/squarelet/organizations/models/payment.py
+++ b/squarelet/organizations/models/payment.py
@@ -387,7 +387,9 @@ class Subscription(models.Model):
     @property
     def free(self):
         """A subscription costs nothing when every line does."""
-        return all(item.plan is None or item.plan.free for item in self.items.all())
+        return all(
+            item.is_free for item in self.items.select_related("plan", "plan_price")
+        )
 
     @property
     def auto_renew(self):
@@ -424,8 +426,14 @@ class Subscription(models.Model):
         each line's own id to update it in place rather than replace it.
         """
         specs = []
-        for item in self.items.select_related("plan"):
-            spec = {"plan": item.plan.stripe_id, "quantity": item.quantity}
+        for item in self.items.select_related("plan", "plan_price"):
+            if item.is_free:
+                # Nothing for Stripe to bill.  A comped line has no Stripe
+                # Price at all, so naming it would reference an object that
+                # does not exist - and a subscription where *every* line is
+                # free never reaches Stripe in the first place.
+                continue
+            spec = {"plan": item.stripe_price_id, "quantity": item.quantity}
             if include_ids and item.stripe_item_id:
                 spec["id"] = item.stripe_item_id
             specs.append(spec)
@@ -610,14 +618,26 @@ class Subscription(models.Model):
         self.save()
         self.items.update(cancelled=False, cancel_at=None)
 
-    def stripe_modify(self):
-        """Push local state to Stripe for every item on this subscription."""
+    def stripe_modify(self, proration_behavior=None):
+        """Push local state to Stripe for every item on this subscription.
+
+        `proration_behavior` is passed to Stripe only when given, so the
+        default stays Stripe's own - a genuine upgrade or downgrade should
+        prorate.  Pass "none" for a change that is not meant to alter what
+        the customer pays, such as moving a line onto the Price that
+        represents the same money it was already billing.
+        """
         if self.stripe_subscription:
             updated = (
                 get_payment_provider()
                 .get_subscription_service()
                 .modify(
                     self.subscription_id,
+                    **(
+                        {"proration_behavior": proration_behavior}
+                        if proration_behavior is not None
+                        else {}
+                    ),
                     cancel_at_period_end=not self.auto_renew,
                     items=self.stripe_items(include_ids=True),
                     billing=(
@@ -773,6 +793,37 @@ class SubscriptionItem(models.Model):
     def __str__(self):
         plan_name = self.plan.name if self.plan else "Free"
         return f"SubscriptionItem: {self.subscription.organization} to {plan_name}"
+
+    @property
+    def is_free(self):
+        """Whether this line costs anything.
+
+        Reads the price once the line has one, and falls back to the plan
+        while `plan_price` can still be null - which it is for every
+        subscriber the backfill deliberately skipped, and for every signup
+        until the purchase flow starts recording a price.
+        """
+        if self.plan_price_id:
+            return self.plan_price.amount == 0
+        return self.plan is None or self.plan.free
+
+    @property
+    def stripe_price_id(self):
+        """The Stripe object this line bills against.
+
+        Prefers the `PlanPrice`'s Stripe Price.  Falls back to the plan's
+        legacy id in two cases: while `plan_price` is still null, and when
+        a price exists but has no Stripe Price yet - a partial state
+        `consolidate_stripe_products` can leave and completes on a re-run.
+        Falling back means the line keeps billing exactly as it did before,
+        which is the safe reading of "not ready yet".
+
+        A free line has no Stripe counterpart at all; `stripe_items` drops
+        those before asking.
+        """
+        if self.plan_price_id and self.plan_price.stripe_price_id:
+            return self.plan_price.stripe_price_id
+        return self.plan.stripe_id
 
     @property
     def organization(self):

--- a/squarelet/organizations/plan_mapping.py
+++ b/squarelet/organizations/plan_mapping.py
@@ -63,6 +63,51 @@ LEGACY_PLAN_MAP = {
     # Admin keeps its own plan - the only one granting staff access across
     # all three products - and simply gains a comped price.
     ("admin", False): ("admin", "monthly", "comped", ""),
+    # --- Plans a new customer can still pick -------------------------------
+    #
+    # These are not legacy rows being consolidated away; they are the tiers
+    # themselves, and they are here because a purchase resolves through this
+    # same table.  Annual is a separate `Plan` row today rather than an
+    # interval, so it maps onto the canonical tier with interval="annual" -
+    # which is exactly what the migration does with them too.
+    ("organization", True): ("organization", "monthly", "standard", ""),
+    ("sunlight-essential", True): ("sunlight-essential", "monthly", "standard", ""),
+    ("sunlight-essential-annual", True): (
+        "sunlight-essential",
+        "annual",
+        "standard",
+        "",
+    ),
+    ("sunlight-enhanced", True): ("sunlight-enhanced", "monthly", "standard", ""),
+    ("sunlight-enhanced-annual", True): ("sunlight-enhanced", "annual", "standard", ""),
+    # Nonprofit variants are not public - `get_selected_plan()` substitutes
+    # one in when the checkbox is ticked - so a purchase arrives here already
+    # on the variant slug.  Mapping them means the label comes out right
+    # without the form having to change.
+    ("sunlight-nonprofit-essential", True): (
+        "sunlight-essential",
+        "monthly",
+        "nonprofit",
+        "",
+    ),
+    ("sunlight-nonprofit-essential-annual", True): (
+        "sunlight-essential",
+        "annual",
+        "nonprofit",
+        "",
+    ),
+    ("sunlight-nonprofit-enhanced", True): (
+        "sunlight-enhanced",
+        "monthly",
+        "nonprofit",
+        "",
+    ),
+    ("sunlight-nonprofit-enhanced-annual", True): (
+        "sunlight-enhanced",
+        "annual",
+        "nonprofit",
+        "",
+    ),
 }
 
 # Deliberately left alone.  Each needs a decision or an action outside this

--- a/squarelet/organizations/plan_mapping.py
+++ b/squarelet/organizations/plan_mapping.py
@@ -1,0 +1,98 @@
+"""Where each legacy plan lands under the consolidated pricing model.
+
+Lives here rather than inside the migration command because two callers
+need it and they want different things from it:
+
+- the migration asks "where does this existing subscription land", and the
+  answer legitimately includes comped and negotiated outcomes;
+- the sign-up flow asks "what does this cost a new customer", which must
+  never resolve to comped.
+
+Keeping one table avoids two descriptions of the same relationship
+drifting apart; `resolve_target` below is what keeps the second caller
+honest.
+"""
+
+# Where each legacy plan's subscriptions land, keyed on the legacy slug and
+# whether the subscription is actually billing.
+#
+# The slug alone is not enough.  Admins granted free access for years by
+# putting organizations on a paid plan without a Stripe subscription, so
+# `organization` means the standard price for its paying subscribers and the
+# comped price for those.  `is_billing` - whether a Stripe subscription
+# exists - is what separates them.
+#
+# Every target was chosen against the legacy plan it replaces so that no
+# subscriber's bill changes.  Values are (canonical slug, interval, label,
+# code).
+LEGACY_PLAN_MAP = {
+    # MuckRock Professional
+    ("professional", True): ("professional", "monthly", "standard", ""),
+    ("professional", False): ("professional", "monthly", "comped", ""),
+    ("professional-pre-paid", True): ("professional", "annual", "standard", ""),
+    # Beta - early users grandfathered onto a free plan, not a distinct tier
+    ("beta", False): ("professional", "monthly", "comped", ""),
+    ("beta", True): ("professional", "monthly", "comped", ""),
+    # MuckRock Organization
+    ("organization", False): ("organization", "monthly", "comped", ""),
+    # Comped organizations, previously each with their own plan
+    ("muckrock-editorial-partner", False): (
+        "organization",
+        "monthly",
+        "comped",
+        "",
+    ),
+    ("premium-org-comp", False): ("organization", "monthly", "comped", ""),
+    ("education-grant", False): ("organization", "monthly", "comped", ""),
+    ("startsmall-grants", False): ("organization", "monthly", "comped", ""),
+    ("education-plan", False): ("organization", "monthly", "comped", ""),
+    # A negotiated rate, so a price of its own rather than a coupon
+    ("insideclimate-news-plan", True): (
+        "organization",
+        "monthly",
+        "standard",
+        "insideclimate",
+    ),
+    # Sunlight
+    ("sunlight-enterprise-rnn", False): (
+        "sunlight-enterprise",
+        "annual",
+        "comped",
+        "",
+    ),
+    # Admin keeps its own plan - the only one granting staff access across
+    # all three products - and simply gains a comped price.
+    ("admin", False): ("admin", "monthly", "comped", ""),
+}
+
+# Deliberately left alone.  Each needs a decision or an action outside this
+# command, given per entry below.
+DEFERRED_SLUGS = {
+    # Two organizations going opposite ways - one cancelled, one comped - so
+    # the slug alone cannot decide.
+    "custom-crp",
+    # Its one subscription belongs to an organization that was merged away.
+    "sunlight-premium-annual",
+}
+
+
+def resolve_target(slug, *, allow_comped):
+    """The canonical (slug, interval, label, code) for a legacy plan slug.
+
+    Returns None when the slug is unmapped, which callers treat as "leave
+    it on the legacy plan" rather than as an error.
+
+    `allow_comped` is the distinction between the two callers.  A comped
+    target is correct for a subscription that is *already* comped and is
+    being migrated; it is never correct for a new self-service purchase,
+    which would be handing out a free subscription.  Negotiated (`code`)
+    targets are deliberately allowed for both: reaching one requires being
+    granted the private plan in the first place, and that grant is the
+    authorisation.
+    """
+    target = LEGACY_PLAN_MAP.get((slug, True))
+    if target is None:
+        return None
+    if not allow_comped and target[2] == "comped":
+        return None
+    return target

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -416,7 +416,74 @@ class ChargeQuerySet(models.QuerySet):
 
 
 class SubscriptionItemQuerySet(models.QuerySet):
-    def start(self, organization, plan, payment_method="card", quantity=1):
+    @staticmethod
+    def _schedule_single_period(item):
+        """A plan that bills once and stops means, for a line, exactly what a
+        customer cancellation means: drop it at the end of the period it was
+        paid for.  The subscription carries on for its other lines, and
+        Resubscribe reverses this if they change their mind."""
+        period_end = item.subscription.current_period_end
+        item.cancelled = True
+        item.cancel_at = period_end.date() if period_end else None
+        item.save()
+
+    @staticmethod
+    def _collection_method(interval, payment_method):
+        """Stripe collects annual subscriptions by invoice when asked."""
+        if interval == "annual" and payment_method == "invoice":
+            return "send_invoice"
+        return "charge_automatically"
+
+    @staticmethod
+    def resolve_purchase(plan, interval, nonprofit=False):
+        """What a new subscription to `plan` should actually be recorded as.
+
+        Returns `(canonical_plan, plan_price)`, or `(plan, None)` when there
+        is nothing to resolve to - which is every plan until
+        `consolidate_stripe_products` has run, and any plan the mapping does
+        not cover.  Falling back leaves the subscription on the legacy plan
+        and the legacy Stripe id, which is what it would have been anyway;
+        the migration picks those up.
+
+        The plan a customer picks is not necessarily the plan they end up
+        on.  Annual and nonprofit are separate `Plan` rows today, and both
+        collapse onto a canonical tier where the difference is carried by
+        the price's `interval` and `label` instead.  Resolving both here
+        means a new subscription is recorded exactly as a migrated one is,
+        so the migration has genuinely nothing to do for it.
+        """
+        # Lazy import to avoid a circular import (payment.py imports this module)
+        # pylint: disable=import-outside-toplevel
+        # Squarelet
+        from squarelet.organizations.models.payment import PlanPrice
+        from squarelet.organizations.plan_mapping import resolve_target
+
+        target = resolve_target(plan.slug, allow_comped=False) or (
+            plan.slug,
+            interval,
+            "nonprofit" if nonprofit else "standard",
+            "",
+        )
+        canonical_slug, interval, label, code = target
+
+        price = (
+            PlanPrice.objects.select_related("plan")
+            .filter(
+                plan__slug=canonical_slug,
+                interval=interval,
+                label=label,
+                code=code,
+                active=True,
+            )
+            .first()
+        )
+        if price is None:
+            return plan, None
+        return price.plan, price
+
+    def start(
+        self, organization, plan, payment_method="card", quantity=1, nonprofit=False
+    ):
         """Add a line for `plan` and make sure Stripe knows about it.
 
         Stripe requires every item on a subscription to share a billing
@@ -434,25 +501,28 @@ class SubscriptionItemQuerySet(models.QuerySet):
         from squarelet.organizations.models.payment import Subscription
 
         interval = "annual" if plan.annual else "monthly"
-        collection_method = (
-            "send_invoice"
-            if interval == "annual" and payment_method == "invoice"
-            else "charge_automatically"
-        )
+        collection_method = self._collection_method(interval, payment_method)
         subscription, created = Subscription.objects.get_or_create(
             organization=organization,
             interval=interval,
             collection_method=collection_method,
         )
+        canonical_plan, plan_price = self.resolve_purchase(plan, interval, nonprofit)
         item = self.model.objects.create(
-            subscription=subscription, plan=plan, quantity=quantity
+            subscription=subscription,
+            plan=canonical_plan,
+            plan_price=plan_price,
+            quantity=quantity,
         )
 
         if created or not subscription.subscription_id:
-            anchor = organization.billing_anchor
             stripe_subscription = subscription.start(
                 payment_method=payment_method,
-                anchor_day=anchor.day if anchor else None,
+                anchor_day=(
+                    organization.billing_anchor.day
+                    if organization.billing_anchor
+                    else None
+                ),
             )
         else:
             # The subscription is already live on Stripe, so the new line is
@@ -461,14 +531,7 @@ class SubscriptionItemQuerySet(models.QuerySet):
             stripe_subscription = subscription.stripe_subscription
 
         if not plan.auto_renew:
-            # A plan that bills once and stops means, for a line, exactly what
-            # a customer cancellation means: drop it at the end of the period
-            # it was paid for.  The subscription carries on for its other
-            # lines, and Resubscribe reverses this if they change their mind.
-            period_end = subscription.current_period_end
-            item.cancelled = True
-            item.cancel_at = period_end.date() if period_end else None
-            item.save()
+            self._schedule_single_period(item)
 
         if not plan.free:
             item.notify_started()

--- a/squarelet/organizations/querysets.py
+++ b/squarelet/organizations/querysets.py
@@ -435,7 +435,7 @@ class SubscriptionItemQuerySet(models.QuerySet):
         return "charge_automatically"
 
     @staticmethod
-    def resolve_purchase(plan, interval, nonprofit=False):
+    def resolve_purchase(plan, nonprofit=False):
         """What a new subscription to `plan` should actually be recorded as.
 
         Returns `(canonical_plan, plan_price)`, or `(plan, None)` when there
@@ -460,7 +460,7 @@ class SubscriptionItemQuerySet(models.QuerySet):
 
         target = resolve_target(plan.slug, allow_comped=False) or (
             plan.slug,
-            interval,
+            "annual" if plan.annual else "monthly",
             "nonprofit" if nonprofit else "standard",
             "",
         )
@@ -500,14 +500,24 @@ class SubscriptionItemQuerySet(models.QuerySet):
         # Squarelet
         from squarelet.organizations.models.payment import Subscription
 
-        interval = "annual" if plan.annual else "monthly"
+        canonical_plan, plan_price = self.resolve_purchase(plan, nonprofit)
+        # The billing shape follows the resolved price, not `plan.annual`.
+        # Annual is a separate `Plan` row today, and the row a customer picks
+        # is not always the row they end up on -- the nonprofit variants are
+        # substituted in by the form.  Trusting the flag would let an annual
+        # price land on a subscription recorded as monthly, which groups it
+        # onto the wrong invoice and picks the wrong collection method.
+        interval = (
+            plan_price.interval
+            if plan_price
+            else "annual" if plan.annual else "monthly"
+        )
         collection_method = self._collection_method(interval, payment_method)
         subscription, created = Subscription.objects.get_or_create(
             organization=organization,
             interval=interval,
             collection_method=collection_method,
         )
-        canonical_plan, plan_price = self.resolve_purchase(plan, interval, nonprofit)
         item = self.model.objects.create(
             subscription=subscription,
             plan=canonical_plan,

--- a/squarelet/organizations/tests/models/test_billing_on_price.py
+++ b/squarelet/organizations/tests/models/test_billing_on_price.py
@@ -242,3 +242,51 @@ class TestProrationIsOptOut:
         kwargs = self._modify(item, mocker, proration_behavior="none")
 
         assert kwargs["proration_behavior"] == "none"
+
+
+@pytest.mark.django_db()
+class TestEveryPurchasablePlanResolves:
+    """A plan a customer can pick must map to a price.
+
+    An unmapped slug falls back to the legacy plan silently -- correct
+    while nothing is set up, but indistinguishable from a missing entry.
+    These pin the slugs that were public when the mapping was written, so
+    adding a purchasable plan without a price fails here rather than in
+    production.
+    """
+
+    PURCHASABLE = [
+        ("organization", "organization", "monthly", "standard"),
+        ("sunlight-essential", "sunlight-essential", "monthly", "standard"),
+        ("sunlight-essential-annual", "sunlight-essential", "annual", "standard"),
+        ("sunlight-enhanced", "sunlight-enhanced", "monthly", "standard"),
+        ("sunlight-enhanced-annual", "sunlight-enhanced", "annual", "standard"),
+        ("professional", "professional", "monthly", "standard"),
+    ]
+
+    NONPROFIT = [
+        ("sunlight-nonprofit-essential", "sunlight-essential", "monthly"),
+        ("sunlight-nonprofit-essential-annual", "sunlight-essential", "annual"),
+        ("sunlight-nonprofit-enhanced", "sunlight-enhanced", "monthly"),
+        ("sunlight-nonprofit-enhanced-annual", "sunlight-enhanced", "annual"),
+    ]
+
+    def test_each_public_plan_maps_to_a_canonical_target(self):
+        for slug, canonical, interval, label in self.PURCHASABLE:
+            target = resolve_target(slug, allow_comped=False)
+            assert target is not None, f"{slug} has no mapping"
+            assert target[:3] == (canonical, interval, label), slug
+
+    def test_each_nonprofit_variant_maps_to_the_nonprofit_price(self):
+        """The checkbox substitutes the plan; the map turns it into a label."""
+        for slug, canonical, interval in self.NONPROFIT:
+            target = resolve_target(slug, allow_comped=False)
+            assert target is not None, f"{slug} has no mapping"
+            assert target[:3] == (canonical, interval, "nonprofit"), slug
+
+    def test_every_target_names_a_blank_code(self):
+        """A purchase must never default onto someone's negotiated rate."""
+        for slug, *_ in self.PURCHASABLE + [
+            (s, None, None) for s, _, _ in self.NONPROFIT
+        ]:
+            assert resolve_target(slug, allow_comped=False)[3] == ""

--- a/squarelet/organizations/tests/models/test_billing_on_price.py
+++ b/squarelet/organizations/tests/models/test_billing_on_price.py
@@ -157,14 +157,14 @@ class TestPurchaseResolvesAPrice:
     price, and deliberately so.
     """
 
-    def _resolve(self, **kwargs):
-        _, price = SubscriptionItem.objects.resolve_purchase(**kwargs)
+    def _resolve(self, plan, nonprofit=False):
+        _, price = SubscriptionItem.objects.resolve_purchase(plan, nonprofit)
         return price
 
     def test_resolves_the_standard_list_price(self, plan_price_factory):
         price = plan_price_factory(interval="monthly", label="standard")
 
-        assert self._resolve(plan=price.plan, interval="monthly") == price
+        assert self._resolve(plan=price.plan) == price
 
     def test_nonprofit_resolves_the_nonprofit_price(self, plan_price_factory):
         """Self-reported, and the only thing the checkbox now decides."""
@@ -173,13 +173,17 @@ class TestPurchaseResolvesAPrice:
             plan=plan, interval="monthly", label="nonprofit", amount=3_500
         )
 
-        assert self._resolve(plan=plan, interval="monthly", nonprofit=True) == nonprofit
+        assert self._resolve(plan=plan, nonprofit=True) == nonprofit
 
-    def test_interval_selects_between_prices(self, plan_price_factory):
-        plan = plan_price_factory(interval="monthly").plan
+    def test_an_annual_plan_resolves_the_annual_price(
+        self, plan_factory, plan_price_factory
+    ):
+        """Interval comes from the plan, not from the caller."""
+        plan = plan_factory(name="Annual Tier", annual=True)
+        plan_price_factory(plan=plan, interval="monthly", amount=10_000)
         annual = plan_price_factory(plan=plan, interval="annual", amount=120_000)
 
-        assert self._resolve(plan=plan, interval="annual") == annual
+        assert self._resolve(plan=plan) == annual
 
     def test_list_pricing_wins_over_a_negotiated_rate(self, plan_price_factory):
         """A deal attached to a plan is not what a stranger buying it pays.
@@ -197,7 +201,7 @@ class TestPurchaseResolvesAPrice:
             amount=3_000,
         )
 
-        assert self._resolve(plan=plan, interval="monthly").code == ""
+        assert self._resolve(plan=plan).code == ""
 
     def test_a_comped_target_is_never_sold(self):
         """The mapping legitimately contains comped targets, for migrating
@@ -209,11 +213,11 @@ class TestPurchaseResolvesAPrice:
     def test_a_comped_price_is_unreachable(self, plan_price_factory):
         plan = plan_price_factory(interval="monthly", label="comped", amount=0).plan
 
-        assert self._resolve(plan=plan, interval="monthly") is None
+        assert self._resolve(plan=plan) is None
 
     def test_no_price_yet_resolves_to_none(self, plan_factory):
         """Every plan, until consolidate_stripe_products has run."""
-        assert self._resolve(plan=plan_factory(), interval="monthly") is None
+        assert self._resolve(plan=plan_factory()) is None
 
 
 @pytest.mark.django_db()
@@ -290,3 +294,45 @@ class TestEveryPurchasablePlanResolves:
             (s, None, None) for s, _, _ in self.NONPROFIT
         ]:
             assert resolve_target(slug, allow_comped=False)[3] == ""
+
+
+@pytest.mark.django_db()
+class TestBillingShapeFollowsThePrice:
+    """The subscription's interval comes from the resolved price.
+
+    `plan.annual` is not enough: annual is a separate Plan row today, and
+    the row a customer picks is not always the row they end up on -- the
+    nonprofit variants are substituted in by the form.  If the flag and the
+    price disagreed, an annual price would land on a subscription recorded
+    as monthly, grouping it onto the wrong invoice.
+    """
+
+    def test_an_annual_price_makes_an_annual_subscription(
+        self, organization_factory, plan_factory, plan_price_factory, mocker
+    ):
+        canonical = plan_factory(name="Sunlight Essential", slug="sunlight-essential")
+        plan_price_factory(
+            plan=canonical,
+            interval="annual",
+            label="nonprofit",
+            amount=400_000,
+            stripe_price_id="price_np_annual",
+        )
+        # The row the form substitutes in, with the flag deliberately wrong
+        picked = plan_factory(
+            name="Sunlight Nonprofit Essential Annual",
+            slug="sunlight-nonprofit-essential-annual",
+            annual=False,
+        )
+        mocker.patch("squarelet.organizations.models.Subscription.start")
+        mocker.patch(
+            "squarelet.organizations.models.payment.SubscriptionItem.notify_started"
+        )
+
+        item, _ = SubscriptionItem.objects.start(
+            organization=organization_factory(), plan=picked, quantity=1
+        )
+
+        assert item.subscription.interval == "annual"
+        assert item.plan == canonical
+        assert item.plan_price.stripe_price_id == "price_np_annual"

--- a/squarelet/organizations/tests/models/test_billing_on_price.py
+++ b/squarelet/organizations/tests/models/test_billing_on_price.py
@@ -1,0 +1,244 @@
+# Third Party
+import pytest
+
+# Squarelet
+from squarelet.organizations.models import SubscriptionItem
+from squarelet.organizations.plan_mapping import resolve_target
+
+
+@pytest.fixture(name="legacy_plan")
+def legacy_plan_fixture(plan_factory):
+    """A plan that costs something, with no PlanPrice behind it yet."""
+    return plan_factory(name="Legacy Plan", base_price=100)
+
+
+@pytest.fixture(name="paid_price")
+def paid_price_fixture(plan_price_factory):
+    """A price with a Stripe Price behind it."""
+    return plan_price_factory(amount=10_000, stripe_price_id="price_paid")
+
+
+@pytest.mark.django_db()
+class TestWhatIsSentToStripe:
+    """Which identifier each line bills against.
+
+    The fallback to the plan's legacy id is not a transitional convenience
+    that disappears when the backfill finishes -- it covers the three
+    populations that keep a null `plan_price` by design: per-user
+    subscribers awaiting decomposition, deferred slugs, and every signup
+    until the purchase flow records a price.
+    """
+
+    def test_a_line_with_a_price_bills_against_it(
+        self, subscription_item_factory, paid_price
+    ):
+        item = subscription_item_factory(plan=paid_price.plan, plan_price=paid_price)
+
+        assert item.subscription.stripe_items() == [
+            {"plan": "price_paid", "quantity": item.quantity}
+        ]
+
+    def test_a_line_without_a_price_falls_back_to_the_plan(
+        self, subscription_item_factory, legacy_plan
+    ):
+        item = subscription_item_factory(plan=legacy_plan)
+
+        assert item.subscription.stripe_items() == [
+            {"plan": item.plan.stripe_id, "quantity": item.quantity}
+        ]
+
+    def test_a_mixed_subscription_sends_the_right_thing_per_line(
+        self, subscription_item_factory, paid_price, legacy_plan
+    ):
+        """The state production sits in for the whole window before 3c."""
+        migrated = subscription_item_factory(
+            plan=paid_price.plan, plan_price=paid_price
+        )
+        legacy = subscription_item_factory(
+            subscription=migrated.subscription, plan=legacy_plan
+        )
+
+        specs = migrated.subscription.stripe_items()
+
+        assert {s["plan"] for s in specs} == {"price_paid", legacy.plan.stripe_id}
+
+    def test_a_price_with_no_stripe_price_yet_falls_back(
+        self, subscription_item_factory, plan_price_factory, plan_factory
+    ):
+        """consolidate_stripe_products can leave a paid row blank on failure."""
+        price = plan_price_factory(
+            plan=plan_factory(name="Unready Plan", base_price=100),
+            amount=10_000,
+            stripe_price_id="",
+        )
+        item = subscription_item_factory(plan=price.plan, plan_price=price)
+
+        assert item.subscription.stripe_items() == [
+            {"plan": item.plan.stripe_id, "quantity": item.quantity}
+        ]
+
+    def test_include_ids_still_carries_the_item_id(
+        self, subscription_item_factory, paid_price
+    ):
+        item = subscription_item_factory(
+            plan=paid_price.plan, plan_price=paid_price, stripe_item_id="si_1"
+        )
+
+        specs = item.subscription.stripe_items(include_ids=True)
+
+        assert specs == [
+            {"plan": "price_paid", "quantity": item.quantity, "id": "si_1"}
+        ]
+
+
+@pytest.mark.django_db()
+class TestCompedLinesNeverReachStripe:
+    """A comped price has no Stripe Price, so there is nothing to name."""
+
+    def test_a_comped_line_is_omitted(
+        self, subscription_item_factory, plan_price_factory, paid_price
+    ):
+        paid = subscription_item_factory(plan=paid_price.plan, plan_price=paid_price)
+        comped_price = plan_price_factory(
+            plan=paid_price.plan, label="comped", amount=0, stripe_price_id=""
+        )
+        subscription_item_factory(
+            subscription=paid.subscription,
+            plan=plan_price_factory(amount=0).plan,
+            plan_price=comped_price,
+        )
+
+        specs = paid.subscription.stripe_items()
+
+        assert specs == [{"plan": "price_paid", "quantity": paid.quantity}]
+
+    def test_an_all_comped_subscription_is_free(
+        self, subscription_item_factory, plan_price_factory
+    ):
+        price = plan_price_factory(label="comped", amount=0, stripe_price_id="")
+        item = subscription_item_factory(plan=price.plan, plan_price=price)
+
+        assert item.subscription.free
+        assert item.subscription.stripe_items() == []
+
+    def test_one_paid_line_makes_the_subscription_not_free(
+        self, subscription_item_factory, plan_price_factory, paid_price
+    ):
+        """The case that would have sent a blank plan id to Stripe."""
+        paid = subscription_item_factory(plan=paid_price.plan, plan_price=paid_price)
+        comped = plan_price_factory(
+            plan=paid_price.plan, label="comped", amount=0, stripe_price_id=""
+        )
+        subscription_item_factory(
+            subscription=paid.subscription,
+            plan=plan_price_factory(amount=0).plan,
+            plan_price=comped,
+        )
+
+        assert not paid.subscription.free
+        assert all(spec["plan"] for spec in paid.subscription.stripe_items())
+
+    def test_free_still_falls_back_to_the_plan_without_a_price(
+        self, subscription_item_factory, plan_factory
+    ):
+        item = subscription_item_factory(
+            plan=plan_factory(name="Free Plan", base_price=0, price_per_user=0)
+        )
+
+        assert item.subscription.free
+
+
+@pytest.mark.django_db()
+class TestPurchaseResolvesAPrice:
+    """What price a new subscription is sold at.
+
+    Plan, interval and label identify exactly one active list price, so
+    this is a lookup rather than a choice -- there is no UI for picking a
+    price, and deliberately so.
+    """
+
+    def _resolve(self, **kwargs):
+        _, price = SubscriptionItem.objects.resolve_purchase(**kwargs)
+        return price
+
+    def test_resolves_the_standard_list_price(self, plan_price_factory):
+        price = plan_price_factory(interval="monthly", label="standard")
+
+        assert self._resolve(plan=price.plan, interval="monthly") == price
+
+    def test_nonprofit_resolves_the_nonprofit_price(self, plan_price_factory):
+        """Self-reported, and the only thing the checkbox now decides."""
+        plan = plan_price_factory(interval="monthly", label="standard").plan
+        nonprofit = plan_price_factory(
+            plan=plan, interval="monthly", label="nonprofit", amount=3_500
+        )
+
+        assert self._resolve(plan=plan, interval="monthly", nonprofit=True) == nonprofit
+
+    def test_interval_selects_between_prices(self, plan_price_factory):
+        plan = plan_price_factory(interval="monthly").plan
+        annual = plan_price_factory(plan=plan, interval="annual", amount=120_000)
+
+        assert self._resolve(plan=plan, interval="annual") == annual
+
+    def test_list_pricing_wins_over_a_negotiated_rate(self, plan_price_factory):
+        """A deal attached to a plan is not what a stranger buying it pays.
+
+        Reaching a negotiated rate requires being granted the private plan
+        it belongs to, and that grant is the authorisation -- so `code`
+        prices are not blocked outright, only never picked by default.
+        """
+        plan = plan_price_factory(interval="monthly", label="standard").plan
+        plan_price_factory(
+            plan=plan,
+            interval="monthly",
+            label="standard",
+            code="insideclimate",
+            amount=3_000,
+        )
+
+        assert self._resolve(plan=plan, interval="monthly").code == ""
+
+    def test_a_comped_target_is_never_sold(self):
+        """The mapping legitimately contains comped targets, for migrating
+        subscriptions that are already comped.  Self-service must not reach
+        one -- that would be handing out a free subscription."""
+        assert resolve_target("beta", allow_comped=True)[2] == "comped"
+        assert resolve_target("beta", allow_comped=False) is None
+
+    def test_a_comped_price_is_unreachable(self, plan_price_factory):
+        plan = plan_price_factory(interval="monthly", label="comped", amount=0).plan
+
+        assert self._resolve(plan=plan, interval="monthly") is None
+
+    def test_no_price_yet_resolves_to_none(self, plan_factory):
+        """Every plan, until consolidate_stripe_products has run."""
+        assert self._resolve(plan=plan_factory(), interval="monthly") is None
+
+
+@pytest.mark.django_db()
+class TestProrationIsOptOut:
+    """A genuine upgrade should prorate; an identifier swap should not."""
+
+    def _modify(self, item, mocker, **kwargs):
+        mocker.patch("squarelet.organizations.models.Subscription.stripe_subscription")
+        svc = mocker.patch(
+            "squarelet.organizations.models.payment.get_payment_provider"
+        ).return_value.get_subscription_service.return_value
+        svc.modify.return_value = None
+        item.subscription.stripe_modify(**kwargs)
+        return svc.modify.call_args.kwargs
+
+    def test_default_leaves_proration_to_stripe(
+        self, subscription_item_factory, mocker
+    ):
+        item = subscription_item_factory(subscription__subscription_id="sub_1")
+
+        assert "proration_behavior" not in self._modify(item, mocker)
+
+    def test_it_can_be_suppressed(self, subscription_item_factory, mocker):
+        item = subscription_item_factory(subscription__subscription_id="sub_1")
+
+        kwargs = self._modify(item, mocker, proration_behavior="none")
+
+        assert kwargs["proration_behavior"] == "none"

--- a/squarelet/organizations/tests/test_backfill_plan_prices.py
+++ b/squarelet/organizations/tests/test_backfill_plan_prices.py
@@ -1,0 +1,321 @@
+# Django
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+# Standard Library
+from io import StringIO
+
+# Third Party
+import pytest
+
+# Squarelet
+from squarelet.organizations.management.commands.backfill_plan_prices import (
+    DEFERRED_SLUGS,
+    LEGACY_PLAN_MAP,
+)
+from squarelet.organizations.models import Plan, SubscriptionItem
+from squarelet.organizations.tests.factories import (
+    OrganizationFactory,
+    PlanFactory,
+    PlanPriceFactory,
+    SubscriptionItemFactory,
+)
+from squarelet.users.tests.factories import UserFactory
+
+
+@pytest.fixture(name="targets")
+def targets_fixture(db):  # pylint: disable=unused-argument
+    """Every PlanPrice the map points at.
+
+    _preflight refuses to run unless all of them exist, so this builds the
+    whole target set rather than just the ones a given test uses.  Derived
+    from LEGACY_PLAN_MAP so it cannot drift from it.
+    """
+    plans = {}
+    for slug, interval, label, code in set(LEGACY_PLAN_MAP.values()):
+        if slug not in plans:
+            # Reuse the migration-seeded plan when it is there.  Whether it
+            # is depends on whether a transactional test has flushed the
+            # database yet, and creating a second one would quietly become
+            # `professional-2` via AutoSlugField - which the command then
+            # cannot find, making these tests pass or fail on run order.
+            plans[slug] = Plan.objects.filter(slug=slug).first() or PlanFactory(
+                name=f"Canonical {slug}", slug=slug
+            )
+        PlanPriceFactory(
+            plan=plans[slug],
+            interval=interval,
+            label=label,
+            code=code,
+            amount=0 if label == "comped" else 10_000,
+        )
+    return plans
+
+
+def legacy(slug, **kwargs):
+    """A legacy plan under its real slug.
+
+    Several legacy slugs are also canonical ones - `professional` maps to
+    itself - so reuse the row the targets fixture already made rather than
+    letting AutoSlugField uniquify a duplicate into `professional-2`.
+    """
+    existing = Plan.objects.filter(slug=slug).first()
+    if existing is not None:
+        for field, value in kwargs.items():
+            setattr(existing, field, value)
+        if kwargs:
+            existing.save()
+        return existing
+    return PlanFactory(name=f"Legacy {slug}", slug=slug, **kwargs)
+
+
+def run(**kwargs):
+    out = StringIO()
+    call_command("backfill_plan_prices", stdout=out, **kwargs)
+    return out.getvalue()
+
+
+@pytest.mark.django_db()
+class TestBillingDecidesTheLabel:
+    """is_billing is what separates a paying subscriber from a comped one."""
+
+    def test_billing_subscription_gets_the_standard_price(self, targets):
+        actor = UserFactory()
+        sub = SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id="sub_live"
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price.label == "standard"
+        assert sub.plan == targets["professional"]
+
+    @pytest.mark.usefixtures("targets")
+    def test_non_billing_subscription_gets_the_comped_price(self):
+        """Years of admin-granted free access live on plans that look paid."""
+        actor = UserFactory()
+        sub = SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id=""
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price.label == "comped"
+
+    @pytest.mark.usefixtures("targets")
+    def test_comped_migration_records_who_authorized_it(self):
+        actor = UserFactory()
+        sub = SubscriptionItemFactory(
+            plan=legacy("beta"), subscription__subscription_id=""
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.granted_by == actor
+        assert "beta" in sub.granted_reason.lower()
+
+    @pytest.mark.usefixtures("targets")
+    def test_standard_migration_records_no_provenance(self):
+        actor = UserFactory()
+        sub = SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id="sub_live"
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.granted_by is None
+        assert sub.granted_reason == ""
+
+
+@pytest.mark.django_db()
+class TestWhatIsLeftAlone:
+    @pytest.mark.usefixtures("targets")
+    def test_deferred_slugs_are_not_touched(self):
+        actor = UserFactory()
+        slug = sorted(DEFERRED_SLUGS)[0]
+        sub = SubscriptionItemFactory(
+            plan=legacy(slug), subscription__subscription_id=""
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is None
+
+    @pytest.mark.usefixtures("targets")
+    def test_per_user_subscribers_still_billing_are_skipped(self):
+        """They need decomposing, which changes what Stripe charges."""
+        actor = UserFactory()
+        sub = SubscriptionItemFactory(
+            plan=legacy("organization", price_per_user=10),
+            subscription__subscription_id="sub_live",
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is None
+
+    @pytest.mark.usefixtures("targets")
+    def test_a_comped_per_user_subscriber_is_not_skipped(self):
+        """The subtle one.
+
+        The exclusion is per-user AND billing.  A comped organization is on a
+        per-user plan with no Stripe subscription, and must still be migrated
+        -- dropping it here would strand it with a null plan_price and fail
+        step 3c much later.
+        """
+        actor = UserFactory()
+        sub = SubscriptionItemFactory(
+            plan=legacy("organization", price_per_user=10),
+            subscription__subscription_id="",
+        )
+
+        run(actor=actor.username)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is not None
+        assert sub.plan_price.label == "comped"
+
+
+@pytest.mark.django_db()
+class TestPreflightRefusesToGuess:
+    """The command has no log-and-skip path; it stops instead."""
+
+    @pytest.mark.usefixtures("targets")
+    def test_unmapped_plan_aborts(self):
+        actor = UserFactory()
+        SubscriptionItemFactory(
+            plan=legacy("not-in-the-map"), subscription__subscription_id=""
+        )
+
+        with pytest.raises(CommandError, match="No mapping for"):
+            run(actor=actor.username)
+
+    @pytest.mark.usefixtures("targets")
+    def test_unmapped_plan_writes_nothing(self):
+        actor = UserFactory()
+        good = SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id="sub_live"
+        )
+        SubscriptionItemFactory(
+            plan=legacy("not-in-the-map"), subscription__subscription_id=""
+        )
+
+        with pytest.raises(CommandError):
+            run(actor=actor.username)
+
+        good.refresh_from_db()
+        assert good.plan_price is None
+
+    @pytest.mark.usefixtures("db")
+    def test_missing_target_price_aborts(self):
+        actor = UserFactory()
+        SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id="sub_live"
+        )
+
+        with pytest.raises(CommandError, match="consolidate_stripe_products"):
+            run(actor=actor.username)
+
+    @pytest.mark.usefixtures("targets")
+    def test_collapsing_two_plans_onto_one_aborts(self):
+        """Two legacy comps for one org would trip unique_together mid-loop."""
+        actor = UserFactory()
+        org = OrganizationFactory()
+        SubscriptionItemFactory(
+            subscription__organization=org,
+            plan=legacy("premium-org-comp"),
+            subscription__subscription_id="",
+        )
+        SubscriptionItemFactory(
+            subscription__organization=org,
+            plan=legacy("education-grant"),
+            subscription__subscription_id="",
+        )
+
+        with pytest.raises(CommandError, match="collapse onto one plan"):
+            run(actor=actor.username)
+
+    def test_actor_is_required_unless_dry_running(self):
+        with pytest.raises(CommandError, match="--actor is required"):
+            run()
+
+    def test_unknown_actor_aborts(self):
+        with pytest.raises(CommandError, match="No such user"):
+            run(actor="nobody")
+
+
+@pytest.mark.django_db()
+@pytest.mark.usefixtures("targets")
+class TestDryRun:
+    def test_dry_run_writes_nothing(self):
+        sub = SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id="sub_live"
+        )
+
+        output = run(dry_run=True)
+
+        sub.refresh_from_db()
+        assert sub.plan_price is None
+        assert "DRY RUN" in output
+
+    def test_dry_run_needs_no_actor(self):
+        SubscriptionItemFactory(
+            plan=legacy("professional"), subscription__subscription_id=""
+        )
+
+        run(dry_run=True)
+
+        assert SubscriptionItem.objects.filter(plan_price__isnull=False).count() == 0
+
+
+@pytest.mark.django_db()
+class TestCollisionWithALineItLeavesAlone:
+    """A collision does not have to be between two pending lines.
+
+    A per-user line still billing is excluded from this step, but it still
+    occupies (subscription, plan).  Another line on the same subscription
+    that maps onto that same canonical plan collides with it, and must be
+    reported up front rather than aborting the write half way through with
+    a bare IntegrityError.
+    """
+
+    @pytest.mark.usefixtures("targets")
+    def test_collision_with_an_excluded_line_is_reported(self):
+        actor = UserFactory()
+        # Excluded: per-user and billing
+        excluded = SubscriptionItemFactory(
+            plan=legacy("professional", price_per_user=5),
+            subscription__subscription_id="sub_live",
+        )
+        # Pending, and `beta` maps onto canonical `professional`
+        SubscriptionItemFactory(subscription=excluded.subscription, plan=legacy("beta"))
+
+        with pytest.raises(CommandError, match="collapse onto one plan"):
+            run(actor=actor.username)
+
+    @pytest.mark.usefixtures("targets")
+    def test_lines_on_different_subscriptions_do_not_collide(self):
+        """Uniqueness is per subscription, so separate parents are fine."""
+        actor = UserFactory()
+        org = OrganizationFactory()
+        SubscriptionItemFactory(
+            subscription__organization=org,
+            plan=legacy("professional", price_per_user=5),
+            subscription__subscription_id="sub_live",
+        )
+        migrating = SubscriptionItemFactory(
+            subscription__organization=org,
+            subscription__interval="annual",
+            plan=legacy("beta"),
+        )
+
+        run(actor=actor.username)
+
+        migrating.refresh_from_db()
+        assert migrating.plan_price is not None

--- a/squarelet/payments/forms.py
+++ b/squarelet/payments/forms.py
@@ -413,7 +413,8 @@ class PlanPurchaseForm(StripeForm):
             user: The authenticated user
 
         Returns:
-            dict with organization, plan, payment_method, and stripe_token
+            dict with organization, plan, payment_method, stripe_token and
+            nonprofit
         """
         organization = self.get_or_create_organization(user)
         selected_plan = self.get_selected_plan()
@@ -423,6 +424,12 @@ class PlanPurchaseForm(StripeForm):
             "plan": selected_plan,
             "payment_method": self.cleaned_data.get("payment_method"),
             "stripe_token": self.cleaned_data.get("stripe_token"),
+            # Self-reported, on the honour system, and only offered for
+            # Sunlight plans - which involve talking to staff anyway.  The
+            # field was collected and validated here long before anything
+            # read it; it now chooses which PlanPrice the subscription is
+            # sold at.
+            "nonprofit": self.cleaned_data.get("is_nonprofit", False),
         }
 
 

--- a/squarelet/payments/tests/test_views.py
+++ b/squarelet/payments/tests/test_views.py
@@ -56,6 +56,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             user,
             token="tok_visa",
             payment_method="new-card",
+            nonprofit=False,
         )
 
         # Should redirect to the organization
@@ -169,6 +170,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             user,
             token="tok_visa",
             payment_method="new-card",
+            nonprofit=False,
         )
 
         # Should redirect to the organization
@@ -321,6 +323,7 @@ class TestPlanDetailViewCreateOrganization(ViewTestMixin):
             user,
             token="",
             payment_method="invoice",
+            nonprofit=False,
         )
 
         # Should redirect to organization

--- a/squarelet/payments/views.py
+++ b/squarelet/payments/views.py
@@ -294,6 +294,7 @@ class PlanDetailView(DetailView):
                 request.user,
                 token=stripe_token,
                 payment_method=payment_method,
+                nonprofit=result.get("nonprofit", False),
             )
         )
         return None
@@ -313,6 +314,7 @@ class PlanDetailView(DetailView):
                 request.user,
                 token=stripe_token,
                 payment_method=payment_method,
+                nonprofit=result.get("nonprofit", False),
             )
             return None
         except PaymentActionRequired as exc:


### PR DESCRIPTION
Unchanged from where it sat below the split, apart from being at its
post-split form -- so the diff that follows shows only the work of turning
it into the single migration run.

It moved because that command needs the split.  The transition is now one
pass over every subscription: set plan_price, repoint plan, decompose
per-user subscribers into a base line plus a usage pack, and push the
result to Stripe with proration suppressed.  Adding a pack line needs
SubscriptionItem and stripe_modify, neither of which exists below the
split, so the command cannot live there.

What is here is still the local-only half and must not be run: it sets
plan_price without switching Stripe, which is exactly the half-state the
single-run design exists to avoid.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>