### PR TITLE
Add Cloudflare IP resolution in Nginx to proxy staging behind Cloudflare

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -24,6 +24,31 @@ http {
 
 	real_ip_header X-Forwarded-For;
 	set_real_ip_from 10.0.0.0/8;
+	real_ip_recursive on;
+
+	# Cloudflare IPs
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2c0f:f248::/32;
+    set_real_ip_from 2a06:98c0::/29;
 	<% ENV.fetch('DENY_IPS', '').split(',').each do |ip| %>
 		deny <%= ip %>;
 	<% end %>


### PR DESCRIPTION
This is to make Accounts staging conform to DocumentCloud and MuckRock staging so that we can proxy Accounts staging behind Cloudflare. 

This has just been done in MuckRock staging: https://github.com/MuckRock/muckrock/pull/2268
and was already done on DocumentCloud for some time. 
https://github.com/MuckRock/documentcloud/blob/master/config/nginx.conf.erb