### PR TITLE
Redis fix

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -6,6 +6,7 @@ Base settings to build other settings files upon.
 from celery.schedules import crontab
 
 # Standard Library
+import ssl
 from datetime import timedelta
 
 # Third Party
@@ -318,6 +319,8 @@ if DEBUG:
 # ------------------------------------------------------------------------------
 INSTALLED_APPS += ["squarelet.taskapp.celery.CeleryAppConfig"]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
+
+
 CELERY_BROKER_URL = env("REDIS_URL", default="django://")
 BROKER_URL = CELERY_BROKER_URL
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
@@ -325,6 +328,15 @@ if CELERY_BROKER_URL == "django://":
     CELERY_RESULT_BACKEND = "redis://"
 else:
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+
+# redis-py used to act more permissively with rediss:// types, but in redis-py 3 this changed
+# Heroku self-signs their certificate, so we get SSL: CERTIFICATE_VERIFY_FAILED
+# According to their developer docs, to deal with this we set ssl_cert_reqs to None.
+# https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-python
+if CELERY_BROKER_URL.startswith("rediss://"):
+    CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
+    CELERY_REDIS_BACKEND_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
+
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_serializer


### PR DESCRIPTION
We recently updated redis and our REDIS url changed. 
I was trying to figure out why we were getting SSL EOF errors coming from the Redis result store backend, like so: 
https://muckrock.sentry.io/issues/7659227976/?environment=production&project=1422309&query=trace%3A7eed3fd79b8a4df9892f725d3d7c4575%20%21issue.id%3A7710463416&referrer=issue-details-trace-preview-issue-stream
which propagates up to a Celery redis result store retry limit:
https://muckrock.sentry.io/issues/7710463416/?environment=production&project=1422309&query=is%3Aunresolved&referrer=issue-stream

Reading the docs, I see "as of redis-py 3.0 changes the default value of the ssl_cert_reqs option from None to ‘required’"
further 
"This check can be disabled by setting ssl_cert_reqs to None"
from https://pypi.org/project/redis/3.5.3/

Reading Heroku's documents, it looks like we MUST set ssl_cert_reqs to None 
https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-python
because they self sign their certificate. 

Ways to replicate this issue in the shell:

>>> import os, ssl, redis
>>> url = os.environ["REDIS_URL"]
>>> redis.from_url(url).ping()   
This raises. 

When I do 
redis.from_url(url, ssl_cert_reqs=ssl.CERT_NONE).ping()
It returns True. 